### PR TITLE
Changed sbt.properties file to include new runtime variables for profile...

### DIFF
--- a/src/config/sbt.properties
+++ b/src/config/sbt.properties
@@ -89,6 +89,19 @@ sample.displayName3=Lucille Suarez
 
 sample.imageFilePath=C:\\SBTKSamples\\ProfilePic\\image1.jpg
 
+sample.updateProfileJobTitle=Chief Execution Officer
+sample.updateProfileBuilding=Building 5
+sample.updateProfileFloor=3rd
+sample.updateProfileTelephoneNumber=1234-567-89
+sample.createProfileId=QWERAB04-F2E1-1222-4825-7A700026E92C
+sample.createProfileEmail=MikeAdams@renovations.com
+sample.createProfileUid=madams
+sample.createProfileDistinguishedName=CN=Mike Adams,o=renovations
+sample.createProfileDisplayName=Mike Adams
+sample.createProfileGivenNames=Mike
+sample.createProfileSurName=Adams
+sample.createProfileUserState=active
+
 # Properties for Smartcloud
 sample.smartcloud.communityId1=5c9e9b91-84d3-4d57-b42d-0b008ee9626e
 sample.smartcloud.contactGUID=964198


### PR DESCRIPTION
Changed sbt.properties file to include new runtime variables to be used by the sbtx profiles service samples of createProfile and updateProfile.

The new properties are only used by sbtx profileService.

Ran sbtxProfilesSuite as unit test.
