### PR TITLE
change to export commons-fileupload and commons-io jars from com.ibm.sbt.libs.j2ee/.classpath

### DIFF
--- a/prereqs/eclipse/plugins/com.ibm.sbt.libs.j2ee/.classpath
+++ b/prereqs/eclipse/plugins/com.ibm.sbt.libs.j2ee/.classpath
@@ -8,7 +8,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-logging-1.1.1.jar"/>
-	<classpathentry kind="lib" path="lib/commons-fileupload-1.2.2.jar"/>
-	<classpathentry kind="lib" path="lib/commons-io-2.4.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-fileupload-1.2.2.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/commons-io-2.4.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
change to export commons-fileupload and commons-io jars from com.ibm.sbt.libs.j2ee/.classpath
