### PR TITLE
TODO to remove hack for jquery module loading issue

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
@@ -22,7 +22,9 @@
  */
 define(["../config", "../declare", "../lang", "../log", "../stringUtil", "../Cache", "../Endpoint", "../Promise" ], 
     function(config, declare,lang,log,stringUtil,Cache,Endpoint,Promise) {
-
+	// TODO sbt/config is required here to solve module loading
+	// issues with jquery until we remove the global sbt object
+	
     var BadRequest = 400;
     
     var requests = {};


### PR DESCRIPTION
The base service needs to wait until at least the library servlet
has finished to do its loading work - but in the library and the 
samples are loaded in different scripts tag on a page, thus they
cannot wait one another (until we remove the global sbt object)
requesting the config object at start tricks require js to wait until
the library loading is done, as it knows it is defining the config.js
object at that point.
