### PR TITLE
Fix for grid default sort order

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/dojo/grid/_Grid.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/dojo/grid/_Grid.js
@@ -59,15 +59,6 @@ define([ "sbt/_bridge/declare", "sbt/data/AtomReadStore", "sbt/widget/_Templated
                 onError: handleError
             });
             
-          //if sorting is being used
-            if(this._activeSortAnchor){
-                
-            	args.sort =  [{ attribute: this._activeSortAnchor.sortParameter }];
-            }
-            if(this._activeSortIsDesc){
-            	args.sort[0].descending = this._activeSortIsDesc;
-            }
-            
             store.fetch(args);
         }
     

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/dojo2/grid/_Grid.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/dojo2/grid/_Grid.js
@@ -39,21 +39,10 @@ define([ "sbt/_bridge/declare", "sbt/store/AtomStore", "dojo/_base/lang", "dojo/
         /*retrieves the data from the Atom Store*/
         _doQuery: function(store, options, query) {
             query = query || {};
-            
-          //if sorting is being used
-            if(this._activeSortAnchor){
-                
-            	options.sort =  [{ attribute: this._activeSortAnchor.sortParameter }];
-            }
-            if(this._activeSortIsDesc){
-            	options.sort[0].descending = this._activeSortIsDesc;
-            }
-            
             var self = this;
-            
             var errCallback = lang.hitch(this, this._updateWithError);
-            
             var results = store.query(query, options);
+            
             Deferred.when(results.total, function(totalCount) {
                 Deferred.when(results, function(results) {
                     self.data = {

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/controls/grid/Grid.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/controls/grid/Grid.js
@@ -144,7 +144,12 @@ define([ "sbt/_bridge/declare", "sbt/lang", "sbt/itemFactory", "sbt/widget/grid/
                this.renderer.render(this, this.gridNode, this.data.items, this.data);
                this.onUpdate(this.data);
            } else if (this.store) {
-               this._doQuery(this.store, { start : 0, count : this.pageSize });
+        	   if(this._activeSortAnchor && this._activeSortIsDesc !== undefined){
+        		   this._doQuery(this.store, { start : 0, count : this.pageSize,sort: [{ attribute: this._activeSortAnchor.sortParameter, descending :this._activeSortIsDesc }] });   
+        	   }else{
+        		   this._doQuery(this.store, { start : 0, count : this.pageSize });
+        	   }
+               
            } else {
               this.renderer.renderEmpty(this, this.gridNode, this.data);
               this.onUpdate(this.data);
@@ -175,6 +180,10 @@ define([ "sbt/_bridge/declare", "sbt/lang", "sbt/itemFactory", "sbt/widget/grid/
 	                		start : 0, count : this.pageSize,
 	                		sort: [{ attribute: this._activeSortAnchor.sortParameter }]
 	                };
+	               
+	                if(this._activeSortIsDesc !== undefined){
+	                	options.sort[0].descending = this._activeSortIsDesc;
+	                }
             	}else{
             		var options = { 
 	                		start : 0, count : this.pageSize,
@@ -188,10 +197,6 @@ define([ "sbt/_bridge/declare", "sbt/lang", "sbt/itemFactory", "sbt/widget/grid/
            	 options.tag = this.filterTag;
             }
             
-            //if sorting is being used
-            if(this._activeSortIsDesc){
-            	options.sort[0].descending = this._activeSortIsDesc;
-            }
             this._doQuery(this.store, options);
             }
         },
@@ -213,6 +218,9 @@ define([ "sbt/_bridge/declare", "sbt/lang", "sbt/itemFactory", "sbt/widget/grid/
 	                    	start : 0, count : this.pageSize ,
 	                    	sort: [{ attribute: this._activeSortAnchor.sortParameter }]
 	                };
+	            	if(this._activeSortAnchor !== undefined){
+	               	 options.sort[0].descending = this._activeSortIsDesc;
+	                }
             	}else {
             		var options = { 
 	                    	start : 0, count : this.pageSize 
@@ -224,11 +232,6 @@ define([ "sbt/_bridge/declare", "sbt/lang", "sbt/itemFactory", "sbt/widget/grid/
              
              if(this.filterTag != "" && this.filterTag != null){
             	 options.tag = this.filterTag;
-             }
-             
-             //if there is sorting
-             if(this._activeSortAnchor){
-            	 options.sort[0].descending = this._activeSortIsDesc;
              }
              this._doQuery(this.store, options);
             }


### PR DESCRIPTION
There is an issue with the grids when they first load. No sorting parameters are being specified, until the next/sort buttons are clicked, this results in some bugs with specific samples. This branch fixes these issues by specifying sort parameters when the grid first loads. 
