### PR TITLE
Removing "$" which looks like it was added by mistake. 

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/communities/nls/CommunityGridRenderer.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/communities/nls/CommunityGridRenderer.js
@@ -21,7 +21,7 @@ define({
         filterByTag : "Click to filter by tag",
         updatedBy : "Updated by ",
         person : "1 person",
-        people : "${memberCount} people",
+        people : "{memberCount} people",
         tags : "Tags: ",
         date: "Date",
         popularity: "Popularity",


### PR DESCRIPTION
This causes community grids to display the number of members as "$3
people" instead of "3 people".
