### PR TITLE
Adding content type in response. Not setting this, results in the

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/security/authentication/oauth/consumer/oauth_10a/servlet/OAClientAuthentication.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/security/authentication/oauth/consumer/oauth_10a/servlet/OAClientAuthentication.java
@@ -83,6 +83,11 @@ public class OAClientAuthentication extends AbstractServiceHandler {
 		String mode = req.getParameter("loginUi");
 
 		PrintWriter pw = resp.getWriter();
+		/*
+		 * Fix : Adding content type in response. Not setting this, results in
+		 * the html being rendered as text/plain.
+		 */
+		resp.setContentType("text/html");
 		try {
 			pw.println("<html>");
 			pw.println("<head>");


### PR DESCRIPTION
html being rendered as text/plain. Issue reported by Konrad.
