### PR TITLE
Fixes for regressions in Unit Tests for sbt and sbtx projects.

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/Endpoint.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/Endpoint.js
@@ -183,7 +183,9 @@ var Endpoint = declare("sbt.Endpoint", null, {
                 promise.fullFilled(response.data);
                 promise.response.fullFilled(response);
             }, function(error) {
-            	error.message = self.getErrorMessage(error.cause);
+            	if(!error.message){
+            		error.message = self.getErrorMessage(error.cause);
+            	}
                 if (self._isAuthRequired(error, options)) {
                     return self._authenticate(url, options, promise);
                 }                

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/CommunityService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/CommunityService.js
@@ -1299,7 +1299,7 @@ define(
 						
 						_checkCommunityPresence : function(obj, args){
 							if (!(obj.community)) {
-								validate.notifyError({
+								util.notifyError({
 									code : communityConstants.sbtErrorCodes.badRequest,
 									message : communityConstants.sbtErrorMessages.null_community
 								}, args);

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/FileService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/FileService.js
@@ -20,8 +20,8 @@
  */
 define(
 		[ "sbt/_bridge/declare", "sbt/config", "sbt/lang", "sbt/connections/core", "sbt/xml", "sbt/xpath", "sbt/Endpoint", "sbt/connections/FileConstants",
-				"sbt/validate", "sbt/log" ],
-		function(declare, cfg, lang, con, xml, xpath, endpoint, constants, validate, log) {
+				"sbt/validate", "sbt/log", "sbt/util" ],
+		function(declare, cfg, lang, con, xml, xpath, endpoint, constants, validate, log, util) {
 
 			// TODO revisit this
 			function evaluateXpath(data, path) {
@@ -658,7 +658,7 @@ define(
 									}
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 
@@ -685,7 +685,7 @@ define(
 									}
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 
@@ -712,7 +712,7 @@ define(
 									}
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 
@@ -757,7 +757,7 @@ define(
 									_self._notifyCb(args, "Success");
 								},
 								error : function(error, ioargs) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},
@@ -1013,7 +1013,7 @@ define(
 								filePath = args.fileControl.value;
 								files = args.fileControl.files;
 							} else {
-								validate.notifyError("Either File Control of File Control ID is required for upload", args);
+								util.notifyError("Either File Control of File Control ID is required for upload", args);
 							}
 							
 							var index = filePath.lastIndexOf("\\");
@@ -1034,7 +1034,7 @@ define(
 								_self.uploadFileBinary(binaryContent, _args);
 							};
 							reader.onerror = function(error) {
-								validate.notifyError(error, args);
+								util.notifyError(error, args);
 							};
 							reader.readAsBinaryString(files[0]);
 						},
@@ -1079,7 +1079,7 @@ define(
 									_self._notifyCb(args, "Success");
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},
@@ -1258,7 +1258,7 @@ define(
 									_self._executePost(args, url, headers, null);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},
@@ -1305,7 +1305,7 @@ define(
 									_self._executePost(args, url, headers, null);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},
@@ -1351,7 +1351,7 @@ define(
 									_self._executeDelete(args, url, headers);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 
@@ -1454,7 +1454,7 @@ define(
 									_self._executePost(_args, url, headers, null);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 
@@ -1505,7 +1505,7 @@ define(
 									_self._executePost(_args, url, headers, null);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},
@@ -1554,7 +1554,7 @@ define(
 									_self._executeDelete(args, url, headers, null);
 								},
 								error : function(error) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								}
 							});
 						},

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/ProfileService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/ProfileService.js
@@ -594,7 +594,7 @@ define(['sbt/_bridge/declare','sbt/config','sbt/lang','sbt/connections/core','sb
 							}
 						},
 						error: function(error){
-							validate.notifyError(error,args);
+							util.notifyError(error,args);
 						}
 					});
 		    };

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/smartcloud/FileService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/smartcloud/FileService.js
@@ -21,8 +21,8 @@
 define(
 		[ 'sbt/_bridge/declare', 'sbt/config', 'sbt/lang', 'sbt/smartcloud/core', 'sbt/xml', 'sbt/xpath', 'sbt/Cache', 'sbt/Endpoint',
 				'sbt/smartcloud/FileConstants', 'sbt/smartcloud/Subscriber', 'sbt/base/BaseService', 'sbt/log', 'sbt/stringUtil', 'sbt/validate',
-				'sbt/base/XmlHandler' ], function(declare, cfg, lang, con, xml, xpath, Cache, Endpoint, FileConstants, Subscriber, BaseService, log,
-				stringUtil, validate, XmlHandler) {
+				'sbt/base/XmlHandler', 'sbt/util' ], function(declare, cfg, lang, con, xml, xpath, Cache, Endpoint, FileConstants, Subscriber, BaseService, log,
+				stringUtil, validate, XmlHandler, util) {
 			
 			var fileHandler = new XmlHandler({xpath_map: FileConstants.xpath_File, xpath_feed_map: FileConstants.xpath_feed_File,nameSpaces:con.namespaces});
 
@@ -797,12 +797,12 @@ define(
 											notifyCbNoCache(args, "SUCCESS");
 										},
 										error : function(error) {
-											validate.notifyError(error, args);
+											util.notifyError(error, args);
 										}
 									});
 								};
 								reader.onerror = function(event) {
-									validate.notifyError(error, args);
+									util.notifyError(error, args);
 								};
 								reader.readAsArrayBuffer(files[0]);
 							}

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/smartcloud/ProfileService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/smartcloud/ProfileService.js
@@ -18,8 +18,8 @@
  * @author Vimal Dhupar
  * Helpers for accessing the SmartCloud Profiles services
  */
-define(['sbt/_bridge/declare','sbt/config','sbt/lang','sbt/smartcloud/core','sbt/Cache','sbt/smartcloud/Subscriber','sbt/Jsonpath','sbt/Endpoint', 'sbt/log' , 'sbt/validate'],
-		function(declare,cfg,lang,con,Cache,Subscriber,jsonPath, Endpoint, log, validate) {
+define(['sbt/_bridge/declare','sbt/config','sbt/lang','sbt/smartcloud/core','sbt/Cache','sbt/smartcloud/Subscriber','sbt/Jsonpath','sbt/Endpoint', 'sbt/log' , 'sbt/validate', 'sbt/util'],
+		function(declare,cfg,lang,con,Cache,Subscriber,jsonPath, Endpoint, log, validate, util) {
 	/**
 	Javascript APIs for IBM SmartCloud Profiles Service.
 	@module sbt.smartcloud.ProfileService
@@ -395,7 +395,7 @@ define(['sbt/_bridge/declare','sbt/config','sbt/lang','sbt/smartcloud/core','sbt
 						},
 						error: function(error){
 							log.debug("_load() : error occurred in load. Error code : {0}, Error status : {1} ", error.code, error.status);
-							validate.notifyError(error,args);
+							util.notifyError(error,args);
 						}
 					});
 			} 


### PR DESCRIPTION
1. Changed the service implementation for calling notifyError method. It
   has been moved from validate.js to util.js
2. Added an additional check in endpoint.js to verify whether message
   field in the error object is present before constructing the error
   message in endpoint.js

Executed sbtTestSuite and sbtxTestSuite with dojo180, dojo143 and
jquery180 to verify no regressions.
