### PR TITLE
Base service now depends on the config object

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
@@ -20,8 +20,8 @@
  * @module sbt.base.BaseService
  * @author Carlos Manias
  */
-define([ "../declare", "../lang", "../log", "../stringUtil", "../Cache", "../Endpoint", "../Promise" ], 
-    function(declare,lang,log,stringUtil,Cache,Endpoint,Promise) {
+define(["../config", "../declare", "../lang", "../log", "../stringUtil", "../Cache", "../Endpoint", "../Promise" ], 
+    function(config, declare,lang,log,stringUtil,Cache,Endpoint,Promise) {
 
     var BadRequest = 400;
     


### PR DESCRIPTION
The base service needs to wait until at least the library servlet
has finished to do its loading work - but in the library and the 
samples are loaded in different scripts tag on a page, thus they
cannot wait one another (until we remove the global sbt object)
requesting the config object at start tricks require js to wait until
the library loading is done, as it knows it is defining the config.js
object at that point.
