### PR TITLE
Minor change to change the reference of stringUtil in log.js

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/log.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/log.js
@@ -164,7 +164,7 @@ define(['./stringUtil'], function(stringUtil) {
 				var args = Array.prototype.slice.call(arguments);
 				var text = args[0];				
 				args = args.slice(1);
-				var formattedText = stringutil.substitute(text, args);
+				var formattedText = stringUtil.substitute(text, args);
 				if (console.error) {
 					console.error("EXCEPTION : " + formattedText);
 				} else {


### PR DESCRIPTION
A reference to correct js module stringUtil was missed in log.js
This function has been used in only one instance in logging sample in utilities folder. The sample is executing fine.
Also ran CheckinTestSuite and no regressions due to this checkin is observed.
