### PR TITLE
Add new getClientParams method and support to emit these from the library servlet

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
@@ -88,6 +88,7 @@ abstract public class AbstractLibrary {
 	public static final String		IS_AUTHENTICATED				= "isAuthenticated";
 	public static final String		PROP_AUTHENTICATION_ERROR_CODE	= "authenticationErrorCode";
 	public static final String		PROP_ENDPOINT_ALIAS	            = "name";
+	public static final String		PROP_PLATFORM    	            = "platform";
 
 	public static final String		PROP_MODULE_PREFIX				= "_module";
 	public static final String		PROP_MODULE_AUTHENTICATOR		= "_moduleAuthenticator";
@@ -381,6 +382,9 @@ abstract public class AbstractLibrary {
 			}
 			if (endpoint.getAutoAuthenticate() != null) {
 				jsonEndpoint.putJsonProperty(PROP_AUTO_AUTHENTICATE, endpoint.getAutoAuthenticate());
+			}
+			if (endpoint.getPlatform() != null) {
+				jsonEndpoint.putJsonProperty(PROP_PLATFORM, endpoint.getPlatform());
 			}
 			jsonEndpoint.putJsonProperty(PROP_AUTHENTICATION_ERROR_CODE,
 					endpoint.getAuthenticationErrorCode());

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/AbstractEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/AbstractEndpoint.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 
 
+
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.DefaultHttpClient;
 
@@ -67,6 +68,12 @@ public abstract class AbstractEndpoint implements Endpoint, Cloneable {
     
     private static final int authenticationErrorCode = 401;
     
+    protected static final String PLATFORM_CONNECTIONS = "connections";
+    protected static final String PLATFORM_SMARTCLOUD = "smartcloud";
+    protected static final String PLATFORM_DOMINO = "domino";
+    protected static final String PLATFORM_SAMETIME = "sametime";
+    protected static final String PLATFORM_DROPBOX = "dropbox";
+    protected static final String PLATFORM_TWITTER = "twitter";
     
     public AbstractEndpoint() {
     }
@@ -84,6 +91,14 @@ public abstract class AbstractEndpoint implements Endpoint, Cloneable {
     @Override
     public Map<String, Object> getClientParams() {
     	return clientParams;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.services.endpoints.Endpoint#getPlatform()
+     */
+    @Override
+    public String getPlatform() {
+    	return null;
     }
     
     @Override

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ApplicationEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ApplicationEndpoint.java
@@ -62,6 +62,14 @@ public class ApplicationEndpoint implements Endpoint {
     public Map<String, Object> getClientParams() {
     	return clientParams;
     }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.services.endpoints.Endpoint#getPlatform()
+     */
+    @Override
+    public String getPlatform() {
+    	return null;
+    }
 
     @Override
 	public String getUrl() {

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsBasicEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsBasicEndpoint.java
@@ -34,6 +34,11 @@ public class ConnectionsBasicEndpoint extends BasicEndpoint {
     public ConnectionsBasicEndpoint() {
         endpointAdapter = new ConnectionsEndpointAdapter(this);
     }
+    
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_CONNECTIONS;
+    }
 
     @Override
 	public boolean isHeaderAllowed(String headerName, String serviceUrl){

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsOAuth2Endpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsOAuth2Endpoint.java
@@ -39,7 +39,6 @@ public class ConnectionsOAuth2Endpoint extends OAuth2Endpoint {
 	 * @return boolean true depicting header is passed
 	 * 
 	 */
-
     @Override
 	public boolean isHeaderAllowed(String headerName, String serviceUrl){
     	if (headerName.equalsIgnoreCase("x-requested-with"))
@@ -52,6 +51,10 @@ public class ConnectionsOAuth2Endpoint extends OAuth2Endpoint {
 
     }
 
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_CONNECTIONS;
+    }
 
     @Override
 	public ClientService getClientService() throws ClientServicesException {

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsSSOEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/ConnectionsSSOEndpoint.java
@@ -37,7 +37,6 @@ public class ConnectionsSSOEndpoint extends SSOEndpoint {
 	 * @return boolean true depicting header is passed
 	 * 
 	 */
-
     @Override
 	public boolean isHeaderAllowed(String headerName, String serviceUrl){
     	if (headerName.equalsIgnoreCase("x-requested-with"))
@@ -50,6 +49,10 @@ public class ConnectionsSSOEndpoint extends SSOEndpoint {
 
     }
 
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_CONNECTIONS;
+    }
     
     @Override
 	public ClientService getClientService() throws ClientServicesException {

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoBasicEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoBasicEndpoint.java
@@ -28,6 +28,12 @@ public class DominoBasicEndpoint extends BasicEndpoint {
 
     public DominoBasicEndpoint() {
     }
+
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_DOMINO;
+    }
+
     public DominoBasicEndpoint(String user, String password, String authenticationPage) {
         super(user, password, authenticationPage);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoOAuth2Endpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoOAuth2Endpoint.java
@@ -30,6 +30,11 @@ public class DominoOAuth2Endpoint extends OAuth2Endpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_DOMINO;
+    }
+
+    @Override
 	public ClientService getClientService() throws ClientServicesException {
     	return new DominoService(this);
     }    

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoSSOEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DominoSSOEndpoint.java
@@ -30,6 +30,11 @@ public class DominoSSOEndpoint extends SSOEndpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_DOMINO;
+    }
+
+    @Override
 	public ClientService getClientService() throws ClientServicesException {
     	return new DominoService(this);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DropBoxOAuthEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/DropBoxOAuthEndpoint.java
@@ -24,4 +24,9 @@ public class DropBoxOAuthEndpoint extends OAuthEndpoint {
 	
     public DropBoxOAuthEndpoint() {
     }
+
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_DROPBOX;
+    }
 }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/Endpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/Endpoint.java
@@ -135,6 +135,12 @@ public interface Endpoint {
     public String getApiVersion();
     
     /**
+     * Get platform for the endpoint
+     * @return
+     */
+    public String getPlatform();
+    
+    /**
      * Return a collection of client parameters that should be emitted with the 
      * endpoint when valid.
      * @return

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SametimeBasicEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SametimeBasicEndpoint.java
@@ -33,6 +33,11 @@ public class SametimeBasicEndpoint extends BasicEndpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_SAMETIME;
+    }
+
+    @Override
 	public ClientService getClientService() throws ClientServicesException {
     	return new SametimeService(this);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudBasicEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudBasicEndpoint.java
@@ -39,6 +39,11 @@ public class SmartCloudBasicEndpoint extends BasicEndpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_SMARTCLOUD;
+    }
+
+    @Override
 	public boolean isHeaderAllowed(String headerName, String serviceUrl){
 		return endpointAdapter.isHeaderAllowed(headerName, serviceUrl);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudOAuth2Endpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudOAuth2Endpoint.java
@@ -32,6 +32,11 @@ public class SmartCloudOAuth2Endpoint extends OAuth2Endpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_SMARTCLOUD;
+    }
+
+    @Override
 	public ClientService getClientService() throws ClientServicesException {
     	return new SmartCloudService(this);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudOAuthEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SmartCloudOAuthEndpoint.java
@@ -32,6 +32,11 @@ public class SmartCloudOAuthEndpoint extends OAuthEndpoint {
     }
 
     @Override
+    public String getPlatform() {
+    	return PLATFORM_SMARTCLOUD;
+    }
+
+    @Override
 	public ClientService getClientService() throws ClientServicesException {
     	return new SmartCloudService(this);
     }

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/TwitterOAuthEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/TwitterOAuthEndpoint.java
@@ -24,4 +24,10 @@ public class TwitterOAuthEndpoint extends OAuthEndpoint {
 	
     public TwitterOAuthEndpoint() {
     }
+
+    @Override
+    public String getPlatform() {
+    	return PLATFORM_TWITTER;
+    }
+
 }


### PR DESCRIPTION
E.g. SmartCloud endpoints now emit the isSmartCloud
property as follows:
 'smartcloudOA2':new Endpoint({"authType":"oauth","authenticator":new
OAuth({"url":"https:\/\/localhost:8443\/sbt.sample.web\/service\/oauth_jsauth\/smartcloudOA2"}),"proxyPath":"smartcloudOA2","isAuthenticated":false,"isSmartCloud":true,"transport":new
Transport({}),"name":"smartcloudOA2","authenticationErrorCode":403,"baseUrl":"https:\/\/apps.lotuslive.com","apiVersion":"3.0","proxy":new
Proxy({proxyUrl:'https://localhost:8443/sbt.sample.web/service/proxy'})}),

Also the exception message from checkValid is emitted as the ErrorTransport message not to aid diagnosing when an ErrorTransport is added e.g.
'twitter':new Endpoint({"invalid":"true","transport":new ErrorTransport('twitter','The Endpoint consumer key is empty, class class com.ibm.sbt.services.endpoints.TwitterOAuthEndpoint')})
'domino':new Endpoint({"invalid":"true","transport":new ErrorTransport('domino','The Endpoint url is empty, class class com.ibm.sbt.services.endpoints.DominoBasicEndpoint')}),
