### PR TITLE
Removing unnecessary script tags for the jQuery library

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery180.jsp
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery180.jsp
@@ -1,4 +1,3 @@
-<script type="text/javascript" src="/sbt.jquery180/js/jquery-1.8.0.min.js"></script>
 <script type="text/javascript" src="/sbt/js/libs/require.js"></script>
 
 <script type="text/javascript">

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery180debug.jsp
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery180debug.jsp
@@ -1,4 +1,3 @@
-<script type="text/javascript" src="/sbt.jquery180/development-bundle/jquery-1.8.0.js"></script>
 <script type="text/javascript" src="/sbt/js/libs/require.js"></script>
 
 <script type="text/javascript">

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery191cdn.jsp
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery191cdn.jsp
@@ -1,4 +1,3 @@
-<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script type="text/javascript" src="/sbt/js/libs/require.js"></script>
 
 <script type="text/javascript">

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery191cdndebug.jsp
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/includes/jquery191cdndebug.jsp
@@ -1,4 +1,3 @@
-<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.js"></script>
 <script type="text/javascript" src="/sbt/js/libs/require.js"></script>
 
 <script type="text/javascript">


### PR DESCRIPTION
jQuery library is already loaded and managed as a dependency by requireJS, so it doesn't need to be loaded with a script tag.
