### PR TITLE
Added base Acme Airlines webapp to Acme ear

### DIFF
--- a/samples/j2ee/acme.social.sample.ear/.project
+++ b/samples/j2ee/acme.social.sample.ear/.project
@@ -7,6 +7,7 @@
 		<project>com.ibm.sbt.web</project>
 		<project>acme.social.sample.webapp</project>
 		<project>acme.social.sample.dataapp</project>
+		<project>acme.sample.webapp</project>
 	</projects>
 	<buildSpec>
 		<buildCommand>

--- a/samples/j2ee/acme.social.sample.ear/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/acme.social.sample.ear/.settings/org.eclipse.wst.common.component
@@ -17,5 +17,9 @@
             <dependent-object>Module_1350933923710</dependent-object>
             <dependency-type>uses</dependency-type>
         </dependent-module>
+        <dependent-module archiveName="acme.sample.webapp.war" deploy-path="/" handle="module:/resource/acme.sample.webapp/acme.sample.webapp">
+            <dependent-object>Module_1366729591213</dependent-object>
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
     </wb-module>
 </project-modules>


### PR DESCRIPTION
acme.social.sample.webapp is referencing widget/scripts from the acme.sample.webapp which was missing from the ear
