### PR TITLE
Fix for Email Service Java API

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/service/core/handlers/EmailHandler.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/service/core/handlers/EmailHandler.java
@@ -12,7 +12,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.ibm.commons.runtime.Application;
 import com.ibm.commons.util.io.json.JsonJavaFactory;
 import com.ibm.commons.util.io.json.JsonJavaObject;
 import com.ibm.commons.util.io.json.JsonObject;
@@ -33,9 +32,8 @@ public class EmailHandler extends AbstractServiceHandler {
      */
     public static final String URL_PATH = "mailer";
     
-    private static final String EXTENSION_ID = "com.ibm.sbt.core.mimeemailfactory";
+    
     private static final String APPLICATION_JSON = "application/json";
-    private static MimeEmailFactory emailFactory;
 
     /* (non-Javadoc)
      * @see com.ibm.sbt.proxy.core.handlers.AbstractProxyHandler#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
@@ -80,7 +78,7 @@ public class EmailHandler extends AbstractServiceHandler {
      * @return A JSON response of what emails were successfully sent and which ones had errors.
      */
     private JsonObject send(List<JsonObject> emails) {
-        MimeEmailFactory emailFactory = getEmailFactory();
+        MimeEmailFactory emailFactory = DefaultMimeEmailFactory.getInstance();
         List<JsonObject> successful = new ArrayList<JsonObject>();
         List<JsonObject> error = new ArrayList<JsonObject>();
         for(JsonObject json : emails) {
@@ -161,27 +159,5 @@ public class EmailHandler extends AbstractServiceHandler {
         buf.close();
         String body = buf.toString();
         return body;
-    }
-    
-    /**
-     * Gets an instance of MimeEmailFactory to use to send emails.
-     * @return An instance of MimeEmailFactory to use to send emails.
-     */
-    private MimeEmailFactory getEmailFactory() {
-        if(emailFactory == null) {
-            Application app = Application.getUnchecked();
-            if (app != null) {
-                List<Object> factories = app.findServices(EXTENSION_ID);
-                for(Object o : factories) {
-                    if(o instanceof MimeEmailFactory) {
-                        emailFactory = (MimeEmailFactory)o;
-                    }
-                }
-            }
-            if(emailFactory==null) {
-            	emailFactory = DefaultMimeEmailFactory.getInstance();
-            }
-        }
-        return emailFactory;
     }
 }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/email/DefaultMimeEmailFactory.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/email/DefaultMimeEmailFactory.java
@@ -2,6 +2,7 @@ package com.ibm.sbt.services.client.email;
 
 import java.util.List;
 
+import com.ibm.commons.runtime.Application;
 import com.ibm.commons.util.io.json.JsonObject;
 
 /**
@@ -9,7 +10,8 @@ import com.ibm.commons.util.io.json.JsonObject;
  *
  */
 public class DefaultMimeEmailFactory implements MimeEmailFactory {
-    
+	
+	private static final String EXTENSION_ID = "com.ibm.sbt.core.mimeemailfactory";
     private static MimeEmailFactory instance;
     
     private DefaultMimeEmailFactory() {};
@@ -30,8 +32,19 @@ public class DefaultMimeEmailFactory implements MimeEmailFactory {
      * @return An instance of DefaultMimeEmailFactory.
      */
     public static MimeEmailFactory getInstance() {
-        if(instance == null) {
-            instance = new DefaultMimeEmailFactory();
+    	if(instance == null) {
+            Application app = Application.getUnchecked();
+            if (app != null) {
+                List<Object> factories = app.findServices(EXTENSION_ID);
+                for(Object o : factories) {
+                    if(o instanceof MimeEmailFactory) {
+                        instance = (MimeEmailFactory)o;
+                    }
+                }
+            }
+            if(instance == null) {
+            	instance = new DefaultMimeEmailFactory();
+            }
         }
         return instance;
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/email/MimeEmailFactory.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/email/MimeEmailFactory.java
@@ -13,7 +13,7 @@ public interface MimeEmailFactory {
     /**
      * Creates a MimeEmail from a JSON object.  The JSON should follow the below
      * model.
-     * <code>
+     * {@code
      *   {
      *     "to" : ["fadams@renovations.com", "tamado@renovations.com"],
      *     "cc" : ["pclemmons@renovations.com"],
@@ -45,8 +45,8 @@ public interface MimeEmailFactory {
      *       }
      *     ]
      *   }
+     * }
      *
-     * </code>
      * @param json The JSON object to create the email from.
      * @return A MimeEmail object.
      * @throws MimeEmailException Thrown if the MIME email cannot be created.


### PR DESCRIPTION
If a consumer tries to use the Java APIs to send an email they will manually have to query the extension point from their code. We should do this for them. I moved the code from the service handler down to the factory class so anyone who uses the factory will get the correct instance.
