### PR TITLE
Cleanup of classpath entries

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/.classpath
+++ b/src/eclipse/plugins/com.ibm.sbt.core/.classpath
@@ -8,11 +8,6 @@
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jst.server.core.container/com.ibm.ws.ast.st.runtime.runtimeTarget.v70/was.base.v7">
-		<attributes>
-			<attribute name="owner.project.facets" value="jst.utility"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/com.ibm.commons"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>

--- a/src/j2ee/com.ibm.sbt.bootstrap211/.classpath
+++ b/src/j2ee/com.ibm.sbt.bootstrap211/.classpath
@@ -2,10 +2,5 @@
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
-		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="WebContent/WEB-INF/classes"/>
 </classpath>

--- a/src/j2ee/com.ibm.sbt.jquery180/.classpath
+++ b/src/j2ee/com.ibm.sbt.jquery180/.classpath
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
-		<attributes>
-			<attribute name="owner.project.facets" value="java"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.web.container"/>
 	<classpathentry kind="con" path="org.eclipse.jst.j2ee.internal.module.container"/>
 	<classpathentry kind="src" path=".apt_generated">


### PR DESCRIPTION
-com.ibm.sbt.core had a WAS library on the classpath, that plugin isn't specific to WAS so I don't think it should be there
-com.ibm.sbt.bootstrap211 had a JRE on the classpath which is not necessary since the plugin is just serving up bootstrap
-com.ibm.sbt.jquery180 had a JRE on the classpath which is not necessary since the plugin is just serving up jquery
