### PR TITLE
Fix jQuery create error message

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/_bridges/jquery/Transport.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/_bridges/jquery/Transport.js
@@ -214,15 +214,6 @@ define(['sbt/_bridge/declare', 'sbt/util', 'sbt/Promise', 'sbt/_bridge/jquery'],
             };
             _error.response = jqXHR;
             return _error;
-        },
-        getErrorMessage: function(jqXHR, textStatus, type) {
-            try {
-            	var xml = (type==="xml" ? jqXHR.responseXML : type==="text" ? jQuery.parseXML(jqXHR.responseText) : undefined );
-                var text = jQuery(jQuery(xml).find("message")[0]).text().trim();
-            } catch(ex) {
-                console.log(ex);
-            }
-            return text || jqXHR.statusText || jqXHR.responseText || textStatus || jqXHR;
         }
 	});
 });


### PR DESCRIPTION
After some changes which @projsaha made to generate the Error Message on the Endpoint.js instead of on the Transport.js, some unit tests were failing.

This is a fix for that.

**Tested with SbtxTestSuite**
