### PR TITLE
added bootstrap, jquery, dojo to samples ear

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.ear/.project
+++ b/samples/j2ee/com.ibm.sbt.sample.ear/.project
@@ -5,6 +5,9 @@
 	<projects>
 		<project>com.ibm.sbt.web</project>
 		<project>com.ibm.sbt.sample.web</project>
+		<project>com.ibm.sbt.bootstrap211</project>
+		<project>com.ibm.sbt.dojo180</project>
+		<project>com.ibm.sbt.jquery180</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/samples/j2ee/com.ibm.sbt.sample.ear/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/com.ibm.sbt.sample.ear/.settings/org.eclipse.wst.common.component
@@ -9,5 +9,17 @@
             <dependent-object>Module_1351598968552</dependent-object>
             <dependency-type>uses</dependency-type>
         </dependent-module>
+        <dependent-module archiveName="com.ibm.sbt.bootstrap211.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.bootstrap211/com.ibm.sbt.bootstrap211">
+            <dependent-object>Module_1366299031096</dependent-object>
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
+        <dependent-module archiveName="com.ibm.sbt.dojo180.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.dojo180/com.ibm.sbt.dojo180">
+            <dependent-object>Module_1366299437786</dependent-object>
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
+        <dependent-module archiveName="com.ibm.sbt.jquery180.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.jquery180/com.ibm.sbt.jquery180">
+            <dependent-object>Module_1366299568328</dependent-object>
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
     </wb-module>
 </project-modules>

--- a/samples/j2ee/com.ibm.sbt.sample.ear/META-INF/application.xml
+++ b/samples/j2ee/com.ibm.sbt.sample.ear/META-INF/application.xml
@@ -15,5 +15,26 @@
  		<web-uri>com.ibm.sbt.sample.web.war</web-uri>
  		<context-root>sbt.sample.web</context-root>
  	</web>
- </module> 
- </application> 
+ </module>
+ <module id="Module_1366299031096">
+   <web>
+     <web-uri>com.ibm.sbt.bootstrap211.war</web-uri>
+     <context-root>sbt.bootstrap211</context-root>
+   </web>
+ </module>
+ <module id="Module_1366299437786">
+   <web>
+     <web-uri>com.ibm.sbt.dojo180.war</web-uri>
+     <context-root>sbt.dojo180</context-root>
+   </web>
+ </module>
+ <module id="Module_1366299568328">
+   <web>
+     <web-uri>com.ibm.sbt.jquery180.war</web-uri>
+     <context-root>sbt.jquery180</context-root>
+   </web>
+ </module>
+
+
+ 
+</application> 


### PR DESCRIPTION
the sample ear was no longer working when deployed alone on websphere
as samples are now referencing elements from the dojo, jquery and
bootstrap projects
It is the samples app navigation menu that needs them, the samples 
work fine if using dojo/jquiry off their CDNs
