### PR TITLE
added selenium test framework and suites to project

### DIFF
--- a/build/distribution/assembly.xml
+++ b/build/distribution/assembly.xml
@@ -1,15 +1,16 @@
-<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
   <id>beta</id>
   <formats>
     <format>zip</format>
-	<format>tar.gz</format>
+    <format>tar.gz</format>
   </formats>
   <baseDirectory>target</baseDirectory>
   <includeBaseDirectory>false</includeBaseDirectory>
   <moduleSets>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sdk:com.ibm.commons</include>
@@ -24,44 +25,44 @@
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sdk:sbt</include>
         <include>com.ibm.sbt.sdk:sbt.dojo180</include>
         <include>com.ibm.sbt.sdk:sbt.jquery182</include>
         <include>com.ibm.sbt.sdk:sbt.bootstrap211</include>
-	  </includes>
+      </includes>
       <binaries>
         <outputDirectory>sbtsdk/redist/war</outputDirectory>
         <outputFileNameMapping>${module.artifactId}.${module.extension}</outputFileNameMapping>
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sample:sbt.sample</include>
-	  </includes>
+      </includes>
       <binaries>
         <outputDirectory>sbtsdk/samples/ear</outputDirectory>
         <outputFileNameMapping>${module.artifactId}-${project.version}.${buildLabel}.${module.extension}</outputFileNameMapping>
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sample:sbt.sample.portlets</include>
         <include>com.ibm.sbt.sample:acme.social.sample</include>
-	  </includes>
+      </includes>
       <binaries>
         <outputDirectory>sbtsdk/samples/ear</outputDirectory>
         <outputFileNameMapping>${module.artifactId}-${project.version}.${buildLabel}.${module.extension}</outputFileNameMapping>
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sample:sbt.sample.web</include>
@@ -71,14 +72,14 @@
         <include>com.ibm.sbt.sample:acme.sample.webapp</include>
         <include>com.ibm.sbt.sample:helloworld.webapp</include>
         <include>com.ibm.sbt.sample:smartcloud.webapp</include>
-    </includes>
+      </includes>
       <binaries>
         <outputDirectory>sbtsdk/samples/war</outputDirectory>
         <outputFileNameMapping>${module.artifactId}.${module.extension}</outputFileNameMapping>
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
-    <moduleSet>  
+    <moduleSet>
       <useAllReactorProjects>true</useAllReactorProjects>
       <includes>
         <include>com.ibm.sbt.sdk:com.ibm.commons</include>
@@ -86,27 +87,39 @@
         <include>com.ibm.sbt.sdk:com.ibm.commons.xml</include>
         <include>com.ibm.sbt.sdk:com.ibm.sbt.core</include>
         <include>com.ibm.sbt.sample:sbt.sample.app</include>
-    </includes>
+      </includes>
       <binaries>
         <outputDirectory>sbtsdk/samples/jar</outputDirectory>
         <outputFileNameMapping>${module.artifactId}-${project.version}.${module.extension}</outputFileNameMapping>
         <unpack>false</unpack>
       </binaries>
     </moduleSet>
+    <moduleSet>
+      <useAllReactorProjects>true</useAllReactorProjects>
+      <includes>
+        <include>com.ibm.sbt.test:com.ibm.sbt.automation.core</include>
+        <include>com.ibm.sbt.test:com.ibm.sbt.automation.test</include>
+      </includes>
+      <binaries>
+        <outputDirectory>sbtsdk/test/selenium</outputDirectory>
+        <outputFileNameMapping>${module.artifactId}-${project.version}.${buildLabel}.${module.extension}</outputFileNameMapping>
+        <unpack>false</unpack>
+      </binaries>
+    </moduleSet>
   </moduleSets>
   <dependencySets>
-  <dependencySet>
-   <includes>
-    <include>commons-logging:commons-logging</include>
-    <include>org.apache.httpcomponents:httpclient</include>
-    <include>org.apache.httpcomponents:httpcore</include>
-   </includes>
-  <outputDirectory>sbtsdk/samples/jar</outputDirectory>
-  </dependencySet>
+    <dependencySet>
+      <includes>
+        <include>commons-logging:commons-logging</include>
+        <include>org.apache.httpcomponents:httpclient</include>
+        <include>org.apache.httpcomponents:httpcore</include>
+      </includes>
+      <outputDirectory>sbtsdk/samples/jar</outputDirectory>
+    </dependencySet>
   </dependencySets>
-  
+
   <fileSets>
-  <fileSet>
+    <fileSet>
       <directory>../../samples/java/sbt.sample.app</directory>
       <outputDirectory>sbtsdk/samples/jar</outputDirectory>
       <includes>
@@ -127,11 +140,11 @@
         <include>**/*.*</include>
       </includes>
     </fileSet>
-        <fileSet>
+    <fileSet>
       <directory>${build.target}/com.ibm.sbt.test/com.ibm.sbt.core.test/site</directory>
       <outputDirectory>sbtsdk/reports</outputDirectory>
       <includes>
-		<include>surefire-report.html</include>
+        <include>surefire-report.html</include>
       </includes>
     </fileSet>
     <fileSet>
@@ -139,8 +152,8 @@
       <outputDirectory>sbtsdk</outputDirectory>
       <includes>
         <include>version.txt</include>
-		<include>changelog.txt</include>
-		<include>weekly.txt</include>
+        <include>changelog.txt</include>
+        <include>weekly.txt</include>
       </includes>
       <lineEnding>crlf</lineEnding>
     </fileSet>
@@ -185,23 +198,37 @@
     <fileSet>
       <directory>../../src/scripts</directory>
       <outputDirectory>sbtsdk/scripts</outputDirectory>
-	  <excludes>
-		<exclude>**/.project</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>**/.project</exclude>
+      </excludes>
       <includes>
         <include>*.*</include>
       </includes>
     </fileSet>
     <fileSet>
+      <directory>../../test/selenium</directory>
+      <outputDirectory>sbtsdk/source</outputDirectory>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
+      <includes>
+        <include>**/*.*</include>
+      </includes>
+    </fileSet>
+    <fileSet>
       <directory>../../src/eclipse/plugins</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -209,13 +236,13 @@
     <fileSet>
       <directory>../../domino/eclipse/plugins/com.ibm.xsp.sbtsdk</directory>
       <outputDirectory>sbtsdk/source/com.ibm.xsp.sbtsdk</outputDirectory>
-    <excludes>
-    <exclude>**/bin/</exclude>
-    <exclude>**/pom.xml</exclude>
-    <exclude>**/.jazzignore</exclude>
-    <exclude>**/.apt_generated</exclude>
-    <exclude>**/.factorypath</exclude>
-    </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -223,13 +250,13 @@
     <fileSet>
       <directory>../../domino/eclipse/features</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-    <excludes>
-    <exclude>**/bin/</exclude>
-    <exclude>**/pom.xml</exclude>
-    <exclude>**/.jazzignore</exclude>
-    <exclude>**/.apt_generated</exclude>
-    <exclude>**/.factorypath</exclude>
-    </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -237,13 +264,13 @@
     <fileSet>
       <directory>../../src/j2ee</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -251,13 +278,13 @@
     <fileSet>
       <directory>../../samples/j2ee</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -265,13 +292,13 @@
     <fileSet>
       <directory>../../samples/java</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -279,15 +306,15 @@
     <fileSet>
       <directory>../../prereqs/eclipse/plugins</directory>
       <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-		<exclude>com.ibm.sbt.libs.was/</exclude>
-		<exclude>com.ibm.sbt.libs.j2ee.tomcat/</exclude>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <excludes>
+        <exclude>com.ibm.sbt.libs.was/</exclude>
+        <exclude>com.ibm.sbt.libs.j2ee.tomcat/</exclude>
+        <exclude>**/bin/</exclude>
+        <exclude>**/pom.xml</exclude>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.apt_generated</exclude>
+        <exclude>**/.factorypath</exclude>
+      </excludes>
       <includes>
         <include>**/*.*</include>
       </includes>
@@ -308,47 +335,30 @@
     </fileSet>
 
     <fileSet>
-	  <directory>${build.target}/com.ibm.sbt.domino/com.ibm.sbt.domino.updatesite</directory>
+      <directory>${build.target}/com.ibm.sbt.domino/com.ibm.sbt.domino.updatesite</directory>
       <outputDirectory>sbtsdk/redist/domino</outputDirectory>
       <includes>
         <include>com.ibm.sbt.domino.updatesite.zip</include>
       </includes>
     </fileSet>
-      <fileSet>
-    <directory>${build.target}/com.ibm.sbt.domino/com.ibm.sbt.domino.playground.updatesite</directory>
+    <fileSet>
+      <directory>${build.target}/com.ibm.sbt.domino/com.ibm.sbt.domino.playground.updatesite</directory>
       <outputDirectory>sbtsdk/redist/domino</outputDirectory>
       <includes>
         <include>com.ibm.sbt.domino.playground.updatesite.zip</include>
       </includes>
     </fileSet>
-	<!--
     <fileSet>
-      <directory>../../test/j2ee</directory>
-      <outputDirectory>sbtsdk/source</outputDirectory>
-	  <excludes>
-	    <exclude>com.ibm.sbt.jasmine.web/</exclude>
-		<exclude>**/bin/</exclude>
-		<exclude>**/pom.xml</exclude>
-		<exclude>**/.jazzignore</exclude>
-		<exclude>**/.apt_generated</exclude>
-		<exclude>**/.factorypath</exclude>
-	  </excludes>
+      <directory>../../workspaces</directory>
+      <outputDirectory>sbtsdk/</outputDirectory>
+      <useDefaultExcludes>false</useDefaultExcludes>
+      <excludes>
+        <exclude>**/.jazzignore</exclude>
+        <exclude>**/.gitignore</exclude>
+      </excludes>
       <includes>
-        <include>**/*.*</include>
+        <include>**/*</include>
       </includes>
     </fileSet>
-	-->
-  <fileSet>
-    <directory>../../workspaces</directory>
-    <outputDirectory>sbtsdk/</outputDirectory>
-    <useDefaultExcludes>false</useDefaultExcludes>
-    <excludes>
-      <exclude>**/.jazzignore</exclude>
-      <exclude>**/.gitignore</exclude>
-    </excludes>
-    <includes>
-      <include>**/*</include>
-    </includes>
-  </fileSet>
   </fileSets>
 </assembly>

--- a/build/distribution/pom.xml
+++ b/build/distribution/pom.xml
@@ -23,6 +23,7 @@
     <project.target.directory>${build.target}</project.target.directory>
     <project.platform.directory>${user.dir}/../platform</project.platform.directory>
     <project.prereqs.directory>${user.dir}/../prereqs</project.prereqs.directory>
+    <project.root>${user.dir}/..</project.root>
   </properties>
 
   <parent>
@@ -64,29 +65,40 @@
 	      <target>
 	        <!-- Package Tomcat -->
             <delete dir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/ROOT"/>
+
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/sbt.war" 
+                file="${project.root}/src/j2ee/com.ibm.sbt.web/target/sbt-1.0.0-SNAPSHOT.war"/>
+                
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/sbt.dojo180.war" 
+                file="${project.root}/src/j2ee/com.ibm.sbt.dojo180/target/sbt.dojo180-1.0.0.war"/>
             
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sdk/sbt/sbt.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sdk/sbt.dojo180/sbt.dojo180.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sdk/sbt.jquery182/sbt.jquery182.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sdk/sbt.bootstrap211/sbt.bootstrap211.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/sbt.sample.web/sbt.sample.web.war"/>
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/sbt.jquery182.war" 
+                file="${project.root}/src/j2ee/com.ibm.sbt.jquery182/target/sbt.jquery182-1.0.0.war"/>
+                
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/sbt.bootstrap211.war" 
+                file="${project.root}/src/j2ee/com.ibm.sbt.bootstrap211/target/sbt.bootstrap211-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/sbt.sample.web.war" 
+                file="${project.root}/samples/j2ee/com.ibm.sbt.sample.web/target/sbt.sample.web-1.0.0.war"/>
+            
             <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/ROOT.war" 
-                file="${project.target.directory}/com.ibm.sbt.sample/com.ibm.sbt.landing/com.ibm.sbt.landing.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/acme.social.sample.dataapp/acme.social.sample.dataapp.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/acme.social.sample.webapp/acme.social.sample.webapp.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/helloworld.webapp/helloworld.webapp.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/smartcloud.webapp/smartcloud.webapp.war"/>
-            <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps" 
-                file="${project.target.directory}/com.ibm.sbt.sample/acme.sample.webapp/acme.sample.webapp.war"/>
+                file="${project.root}/samples/j2ee/com.ibm.sbt.landing/target/com.ibm.sbt.landing-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/acme.social.sample.dataapp.war" 
+                file="${project.root}/samples/j2ee/acme.social.sample.dataapp/target/acme.social.sample.dataapp-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/acme.social.sample.webapp.war" 
+                file="${project.root}/samples/j2ee/acme.social.sample.webapp/target/acme.social.sample.webapp-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/helloworld.webapp.war" 
+                file="${project.root}/samples/j2ee/helloworld.webapp/target/helloworld.webapp-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/smartcloud.webapp.war" 
+                file="${project.root}/samples/j2ee/smartcloud.webapp/target/smartcloud.webapp-1.0.0.war"/>
+            
+            <copy tofile="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/webapps/acme.sample.webapp.war" 
+                file="${project.root}/samples/j2ee/acme.sample.webapp/target/acme.sample.webapp-1.0.0.war"/>
+                
             <copy todir="${project.target.directory}/tomcat/unzip/apache-tomcat-7.0.30/conf" 
                 file="./../../src/config/sbt.properties"/>
                 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -40,11 +40,6 @@
   </modules>
 
   <build>
-    <!-- project defaults for the sbt modules -->
-    <directory>${build.target}/${project.groupId}/${project.artifactId}</directory>
-    <outputDirectory>bin</outputDirectory>
-    <finalName>${project.artifactId}</finalName>
-    <testOutputDirectory>bin-test</testOutputDirectory>
     <sourceDirectory>src</sourceDirectory>
     <scriptSourceDirectory>js</scriptSourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
@@ -177,9 +172,6 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-surefire-plugin</artifactId>
         <version>${tycho-version}</version>
-        <configuration>
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory> 
-        </configuration>
       </plugin>
         <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -213,7 +205,6 @@
           <aggregate>true</aggregate>
           <failOnError>false</failOnError>
   		    <excludePackageNames>com.sun.*:com.ibm.commons.*:com.ibm.sbt.core.*:com.ibm.sbt.plugin.*:com.ibm.sbt.jslibrray.*:com.ibm.sbt.proxy.*:com.ibm.sbt.security.*:*.util.*:com.ibm.sbt.portlet.*:com.ibm.sbt.playground.*:demo.*:acme.*</excludePackageNames>
-          <reportOutputDirectory>${build.target}/doc</reportOutputDirectory>
           <destDir>javadoc</destDir>		  
         </configuration>	    
 	    </plugin>

--- a/build/test/pom.xml
+++ b/build/test/pom.xml
@@ -31,6 +31,9 @@
     <module>../../test/java/com.ibm.sbt.core.test</module>
     <module>stopcargo</module>
 -->
+    <module>../../test/selenium/com.ibm.sbt.automation.core</module>
+    <module>../../test/selenium/com.ibm.sbt.automation.test</module>
+
   </modules>
 
 </project>

--- a/src/j2ee/com.ibm.sbt.bootstrap211/pom.xml
+++ b/src/j2ee/com.ibm.sbt.bootstrap211/pom.xml
@@ -10,7 +10,4 @@
     <relativePath>../../../build/sdk</relativePath>
   </parent>
   
-  <build>
-    <directory>${build.target}/${project.groupId}/${project.artifactId}</directory>
-  </build>
 </project>

--- a/src/j2ee/com.ibm.sbt.dojo180/pom.xml
+++ b/src/j2ee/com.ibm.sbt.dojo180/pom.xml
@@ -10,7 +10,4 @@
     <relativePath>../../../build/sdk</relativePath>
   </parent>
   
-  <build>
-    <directory>${build.target}/${project.groupId}/${project.artifactId}</directory>
-  </build>
 </project>

--- a/src/j2ee/com.ibm.sbt.jquery180/.project
+++ b/src/j2ee/com.ibm.sbt.jquery180/.project
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.sbt.jquery180</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.jsdt.core.javascriptValidator</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.common.project.facet.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jem.workbench.JavaEMFNature</nature>
+		<nature>org.eclipse.wst.common.modulecore.ModuleCoreNature</nature>
+		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+	</natures>
+</projectDescription>

--- a/src/j2ee/com.ibm.sbt.jquery182/pom.xml
+++ b/src/j2ee/com.ibm.sbt.jquery182/pom.xml
@@ -10,7 +10,4 @@
     <relativePath>../../../build/sdk</relativePath>
   </parent>
   
-  <build>
-    <directory>${build.target}/${project.groupId}/${project.artifactId}</directory>
-  </build>
 </project>

--- a/src/j2ee/com.ibm.sbt.web/pom.xml
+++ b/src/j2ee/com.ibm.sbt.web/pom.xml
@@ -9,11 +9,7 @@
     <version>1.0.0</version>
     <relativePath>../../../build/sdk</relativePath>
   </parent>
-  
-  <build>
-    <directory>${build.target}/${project.groupId}/${project.artifactId}</directory>
-  </build>
-  
+    
   <dependencies>
     <dependency>
       <groupId>javax</groupId>

--- a/test/selenium/com.ibm.sbt.automation.core/.classpath
+++ b/test/selenium/com.ibm.sbt.automation.core/.classpath
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/test/selenium/com.ibm.sbt.automation.core/.jazzignore
+++ b/test/selenium/com.ibm.sbt.automation.core/.jazzignore
@@ -1,0 +1,24 @@
+### Jazz Ignore 0
+# Default value for core.ignore.recursive is *.class
+#  Changing this value changes check-in behaviour for the entire project. 
+#
+# Default value for core.ignore is bin
+#  Changing this value changes check-in behaviour for the local directory.
+#
+# Ignored files and folders will not be committed, but may be modified during
+# accept or update.
+# Ignore properties should contain a space separated list of filename patterns.
+# Each pattern is case sensitive and surrounded by braces ('{' and '}'). 
+# "*" matches zero or more characters, and "?" matches single characters. 
+#
+#   e.g: {*.sh} {\.*}    ignores shell scripts and hidden files
+
+# NOTE: modifying ignore files will not change the ignore status of derived 
+# resources.
+
+core.ignore.recursive= \
+	{*.class} 
+
+core.ignore= \
+	{.project} \
+	{bin} 

--- a/test/selenium/com.ibm.sbt.automation.core/.project
+++ b/test/selenium/com.ibm.sbt.automation.core/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.sbt.automation.core</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/test/selenium/com.ibm.sbt.automation.core/pom.xml
+++ b/test/selenium/com.ibm.sbt.automation.core/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>com.ibm.sbt.automation.core</artifactId>
+
+  <parent>
+    <groupId>com.ibm.sbt.test</groupId>
+    <artifactId>test.parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../../../build/test</relativePath>
+  </parent>
+  
+  <dependencies>
+
+    <dependency>
+      <groupId>org.seleniumhq.selenium</groupId>
+      <artifactId>selenium-java</artifactId>
+      <version>2.32.0</version>
+    </dependency>
+    <!-- Change to version 10.5.3.0 -->
+    <dependency>
+      	<groupId>com.ibm.sbt.sdk</groupId>
+      	<artifactId>com.ibm.commons</artifactId>
+      	<version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      	<groupId>com.ibm.sbt.sdk</groupId>
+      	<artifactId>com.ibm.commons.xml</artifactId>
+      	<version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      	<groupId>com.ibm.sbt.sdk</groupId>
+      	<artifactId>com.ibm.commons.runtime</artifactId>
+      	<version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      	<groupId>com.ibm.sbt.sdk</groupId>
+      	<artifactId>com.ibm.sbt.core</artifactId>
+      	<version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/AcmeEnvironment.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/AcmeEnvironment.java
@@ -1,0 +1,104 @@
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.environment;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.SbtWebResultPage;
+
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author DavidRyan
+ * 
+ * @date 27 may 2013
+ */
+public class AcmeEnvironment extends TestEnvironment {
+   
+    private String baseUrl;
+    
+    public AcmeEnvironment() {
+        baseUrl = System.getProperty(TestEnvironment.PROP_ACME_SAMPLE_URL);
+        if (StringUtil.isEmpty(baseUrl)) {
+            baseUrl = getProperty(TestEnvironment.PROP_ACME_SAMPLE_URL);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#login()
+     */
+    @Override
+    public boolean login() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#computeLaunchUrl(com.ibm.sbt.automation.core.test.BaseTest)
+     */
+    @Override
+    public String computeLaunchUrl(BaseTest baseTest) {
+        /*String url = null;
+        if (baseTest.getSnippetType() == SnippetType.JAVASCRIPT) {
+            url = baseUrl + "/javascriptPreview.jsp?snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        } else {
+            url = baseUrl + "/javaPreview.jsp?snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        }
+        
+        url = addSnippetParams(baseTest, url);*/
+        
+        return "http://acmeairlines.com:8080/acme.social.sample.webapp/";
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#getPageObject(org.openqa.selenium.WebDriver, java.lang.String)
+     */
+    @Override
+    public ResultPage getPageObject(WebDriver webDriver) {
+        ResultPage resultPage = (ResultPage)PageFactory.initElements(webDriver, SbtWebResultPage.class);
+        resultPage.setWebDriver(webDriver);
+        return resultPage;
+    }
+    
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Test environment for Acme Airlines Sample Application";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/PlaygroundEnvironment.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/PlaygroundEnvironment.java
@@ -1,0 +1,104 @@
+package com.ibm.sbt.automation.core.environment;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.PageFactory;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.BaseTest.SnippetType;
+import com.ibm.sbt.automation.core.test.pageobjects.PlaygroundResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author mkataria
+ * @author mwallace
+ * 
+ * @date Jan 10, 2013
+ */
+public class PlaygroundEnvironment extends TestEnvironment {
+private String baseUrl;
+
+    public PlaygroundEnvironment() {
+        baseUrl = System.getProperty(TestEnvironment.PROP_SBT_PLAYGROUND_URL);
+        if (StringUtil.isEmpty(baseUrl)) {
+            baseUrl = getProperty(TestEnvironment.PROP_SBT_PLAYGROUND_URL);
+        }
+        if (!baseUrl.endsWith("/")) baseUrl = baseUrl.concat("/");
+    }
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#login()
+     */
+    @Override
+    public boolean login() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#computeLaunchUrl(com.ibm.sbt.automation.core.test.BaseTest)
+     */
+    @Override
+    public String computeLaunchUrl(BaseTest baseTest) {
+        String url = null;
+        if (baseTest.getSnippetType() == SnippetType.JAVASCRIPT) {
+            url = baseUrl + "JavaScriptSnippets.xsp#snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        } else {
+            url = baseUrl + "JavaSnippets.xsp#snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+            
+            return null;//url = baseUrl + "/javaPreview.jsp?snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        }
+        
+        url = addSnippetParams(baseTest, url);
+        
+        return url;
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#getPageObject(org.openqa.selenium.WebDriver, java.lang.String)
+     */
+    @Override
+    public ResultPage getPageObject(WebDriver webDriver) {
+        ResultPage resultPage = (ResultPage)PageFactory.initElements(unwrapPage(webDriver), PlaygroundResultPage.class);
+        resultPage.setWebDriver(unwrapPage(webDriver));
+        return resultPage;
+    }
+    
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+	    return "Test environment for Playground";
+	}
+
+
+    public WebDriver unwrapPage(WebDriver webDriver) {
+        try {
+            WebElement we = webDriver.findElement(By.xpath("//iframe[@id='preview']"));
+            webDriver = webDriver.switchTo().frame(we);
+        } catch (Throwable e) {
+            //logger.info(e.getMessage());
+        }
+        return webDriver;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/SbtWebEnvironment.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/SbtWebEnvironment.java
@@ -1,0 +1,94 @@
+package com.ibm.sbt.automation.core.environment;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.PageFactory;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.BaseTest.SnippetType;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.SbtWebResultPage;
+
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author mkataria
+ * @author mwallace
+ * 
+ * @date Jan 10, 2013
+ */
+public class SbtWebEnvironment extends TestEnvironment {
+   
+    private String baseUrl;
+    
+    public SbtWebEnvironment() {
+        baseUrl = System.getProperty(TestEnvironment.PROP_SBT_SAMPLE_WEB_URL);
+        if (StringUtil.isEmpty(baseUrl)) {
+            baseUrl = getProperty(TestEnvironment.PROP_SBT_SAMPLE_WEB_URL);
+        }
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#login()
+     */
+    @Override
+    public boolean login() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#computeLaunchUrl(com.ibm.sbt.automation.core.test.BaseTest)
+     */
+    @Override
+    public String computeLaunchUrl(BaseTest baseTest) {
+        String url = null;
+        if (baseTest.getSnippetType() == SnippetType.JAVASCRIPT) {
+            url = baseUrl + "/javascriptPreview.jsp?snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        } else if (baseTest.getSnippetType() == SnippetType.JAVASCRIPTFRAMEWORK) {
+        	url = baseUrl + "/javascript.jsp?" + "jsLibId=" + jsLib;
+        } else if (baseTest.getSnippetType() == SnippetType.JAVAFRAMEWORK){
+        	url = baseUrl + "/java.jsp";
+        } else {
+        	url = baseUrl + "/javaPreview.jsp?snippet=" + baseTest.getSnippetId() + "&jsLibId=" + jsLib;
+        }
+        
+        url = addSnippetParams(baseTest, url);
+        
+        return url;
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.TestEnvironment#getPageObject(org.openqa.selenium.WebDriver, java.lang.String)
+     */
+    @Override
+    public ResultPage getPageObject(WebDriver webDriver) {
+        ResultPage resultPage = (ResultPage)PageFactory.initElements(webDriver, SbtWebResultPage.class);
+        resultPage.setWebDriver(webDriver);
+        return resultPage;
+    }
+    
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Test environment for sbtx.sample.web";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironment.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironment.java
@@ -1,0 +1,1169 @@
+package com.ibm.sbt.automation.core.environment;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.ibm.commons.runtime.Context;
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.services.endpoints.BasicEndpoint;
+import com.ibm.sbt.services.endpoints.EndpointFactory;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author mkataria
+ * @author mwallace
+ * 
+ * @date Jan 10, 2013
+ */
+public abstract class TestEnvironment {
+
+    private WebDriver webDriver;
+    private boolean quitDriver = true;
+    private int loginTimeout = 20;
+    private Properties properties;
+    private Map<String, String> snippetParams = new HashMap<String, String>();
+    private boolean smartCloud;
+
+    protected String jsLib;
+
+    // Need to create property bundles for localizable values
+    protected String BasicLoginTitle = "Authentication";
+    protected String OAuth10LoginTitle = "Log In";
+    protected String OAuth20LoginTitle = "Log In to IBM Connections";
+    protected String OAuth20AuthTitle = "Authorize access to IBM Connections";
+	private boolean takeScreenshot;
+	private String screenshotsPath;
+
+    static final public String PROP_ENVIRONMENT                 = "environment"; //$NON-NLS-1$
+    static final public String PROP_JAVASCRIPT_LIB              = "jslib"; //$NON-NLS-1$
+    static final public String PROP_USERNAME                    = "username"; //$NON-NLS-1$
+    static final public String PROP_PASSWORD                    = "password"; //$NON-NLS-1$
+    static final public String PROP_RESTART_BROWSER             = "restart.browser"; //$NON-NLS-1$
+    static final public String PROP_LOGIN_TIMEOUT               = "login.timeout"; //$NON-NLS-1$
+    static final public String PROP_BROWSER                     = "browser"; //$NON-NLS-1$
+    static final public String PROP_WEBDRIVER_IE_DRIVER         = "webdriver.ie.driver"; //$NON-NLS-1$
+    static final public String PROP_WEBDRIVER_CHROMER_DRIVER    = "webdriver.chrome.driver"; //$NON-NLS-1$
+    static final public String PROP_CHROME_BINARY               = "chrome.binary"; //$NON-NLS-1$
+    static final public String PROP_USER_DIR                    = "user.dir"; //$NON-NLS-1$
+    static final public String PROP_SBT_SAMPLE_WEB_URL          = "sbt.sample.web.url"; //$NON-NLS-1$
+    static final public String PROP_SBT_PLAYGROUND_URL          = "playground.web.url"; //$NON-NLS-1$
+    static final public String PROP_ACME_SAMPLE_URL				= "acme.url";
+    static final public String PROP_BASIC_LOGINFORMID           = "basic.loginFormId"; //$NON-NLS-1$
+    static final public String PROP_BASIC_USERNAMEID            = "basic.usernameId"; //$NON-NLS-1$
+    static final public String PROP_BASIC_PASSWORDID            = "basic.passwordId"; //$NON-NLS-1$
+    static final public String PROP_BASIC_SUBMITID              = "basic.submitId"; //$NON-NLS-1$
+    static final public String PROP_BASIC_USERNAME              = "basic.username"; //$NON-NLS-1$
+    static final public String PROP_BASIC_PASSWORD              = "basic.password"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_LOGINFORMID         = "oauth10.loginFormId"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_USERNAMEID          = "oauth10.usernameId"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_PASSWORDID          = "oauth10.passwordId"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_SUBMITID            = "oauth10.submitId"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_USERNAME            = "oauth10.username"; //$NON-NLS-1$
+    static final public String PROP_OAUTH10_PASSWORD            = "oauth10.password"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_LOGINFORMXPATH      = "oauth20.loginFormXPath"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_USERNAMEXPATH       = "oauth20.usernameXPath"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_PASSWORDXPATH       = "oauth20.passwordXPath"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_SUBMITXPATH         = "oauth20.submitXPath"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_GRANTXPATH          = "oauth20.grantXPath"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_USERNAME            = "oauth20.username"; //$NON-NLS-1$
+    static final public String PROP_OAUTH20_PASSWORD            = "oauth20.password"; //$NON-NLS-1$
+    static final public String PROP_GENERATE_SCREENSHOTS		= "screenshots.enabled"; //$NON-NLS-1$
+    static final public String PROP_SCREENSHOTS_BASE_PATH		= "screenshots.base"; //$NON-NLS-1$
+    static final public String PROP_ENABLE_SMARTCLOUD           = "enable.smartcloud"; //$NON-NLS-1$
+    static final public String PROP_ENABLED_TRACE				= "enable.trace"; //$NON-NLS-1$
+    static final public String PROP_FIREBUG_ENABLED             = "firebug.enabled"; //$NON-NLS-1$
+    static final public String PROP_ENABLE_MOCKTRANSPORT        = "enable.mocktransport"; //$NON-NLS-1$
+    static final public String PROP_ENABLE_DEBUGTRANSPORT       = "enable.debugtransport"; //$NON-NLS-1$
+
+    private static final String PROP_OVERRIDE_CONNECTIONS_BE    = "connections.override.url"; //$NON-NLS-1$
+    private static final String PROP_OVERRIDE_SMARTCLOUD_BE     = "smartcloud.override.url"; //$NON-NLS-1$
+
+    static final String sourceClass = TestEnvironment.class.getName();
+    static final Logger logger = Logger.getLogger(sourceClass);
+
+    /**
+     * Perform cleanup
+     */
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        if (environment != null) {
+            environment.snippetParams.clear();
+            environment.quitDriver();
+        }
+    }
+    
+    /**
+     * Clean the browser state. 
+     * The browser cookies are removed and 
+     * it is returned to the default empty page
+     */
+    public void cleanBrowserState() {
+        if (webDriver!=null){
+            //because the session cookie is HttpOnly, selenium can't clear it.
+            //browser cleanup happens by cosing it and letting the next getWebDriver() 
+            //call create a new browser from scratch
+            webDriver.quit();
+            webDriver=null;
+        }
+    }
+    /**
+     * Default constructor
+     */
+    public TestEnvironment() {
+        properties = loadProperties();
+
+        // JS toolkit to test with
+        jsLib = properties.getProperty(PROP_JAVASCRIPT_LIB);
+
+        String restart = properties.getProperty(PROP_RESTART_BROWSER, "false");
+        quitDriver = "true".equalsIgnoreCase(restart);
+
+        String timeout = properties.getProperty(PROP_LOGIN_TIMEOUT, "30");
+        loginTimeout = Integer.parseInt(timeout);
+        
+        String ts = properties.getProperty(PROP_GENERATE_SCREENSHOTS, "false");
+        takeScreenshot = "true".equalsIgnoreCase(ts);
+
+        // Where screenshot go
+        screenshotsPath = properties.getProperty(PROP_SCREENSHOTS_BASE_PATH);
+        if (takeScreenshot && StringUtil.isEmpty(screenshotsPath)) {
+        	logger.severe("no screenshot path defined, please define system property " +PROP_SCREENSHOTS_BASE_PATH);
+        	takeScreenshot = false;
+        }
+    
+        // Enable SmartCloud
+        String enableSmartCloud = properties.getProperty(PROP_ENABLE_SMARTCLOUD, "false");
+        if ("true".equalsIgnoreCase(enableSmartCloud)) {
+            enableSmartCloud();
+        }
+    }
+
+    /**
+     * Return the specified test property
+     * 
+     * @param name
+     * @return
+     */
+    public String getProperty(String name) {
+        return properties.getProperty(name);
+    }
+    
+    /**
+     * Enable SmartCloud environment
+     */
+    public void enableSmartCloud() {
+        smartCloud = true;
+        logger.config("Enabling Smartcloud");
+        addSnippetParam("env", getProperty("smartcloud.env"));
+    }
+    
+    /**
+     * Enable SmartCloud environment
+     */
+    public void disableSmartCloud() {
+        smartCloud = false;
+        removeSnippetParam("env");
+    }
+    
+    /**
+     * Return true if SmartCloud environment is enabled.
+     * 
+     * @return
+     */
+    public boolean isSmartCloud() {
+        return smartCloud;
+    }
+    
+    /**
+     * Return true if mock transport is being used.
+     * @return
+     */
+    public boolean isMockTransport() {
+    	return properties.getProperty(PROP_ENABLE_MOCKTRANSPORT, "false").equals("true");
+    }
+
+    /**
+     * Return true if debug transport is being used.
+     * @return
+     */
+    public boolean isDebugTransport() {
+    	return properties.getProperty(PROP_ENABLE_DEBUGTRANSPORT, "false").equals("true");
+    }
+
+    /**
+     * Remove a snippet param
+     * @param key
+     */
+    public void removeSnippetParam(String key) {
+        snippetParams.remove(key);
+    }
+    
+    /**
+     * Add a snippet param which will be passed to the snippet when it is invoked
+     * @param key
+     * @param value
+     */
+    public void addSnippetParam(String key, String value) {
+        snippetParams.put(key, value);
+    }
+    
+    /**
+     * Add a snippet param which will be passed to the snippet when it is invoked
+     * @param key
+     * @param value
+     */
+    public void addSnippetParam(String key, String[] values) {
+        snippetParams.put(key, StringUtil.concatStrings(values, ',', true));
+    }
+        
+    /**
+     * Return the WebDriver
+     * 
+     * @return
+     */
+    public WebDriver getWebDriver() {
+        if (webDriver == null) {
+            // browser to test with
+            String browserName = System.getProperty(PROP_BROWSER);
+            if ("ie".equals(browserName)) {
+                initInternetExplorerDriver();
+            } else if ("chrome".equals(browserName)) {
+                initChromeDriver();
+            } else if ("safari".equals(browserName)) {
+                webDriver = new SafariDriver();
+            }  else if ("headless".equals(browserName)) {
+                HtmlUnitDriver driver = new HtmlUnitDriver(true);
+                webDriver = driver;
+            } else {
+                webDriver = new FirefoxDriver();
+            }
+        }
+        return webDriver;
+    }
+
+    /**
+     * @return true to quit the driver after each test
+     */
+    public boolean isQuitDriver() {
+        return quitDriver;
+    }
+
+    /**
+     * Close the web driver
+     */
+    public void closeDriver() {
+        if (webDriver != null) {
+            webDriver.close();
+        }
+    }
+
+    /**
+     * Quit the web driver
+     */
+    public void quitDriver() {
+        if (webDriver != null) {
+            webDriver.quit();
+            webDriver = null;
+        }
+    }
+
+    /**
+     * Launch the specified snippet
+     * 
+     * @param snippetId
+     * 
+     * @return true if the snippet could be launched
+     */
+    public ResultPage launchSnippet(BaseTest baseTest) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.entering(sourceClass, "launchSnippet", new Object[] { baseTest });
+        }
+        
+        if (properties.getProperty(PROP_FIREBUG_ENABLED, "false").equals("true")) {
+            addSnippetParam("debug", "true");
+        }
+        if (properties.getProperty(PROP_ENABLE_MOCKTRANSPORT, "false").equals("true")) {
+            addSnippetParam("mockTransport", "true");
+        }
+        if (properties.getProperty(PROP_ENABLE_DEBUGTRANSPORT, "false").equals("true")) {
+            addSnippetParam("debugTransport", "true");
+        }
+
+        String launchUrl = computeLaunchUrl(baseTest);
+        Trace.log(launchUrl);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.exiting(sourceClass, "computeLaunchUrl", new Object[] { baseTest, launchUrl });
+        }
+        if (StringUtil.isEmpty(launchUrl)) {
+            return null;
+        }
+        //TODO call this init
+        webDriver = getWebDriver();
+        webDriver.get(launchUrl);
+        
+        WebElement webElement = authenticate(baseTest, null);
+        if (baseTest.getAuthType() != AuthType.NONE && baseTest.getAuthType() != AuthType.AUTO_DETECT) {
+            assertNotNull("Unable to confirm authentication for: " + baseTest.getSnippetId(), webElement);
+        }
+
+        return getPageObject();
+    }
+
+    // Protected stuff
+
+    /**
+     * Authenticate and return the WebElement for the specified match/condition
+     * 
+     * If authType == NONE then null is returned
+     */
+    protected WebElement authenticate(BaseTest baseTest, AuthType authType) {
+        if (logger.isLoggable(Level.FINE)) {
+            logger.entering(sourceClass, "authenticate", new Object[] { baseTest });
+        }
+        
+        String windowHandle = getPageObject().getWebDriver().getWindowHandle();
+
+        if (authType == null) {
+            authType = baseTest.getAuthType();
+        }
+        switch (authType) {
+        case NONE:
+            break;
+        case AUTO_DETECT:
+            return handleAutoDetect(baseTest);
+        case BASIC:
+            handleBasicLogin(baseTest);
+            break;
+        case OAUTH10:
+            handleOAuth10(baseTest);
+            break;
+        case OAUTH20:
+            handleOAuth20(baseTest);
+            break;
+        }
+
+        // restore window handle
+        restoreWindowHandle(webDriver, windowHandle);
+
+        // wait to confirm result page has displayed
+        WebElement webElement = baseTest.waitForResult(loginTimeout);
+        if (logger.isLoggable(Level.FINE)) {
+            logger.exiting(sourceClass, "authenticate", webElement);
+        }
+        return webElement;
+    }
+
+    /*
+     * Handle auto detection of the authentication mechanism
+     */
+    protected WebElement handleAutoDetect(BaseTest baseTest) {
+        WebElement form = searchAnyAuthenticationForm(baseTest, loginTimeout);
+        if (baseTest.isResultsReady()) {
+        	// results for this test are ready so return them here
+        	return form;
+        }
+        
+        AuthType authType = detectAuthType(baseTest, form);
+        if (authType != AuthType.NONE) {
+        	Trace.log("handleAutoDetect: " + form.getText() + " - " + authType);
+        }
+
+        return authenticate(baseTest, authType);
+    }
+
+    /*
+     * Handle basic authentication login
+     */
+    protected void handleBasicLogin(BaseTest baseTest) {
+        String loginFormId = baseTest.getProperty(PROP_BASIC_LOGINFORMID);
+        String usernameId = baseTest.getProperty(PROP_BASIC_USERNAMEID);
+        String passwordId = baseTest.getProperty(PROP_BASIC_PASSWORDID);
+        String submitId = baseTest.getProperty(PROP_BASIC_SUBMITID);
+        
+        String username = null;
+        String password = null;
+        if (isSmartCloud()) {
+        	username = baseTest.getProperty(PROP_OAUTH10_USERNAME);
+            password = baseTest.getProperty(PROP_OAUTH10_PASSWORD);
+        } else {
+        	username = baseTest.getProperty(PROP_BASIC_USERNAME);
+            password = baseTest.getProperty(PROP_BASIC_PASSWORD);
+        }
+
+        WebElement loginForm = waitForLoginForm(loginTimeout, loginFormId, null, BasicLoginTitle, baseTest);
+        if (baseTest.isResultsReady()) return;
+        if (loginForm != null) {
+            WebElement usernameEl = loginForm.findElement(By.name(usernameId));
+            WebElement passwordEl = loginForm.findElement(By.name(passwordId));
+            WebElement submitEl = loginForm.findElement(By.name(submitId));
+            usernameEl.sendKeys(username);
+            passwordEl.sendKeys(password);
+            submitEl.click();
+        } else {
+            //check if page was authenticated before
+            if (baseTest.waitForResult(0)!=null) return;
+            fail("Unable to locate basic login form");
+        }
+    }
+
+    /*
+     * Handle OAuth1.0 authentication
+     */
+    protected void handleOAuth10(BaseTest baseTest) {
+        String loginFormId = baseTest.getProperty(PROP_OAUTH10_LOGINFORMID);
+        String usernameId = baseTest.getProperty(PROP_OAUTH10_USERNAMEID);
+        String passwordId = baseTest.getProperty(PROP_OAUTH10_PASSWORDID);
+        String submitId = baseTest.getProperty(PROP_OAUTH10_SUBMITID);
+        String username = baseTest.getProperty(PROP_OAUTH10_USERNAME);
+        String password = baseTest.getProperty(PROP_OAUTH10_PASSWORD);
+
+        WebElement loginForm = waitForLoginForm(loginTimeout, loginFormId, null, OAuth10LoginTitle, baseTest);
+        if (baseTest.isResultsReady()) return;
+        if (loginForm != null) {
+            WebElement usernameEl = loginForm.findElement(By.name(usernameId));
+            WebElement passwordEl = loginForm.findElement(By.name(passwordId));
+            WebElement submitEl = loginForm.findElements(By.id(submitId)).get(0);
+            usernameEl.sendKeys(username);
+            passwordEl.sendKeys(password);
+            submitEl.click();
+        } else {
+            fail("Unable to locate OAuth1.0 login form");
+        }
+    }
+
+    /*
+     * Handle OAuth2.0 authentication
+     */
+    protected void handleOAuth20(BaseTest baseTest) {
+        String loginFormXPath = baseTest.getProperty(PROP_OAUTH20_LOGINFORMXPATH);
+        String usernameXPath = baseTest.getProperty(PROP_OAUTH20_USERNAMEXPATH);
+        String passwordXPath = baseTest.getProperty(PROP_OAUTH20_PASSWORDXPATH);
+        String submitXPath = baseTest.getProperty(PROP_OAUTH20_SUBMITXPATH);
+        String grantXPath = baseTest.getProperty(PROP_OAUTH20_GRANTXPATH);
+        String username = baseTest.getProperty(PROP_OAUTH20_USERNAME);
+        String password = baseTest.getProperty(PROP_OAUTH20_PASSWORD);
+
+        WebElement loginForm = waitForLoginForm(loginTimeout, null, loginFormXPath, OAuth20LoginTitle, baseTest);
+        if (baseTest.isResultsReady()) return;
+
+        if (loginForm != null) {
+            WebElement usernameEl = loginForm.findElement(By.xpath(usernameXPath));
+            WebElement passwordEl = loginForm.findElement(By.xpath(passwordXPath));
+            WebElement submitEl = loginForm.findElements(By.xpath(submitXPath)).get(0);
+            usernameEl.sendKeys(username);
+            passwordEl.sendKeys(password);
+            submitEl.click();
+
+            // wait for authorization popop
+            WebElement authPage = waitForPopup(loginTimeout, OAuth20AuthTitle);
+            if (authPage != null) {
+                WebElement grantEl = authPage.findElement(By.xpath(grantXPath));
+                grantEl.click();
+            } else {
+                fail("Unable to locate OAuth2.0 authorization page");
+            }
+        } else {
+            fail("Unable to locate OAuth2.0 login form");
+        }
+    }
+
+    /**
+     * Detect what type of authentication is being used
+     * @param form 
+     * 
+     * @return
+     */
+    public AuthType detectAuthType(BaseTest baseTest, WebElement loginForm) {
+    	// if results are available then no need to check for authentication
+        if (baseTest.isResultsReady()) {
+        	return AuthType.NONE;
+        }
+    	
+        // look for all variations of login form
+        String basicLoginFormId = baseTest.getProperty(PROP_BASIC_LOGINFORMID);
+        String oauth10LoginFormId = baseTest.getProperty(PROP_OAUTH10_LOGINFORMID);
+        String[] loginFormIds = { basicLoginFormId, oauth10LoginFormId };
+        String oauth20LoginFormXPath = baseTest.getProperty(PROP_OAUTH20_LOGINFORMXPATH);
+        String[] loginFormXPathExprs = { oauth20LoginFormXPath };
+        if (loginForm != null) {
+            String loginFormId = loginForm.getAttribute("id");
+            if (basicLoginFormId.equals(loginFormId)) {
+                return AuthType.BASIC;
+            } else if (oauth10LoginFormId.equals(loginFormId)) {
+                return AuthType.OAUTH10;
+            } else {
+                // TODO handle multiple login form xpath exprs
+                return AuthType.OAUTH20;
+            }
+        }
+        return AuthType.NONE;
+    }
+
+    /**
+     * Wait the specified interval for the one of the authentication screens to
+     * appear
+     */
+    private WebElement searchAnyAuthenticationForm(final BaseTest baseTest, final int secs) {
+        String basicLoginFormId = baseTest.getProperty(PROP_BASIC_LOGINFORMID);
+        String oauth10LoginFormId = baseTest.getProperty(PROP_OAUTH10_LOGINFORMID);
+        String[] loginFormIds = { basicLoginFormId, oauth10LoginFormId };
+        String oauth20LoginFormXPath = baseTest.getProperty(PROP_OAUTH20_LOGINFORMXPATH);
+        String[] loginFormXPathExprs = { oauth20LoginFormXPath };
+        String[] loginTitles = { BasicLoginTitle, OAuth10LoginTitle, OAuth20LoginTitle };
+        return waitForLoginForm(secs, loginFormIds, loginFormXPathExprs, loginTitles, baseTest);
+    }
+    
+    /**
+     * Return true if the WebElement represents a login form
+     */
+    public boolean isLoginForm(BaseTest baseTest, WebElement webElement) {
+        String basicLoginFormId = baseTest.getProperty(PROP_BASIC_LOGINFORMID);
+        String oauth10LoginFormId = baseTest.getProperty(PROP_OAUTH10_LOGINFORMID);
+        String[] loginFormIds = { basicLoginFormId, oauth10LoginFormId };
+        String oauth20LoginFormXPath = baseTest.getProperty(PROP_OAUTH20_LOGINFORMXPATH);
+        String[] loginFormXPathExprs = { oauth20LoginFormXPath };
+    	
+        for (int i = 0; i < loginFormIds.length; i++) {
+            if (StringUtil.isNotEmpty(loginFormIds[i])) {
+                try {
+                    if (loginFormIds[i] != null) {
+                        WebElement loginForm = webElement.findElement(By.id(loginFormIds[i]));
+                        if (loginForm != null) {
+                            return true;
+                        }
+                    }
+                } catch (Exception e) {
+                }
+            }
+        }
+        for (int i = 0; i < loginFormXPathExprs.length; i++) {
+            if (StringUtil.isNotEmpty(loginFormXPathExprs[i])) {
+                try {
+                    if (loginFormXPathExprs[i] != null) {
+                        WebElement loginForm = webElement.findElement(By.xpath(loginFormXPathExprs[i]));
+                        if (loginForm != null) {
+                            return true;
+                        }
+                    }
+                } catch (Exception e) {
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Wait the specified interval for the popup with the specified title to
+     * appear
+     */
+    public WebElement waitForPopup(final int secs, final String title) {
+        return waitForPopups(secs, new String[] { title });
+    }
+    /**
+     * Wait the specified interval for any popup with the specified titles to
+     * appear
+     */
+    public WebElement waitForPopups(final int secs, final String[] titles) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(webDriver);
+                    WebDriver popup = findPopup(titles);
+                    if (popup != null) {
+                        return popup.findElement(By.tagName("body"));
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Wait the specified interval for the login form to appear
+     */
+    public WebElement waitForLoginForm(int secs, String id, String xpathExpr, String title, final BaseTest baseTest) {
+        return waitForLoginForm(secs, new String[] { id }, new String[] { xpathExpr }, new String[] { title }, baseTest);
+    }
+
+    /**
+     * Wait the specified interval for the login form to appear
+     */
+    public WebElement waitForLoginForm(final int secs, final String[] ids, final String[] xpathExprs, final String[] titles, final BaseTest baseTest) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).pollingEvery(1, TimeUnit.SECONDS)
+                    .until(new ExpectedCondition<WebElement>() {
+                
+                boolean lookForResult = false;
+                
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(webDriver);
+                    
+                    
+                    WebElement loginForm = findLoginForm(getPageObject(webDriver).getWebDriver(), ids, xpathExprs, titles);
+                    
+                    if (loginForm == null && lookForResult) {
+                        WebElement result = baseTest.waitForResult(0);
+                            if (result!=null) {
+                            // wait for result may not flag ready if overridden
+                            baseTest.setResultsReady();
+                            // returning the result not a login form
+                            return result;
+                        }
+                    } 
+                    lookForResult = true;
+                    return loginForm;
+                }
+
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Wait the specified interval for the specified web element to be available
+     */
+    public WebElement waitForElement(final String match, final int secs, final String condition) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(webDriver);
+                    webDriver = getPageObject(webDriver).getWebDriver();
+                    if (condition.equalsIgnoreCase("id")) {
+                        return webDriver.findElement(By.id(match));
+                    } else if (condition.equalsIgnoreCase("linkText")) {
+                        return webDriver.findElement(By.linkText(match));
+                    } else if (condition.equalsIgnoreCase("tagName")) {
+                        return webDriver.findElement(By.tagName(match));
+                    } else if (condition.equalsIgnoreCase("name")) {
+                        return webDriver.findElement(By.name(match));
+                    } else if (condition.equalsIgnoreCase("idWithText")) {
+                        WebElement element = webDriver.findElement(By.id(match));
+                        String text = element.getText();
+                        if (StringUtil.isNotEmpty(text)) {
+                            return element;
+                        }
+                        String value = element.getAttribute("value");
+                        if (StringUtil.isNotEmpty(value)) {
+                            return element;
+                        }
+                        return null;
+                    } else if (condition.equalsIgnoreCase("idWithChild")) {
+                        WebElement element = webDriver.findElement(By.id(match));
+                        List<WebElement> children = element.findElements(By.xpath("*"));
+                        if (!children.isEmpty()) {
+                            return element;
+                        }
+                        return null;
+                    } else {
+                        return webDriver.findElement(By.name(match));
+                    }
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Wait the specified interval for the specified web element to be available
+     * and for it to have non empty content
+     */
+    public WebElement waitForText(final String id, final int secs) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(webDriver);
+                    webDriver = getPageObject(webDriver).getWebDriver();
+                    WebElement element = webDriver.findElement(By.id(id));
+                    String text = element.getText();
+                    if (StringUtil.isNotEmpty(text)) {
+                        return element;
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    
+    /**
+     * Wait the specified interval for the specified web element to be available
+     * and for it to have non empty content
+     * @param xPath This is the xPath expression used to find the element 
+     * @param secs This is the amount of seconds to wait before timing out
+     * @param expectedText This is the text that you expect the element to have
+     */
+    public WebElement waitForText(final String xPath, final int secs, final String expectedText) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(webDriver);
+                    webDriver = getPageObject(webDriver).getWebDriver();
+                    WebElement element = webDriver.findElement(By.xpath(xPath));
+                    String text = element.getText();
+                    if (text!=null && text.contains(expectedText)) {
+                        return element;
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    
+    /**
+     * Wait the specified interval for the specified web element to be available with the specified children
+     */
+    public WebElement waitForChildren(final String tagName, final String xpath, final int secs) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                	failIfPageCrashed(getPageObject(webDriver).getWebDriver());
+                    WebElement tableElement = getPageObject(webDriver).getWebDriver().findElement(By.tagName(tagName));
+                    WebElement element = tableElement.findElement(By.xpath(xpath));  
+                    return element;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Wait the specified interval for the specified web element to be available
+     */
+    public WebElement waitForText(final String id, final String match, final int secs) {
+        try {
+            return (new WebDriverWait(getPageObject().getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    failIfPageCrashed(getPageObject(webDriver).getWebDriver());
+                    WebElement element = getPageObject(webDriver).getWebDriver().findElement(By.id(id));
+                    String text = element.getText();
+                    if (text != null && text.contains(match)) {
+                        return element;
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Dump the specified result page to the trace log
+     */
+    public void dumpWebElement(WebElement webElement) {
+        Trace.log(webElement + " tagName:" + webElement.getTagName() + " text:" + webElement.getText() + " id:" + webElement.getAttribute("id") + " displayed:"
+                + webElement.isDisplayed());
+
+        List<WebElement> webElements = webElement.findElements(By.xpath("*"));
+        if (webElements.size() > 0) {
+            Trace.log("Children size: " + webElements.size());
+            for (int i = 0; i < webElements.size(); i++) {
+                WebElement nextElement = webElements.get(i);
+                Trace.log("[" + i + "]" + nextElement + " tagName:" + webElement.getTagName() + " text:" + nextElement.getText() + " id:"
+                        + nextElement.getAttribute("id") + " displayed:" + nextElement.isDisplayed());
+            }
+        }
+    }
+
+    /**
+     * Dump the page source to the trace log
+     */
+    public void dumpPageSource(WebDriver webDriver) {
+        String pageSource = webDriver.getPageSource();
+        Trace.log("Page source: " + pageSource);
+    }
+
+    /**
+     * Find the login form and optionally include popups
+     */
+    protected WebElement findLoginForm(SearchContext webDriver, String[] ids, String[] xpathExprs, String[] titles) {
+        WebElement loginForm = findLoginForm(webDriver, ids, xpathExprs);
+        if (loginForm != null) {
+            return loginForm;
+        }
+
+        if (titles != null) {
+            // look for authentication popup
+            WebDriver popup = findPopup(titles);
+            if (popup != null) {
+                loginForm = findLoginForm(popup, ids, xpathExprs);
+                if (loginForm != null) {
+                    return loginForm;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the basic authentication login form
+     */
+    protected WebElement findLoginForm(SearchContext wd, String[] ids, String[] xpathExprs) {
+        for (int i = 0; i < ids.length; i++) {
+            if (StringUtil.isNotEmpty(ids[i])) {
+                try {
+                    if (ids[i] != null) {
+                        WebElement loginForm = wd.findElement(By.id(ids[i]));
+                        if (loginForm != null) {
+                            return loginForm;
+                        }
+                    }
+                } catch (Exception e) {
+                }
+            }
+        }
+        for (int i = 0; i < xpathExprs.length; i++) {
+            if (StringUtil.isNotEmpty(xpathExprs[i])) {
+                try {
+                    if (xpathExprs[i] != null) {
+                        WebElement loginForm = wd.findElement(By.xpath(xpathExprs[i]));
+                        if (loginForm != null) {
+                            return loginForm;
+                        }
+                    }
+                } catch (Exception e) {
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return a WebDriver for the window with the specified title
+     */
+    public WebDriver findPopup(String title) {
+        return findPopup(new String[] { title });
+    }
+
+    /**
+     * Return a WebDriver for the window with one of the specified titles
+     */
+    public WebDriver findPopup(String[] titles) {
+        if (titles == null || titles.length == 0) return null;
+        WebDriver webDriver = getWebDriver();
+        WebDriver popup = null;
+        Set<String> windowHandles = webDriver.getWindowHandles();
+        Iterator<String> windowIterator = windowHandles.iterator();
+        while (windowIterator.hasNext()) {
+            String windowHandle = windowIterator.next();
+            popup = webDriver.switchTo().window(windowHandle);
+            String title = popup.getTitle();
+            for (int i = 0; i < titles.length; i++) {
+                if (title != null && title.contains(titles[i])) {
+                    return popup;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * tests whether the current environment is using the specified library
+     * @param lib a library identifier, like dojo or jquery
+     * @return true if the environment is using the specified library
+     */
+    public boolean isLibrary(String lib) {
+        if (jsLib==null|| lib == null)return false;
+        if (jsLib.startsWith(lib)) return true;
+        return false;
+    }
+    
+    /**
+     * tests the version identifier of the current library
+     * @param lib a library version, using non dotted format 
+     * (i.e. 182 for jquery 1.8.2, 143 for dojo 1.4.3)
+     * @return true if the environment is using the specified library
+     */
+    public boolean isLibraryVersion(String version) {
+        if (jsLib==null|| version == null)return false;
+        if (!version.matches("[\\D]"))return false;
+        return jsLib.replaceAll("[\\D]", "").equals(version);
+    }
+    /**
+     * tests the version identifier of the current library
+     * @param lib a library version, using non dotted format 
+     * (i.e. 182 for jquery 1.8.2, 143 for dojo 1.4.3)
+     * @return
+     */
+    public boolean isLibraryVersionGreatherThan(String version) {
+        if (jsLib==null|| version == null)return false;
+        if (version.matches("[\\D]"))return false;
+        return Integer.valueOf(jsLib.replaceAll("[\\D]", ""))> Integer.valueOf(version);
+    }
+
+    /**
+     * Return the WebDriver being in use without creating it on demand
+     * @return the current WebDriver
+     */
+    public WebDriver getCurrentDriver() {
+        return webDriver;
+    }
+
+    /**
+     * Return true if screenshots should be taken.
+     * @return
+     */
+    public boolean isTakeScreenshots() {
+        return takeScreenshot;
+    }
+
+    /**
+     * Return the path where screenshots should be stored.
+     * 
+     * @return
+     */
+    public String getScreenshotsPath() {
+        return screenshotsPath;
+    }
+
+    /**
+     * @param webDriver
+     * @param windowHandle
+     */
+    protected void restoreWindowHandle(WebDriver webDriver, String windowHandle) {
+        Set<String> windowHandles = webDriver.getWindowHandles();
+        if (!windowHandles.contains(windowHandle)) {
+            // expected window handle doesn't exist
+            Iterator<String> windowIterator = windowHandles.iterator();
+            if (windowIterator.hasNext()) {
+                windowHandle = windowIterator.next();
+            }
+        }
+        webDriver.switchTo().window(windowHandle);
+    }
+    
+    // Protected stuff
+
+    /**
+     * Load the test properties
+     */
+    protected Properties loadProperties() {
+        Properties properties = new Properties();
+        try {
+            ClassLoader loader = getClass().getClassLoader();
+            InputStream in = loader.getResourceAsStream("com/ibm/sbt/automation/core/environment/TestEnvironment.properties");
+            if (in != null) {
+                properties.load(in);
+                in.close();
+            }
+            for (Object key : properties.keySet()) {
+                if (key==null) continue;
+                if(StringUtil.isNotEmpty(System.getProperty(key.toString()))) {
+                    properties.put(key, System.getProperty(key.toString()));
+                }
+            }
+        } catch (IOException ioe) {
+        }
+        return properties;
+    }
+
+    /**
+     * @param baseTest
+     * @param url
+     * @return
+     */
+    protected String addSnippetParams(BaseTest baseTest, String url) {
+        Map<String, String> params = baseTest.getSnippetParams();
+        Iterator<Entry<String, String>> entries = params.entrySet().iterator();
+        while (entries.hasNext()) {
+            Entry<String, String> entry = entries.next();
+            if(url.indexOf("?") != -1)
+                url += "&" + entry.getKey() + "=" + URLEncoder.encode(entry.getValue());
+            else
+                url += "?" + entry.getKey() + "=" + URLEncoder.encode(entry.getValue());
+        }
+        
+        // add params from the environment but do not override the same
+        // param from the test
+        entries = snippetParams.entrySet().iterator();
+        while (entries.hasNext()) {
+            Entry<String, String> entry = entries.next();
+            if (!params.containsKey(entry.getKey())) {
+                if(url.indexOf("?") != -1)
+                    url += "&" + entry.getKey() + "=" + URLEncoder.encode(entry.getValue());
+                else
+                    url += "?" + entry.getKey() + "=" + URLEncoder.encode(entry.getValue());
+            }
+        }
+        
+        return url;
+    }
+    
+    // Private stuff
+
+    private void initInternetExplorerDriver() {
+        String ieDriver = System.getProperty(PROP_WEBDRIVER_IE_DRIVER);
+        if (StringUtil.isEmpty(ieDriver)) {
+            String userDir = System.getProperty(PROP_USER_DIR);
+            // TODO check the bitness of the OS and move this to test.properties
+            String driverPath = userDir + "/../../../tools/com.ibm.sbtx.ci/selenium/iew32/IEDriverServer.exe";
+            System.setProperty(PROP_WEBDRIVER_IE_DRIVER, driverPath);
+        }
+        webDriver = new InternetExplorerDriver() {
+            @Override
+            public void get(String url) {
+                super.get(url);
+                // FIX for self signed certificates
+                String t = super.getCurrentUrl();
+                if (t.contains("res://ieframe.dll/invalidcert.htm")) {
+                    super.navigate().to("javascript:document.getElementById('overridelink').click()");
+                }
+            }
+        };
+    }
+
+    private void initChromeDriver() {
+        String chromeDriver = System.getProperty(PROP_WEBDRIVER_CHROMER_DRIVER);
+        if (StringUtil.isEmpty(chromeDriver)) {
+            String userDir = System.getProperty(PROP_USER_DIR);
+            String driverPath = userDir + "/../../../tools/com.ibm.sbtx.ci/selenium/Chrome/chromedriver.exe";
+            System.setProperty(PROP_WEBDRIVER_CHROMER_DRIVER, driverPath);
+        }
+        if (!StringUtil.isEmpty(System.getProperty(PROP_CHROME_BINARY))) {
+            DesiredCapabilities capabilities = DesiredCapabilities.chrome();
+            capabilities.setCapability("chrome.binary", System.getProperty(PROP_CHROME_BINARY));
+            webDriver = new ChromeDriver(capabilities);
+        } else {
+            webDriver = new ChromeDriver();
+        }
+    }
+
+    /**
+     * this method tests for error pages from which the test cannot recover so
+     * that instead of waiting the full timeout while testing for a until() to
+     * happen we can fail the test early
+     */
+    private void failIfPageCrashed(WebDriver webDriver) {
+        // TODO: populate with more conditions as we find them
+        String text = getPageObject(webDriver).getText();
+        if (webDriver.getTitle().contains("Apache Tomcat") && webDriver.getTitle().contains("Error report")) {
+            fail(text);
+        }
+        if (text.startsWith("Error, unable to load snippet: ")) {
+            fail(text);
+        }
+        if (text.contains("Unrecognized SSL message, plaintext connection?")) {
+            fail("Cannot reach the quickstart image, probably firewall issues\n"+text);
+        }        
+        if (text.contains("Your account has been expired or suspended.")) {
+            fail("Smartcloud credential probably expired\n"+text);
+        }
+    }
+
+    // Abstract stuff
+
+    /**
+     * Perform a login
+     * 
+     * @return true if the log in operation succeeded
+     */
+    abstract public boolean login();
+
+    /**
+     * Compute the launch URL for the specified test
+     * 
+     * @param baseTest
+     * @return
+     */
+    abstract public String computeLaunchUrl(BaseTest baseTest);
+
+    /**
+     * Return the result page for the current web driver
+     * 
+     * @return
+     */
+    public ResultPage getPageObject() {
+        return getPageObject(getCurrentDriver());
+    }
+    
+    
+    /**
+     * Return the result page for the specified web driver
+     * 
+     * @param webDriver
+     * @return
+     */
+    abstract public ResultPage getPageObject(WebDriver webDriver);
+
+    public void decorateContext(Context context) {
+        try {
+            if (!StringUtil.isEmpty(getProperty(PROP_OVERRIDE_CONNECTIONS_BE))) {
+                BasicEndpoint connections = (BasicEndpoint) EndpointFactory.getEndpoint("connections");
+                connections.setUrl(getProperty(PROP_OVERRIDE_CONNECTIONS_BE));
+                context.getSessionMap().put("connections", connections);
+            }
+            
+            if (!StringUtil.isEmpty(getProperty(PROP_OVERRIDE_SMARTCLOUD_BE))) {
+                BasicEndpoint smartcloud = (BasicEndpoint) EndpointFactory.getEndpoint("smartcloud");
+                smartcloud.setUrl(getProperty(PROP_OVERRIDE_SMARTCLOUD_BE));
+                context.getSessionMap().put("smartcloud", smartcloud);
+            }
+        } catch (Throwable e) {
+            logger.severe(e.getMessage());
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironment.properties
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironment.properties
@@ -1,0 +1,79 @@
+jslib=dojo180
+sbt.sample.web.url=https://localhost:8443/sbt.sample.web
+sbtx.sample.web.url=https://localhost:8443/sbtx.sample.web
+playground.web.url=https://greenhousestage.lotus.com/sbt/sbtplayground.nsf
+restart.browser=false
+login.timeout=30
+firebug.enabled=false
+screenshots.enabled=false
+screenshots.base=
+
+connections.override.url=
+smartcloud.override.url=
+
+smartcloud.env=smartcloudEnvironment
+enable.smartcloud=false
+enable.trace=true
+#enable.debugtransport=true
+
+basic.loginFormId=ibmsbt.loginActionForm
+basic.usernameId=username
+basic.passwordId=password
+basic.submitId=submitBtn
+basic.username=fadams
+basic.password=passw0rd
+    
+oauth10.loginFormId=loginActionForm
+oauth10.usernameId=username
+oauth10.passwordId=password
+oauth10.submitId=submit_form
+oauth10.username=frankadams@try.lotuslive.com
+oauth10.password=Password61
+
+oauth20.loginFormXPath=//form[@class='lotusForm2 lotusLoginForm']
+oauth20.usernameXPath=//input[@id='username']
+oauth20.passwordXPath=//input[@id='password']
+oauth20.submitXPath=//input[@type='submit']
+oauth20.grantXPath=//input[@id='authBtn']
+oauth20.username=FrankAdams@renovations.com
+oauth20.password=passw0rd
+
+sample.displayName1=Frank Adams
+sample.title1=Frank Adams
+sample.email1=FrankAdams@renovations.com
+sample.id1=0EE5A7FA-3434-9A59-4825-7A7000278DAA
+sample.userId1=0EE5A7FA-3434-9A59-4825-7A7000278DAA
+# Settings for QSI Jun28
+#sample.email1=fadams@renovations.com
+#sample.id1=ECFF6A52-8D9A-3A1F-8525-7B970072A1A8
+#sample.userId1=ECFF6A52-8D9A-3A1F-8525-7B970072A1A8
+sample.userId1.fileId1=e46e18b8-3a37-4199-a26c-8d7c5ca5d59a
+sample.profileUrl1=https://qs.renovations.com:444/profiles/atom/profile.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7
+sample.pronunciationUrl1=https://qs.renovations.com:444/profiles/audio.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7
+sample.thumbnailUrl1=https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7
+
+sample.displayName2=Bill Jordan
+sample.email2=BillJordan@renovations.com
+sample.id2=04F26086-1A63-D244-4825-7A70002586FA
+sample.userId2=04F26086-1A63-D244-4825-7A70002586FA
+# Settings for QSI Jun28
+#sample.email2=bjordan@renovations.com
+#sample.id2=4557C8CB-C5D2-E87F-8525-7B9700727141
+#sample.userId2=4557C8CB-C5D2-E87F-8525-7B9700727141
+
+# na.collabserv.com:user:20547574
+
+smartcloud.displayName1=Frank Adams
+smartcloud.title1=Frank Adams
+smartcloud.email1=frankadams@try.lotuslive.com
+smartcloud.id1=20547574
+smartcloud.userId1=20547574
+smartcloud.userId1.fileId1=
+smartcloud.profileUrl1=https://apps.na.collabserv.com/contacts/profiles/view/20547574
+smartcloud.pronunciationUrl1=
+smartcloud.thumbnailUrl1=https://apps.lotuslive.com/contacts/img/photos/20547574__1354512034.jpg
+
+smartcloud.displayName2=Alan Goodwin
+smartcloud.email2=alangoodwin@try.lotuslive.com
+smartcloud.id2=20548027
+smartcloud.userId2=20548027

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironmentFactory.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/environment/TestEnvironmentFactory.java
@@ -1,0 +1,61 @@
+package com.ibm.sbt.automation.core.environment;
+
+/**
+ * @author mkataria
+ * @author mwallace
+ * 
+ * @date Jan 14, 2013
+ */
+public class TestEnvironmentFactory {
+    
+    static public String SBT_SAMPLE_WEB = "sbt.sample.web";
+    static public String SBT_PLAYGROUND = "sbt.playground";
+    static public String ACME_SAMPLE_APP = "acme.sample.app";
+        
+    static private TestEnvironment sampleEnv = new SbtWebEnvironment();
+    static private TestEnvironment playgroundEnv = new PlaygroundEnvironment();
+    static private TestEnvironment acmeAppEnv = new AcmeEnvironment();
+    
+    static private TestEnvironment defaultEnv = sampleEnv;
+
+    /**
+     * Return the TestEnvironment instance to use.
+     * 
+     * @return the TestEnvironment instance to use.
+     */
+	public static TestEnvironment getEnvironment() {
+	    String envName = System.getProperty(TestEnvironment.PROP_ENVIRONMENT);
+	    TestEnvironment environment = getEnvironmentByName(envName);
+	    if (environment == null) {
+	        environment = defaultEnv;
+	    }
+		return environment;
+	}
+
+    /**
+     * @param envName
+     */
+    public static TestEnvironment getEnvironmentByName(String envName) {
+        if (SBT_SAMPLE_WEB.equals(envName)) {
+            return sampleEnv;
+        } else if (SBT_PLAYGROUND.equals(envName)) {
+            return playgroundEnv;
+        } else if (ACME_SAMPLE_APP.equals(envName)) {
+        	return acmeAppEnv;
+        }
+        return null;
+    }
+	
+    /**
+     * Set the default environment to use.
+     * 
+     * @param envName
+     */
+	public static void setDefaultEnvironment(String envName) {
+	    TestEnvironment environment = getEnvironmentByName(envName);
+        if (environment != null) {
+            defaultEnv = environment;
+        }
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAcmeTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAcmeTest.java
@@ -1,0 +1,120 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import static org.junit.Assert.assertTrue;
+
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.AcmeSample.AcmeFlightsPage;
+import com.ibm.sbt.automation.core.test.pageobjects.AcmeSample.AcmeMyFlightPage;
+import com.ibm.sbt.automation.core.test.pageobjects.AcmeSample.AcmeNavigationPage;
+import com.ibm.sbt.automation.core.test.pageobjects.AcmeSample.AcmeResultPage;
+
+public class BaseAcmeTest extends BaseTest{
+	
+	//the navigation links
+	AcmeNavigationPage navPage;
+	
+	public boolean testAcmeAirlinesSample(){
+		
+		//launch the sample
+		AcmeResultPage result = launchAcmeAirlines("/index.html");
+		
+		//maximize the window - Because the nav links are not visible when the browser is not maximized
+		result.getWebDriver().manage().window().maximize();
+		
+		//check the home page appears
+		WebElement page = result.getMainContent();
+		assertTrue(page.isDisplayed());
+		
+		boolean navigationIsOkay = checkNavigationLinks(result);	
+		assertTrue(navigationIsOkay);
+		
+		boolean flightsPageIsOkay = checkFlightsPage(result);
+		assertTrue(flightsPageIsOkay);
+		
+		boolean myFlightsPageIsOkay = checkMyFlightsPage(result);
+		assertTrue(myFlightsPageIsOkay);
+		
+		return navigationIsOkay && flightsPageIsOkay && myFlightsPageIsOkay;
+	}
+	
+	public boolean checkMyFlightsPage(AcmeResultPage resultPage){
+		
+		if(this.navPage == null){
+			this.navPage = new AcmeNavigationPage(resultPage);
+		}
+		
+		navPage.goToMyFlightsPage();
+		AcmeMyFlightPage myFlights = new AcmeMyFlightPage(resultPage);
+		
+		return myFlights.checkFlight103IsBooked();
+	}
+	
+	public boolean checkFlightsPage(AcmeResultPage resultPage){
+		
+		if(this.navPage == null){
+			this.navPage = new AcmeNavigationPage(resultPage);
+		}
+		
+		navPage.goToFlightsPage();
+		AcmeFlightsPage flightsPage = new AcmeFlightsPage(resultPage);
+		
+		flightsPage.clickTheBookButton();
+		
+		return flightsPage.isFlightsTableDisplayed();
+	}
+	
+	public boolean checkNavigationLinks(AcmeResultPage resultPage){
+		
+		if(this.navPage == null){
+			this.navPage = new AcmeNavigationPage(resultPage);
+		}
+
+		navPage.goToFlightsPage();
+		
+		navPage.goToMyFlightsPage();
+		
+		navPage.goToFlightStatusPage();
+		
+		navPage.goToServicesPage();
+		
+		return true;
+	}
+	
+	protected AcmeResultPage launchAcmeAirlines(String snippetId) {
+		this.setAuthType(this.authType.AUTO_DETECT);
+		AcmeResultPage resultPage = launchAcmeSample(snippetId);
+        return resultPage;
+    }
+
+	protected AcmeResultPage launchAcmeSample(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return wrapResultPage(resultPage);
+    }
+	
+	protected AcmeResultPage wrapResultPage(ResultPage resultPage) {
+        return new AcmeResultPage(resultPage);
+    }
+	
+	@Override
+	public String getAuthenticatedMatch() {
+		// TODO Auto-generated method stub
+		return "mainContainer";
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseActivityStreamTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseActivityStreamTest.java
@@ -1,0 +1,59 @@
+package com.ibm.sbt.automation.core.test;
+
+import org.openqa.selenium.WebElement;
+import com.ibm.sbt.automation.core.test.pageobjects.WrapperResultPage;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class BaseActivityStreamTest extends BaseWrapperTest{
+
+	/**
+     * Default constructor
+     */
+    public BaseActivityStreamTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+	
+	/**
+	 * Check if the ActivityStream is displayed on the page
+	 * @param snippetId
+	 * @return true if displayed
+	 */
+	protected boolean checkActivityStream(String snippetId) {
+		WrapperResultPage resultPage = launchSnippet(snippetId);
+		
+		WebElement activityStreamFrame = resultPage.getActivityStreamFrame();
+		
+		// switch context into the iframe.
+		switchContextToIframe(resultPage, activityStreamFrame);
+		
+	    WebElement activityStream = resultPage.getActivityStream();
+		
+		WebElement newsFeedNode = resultPage.getNewsFeedNode();
+		
+		return (activityStream!=null) && (newsFeedNode!=null);
+	}
+	
+	@Override
+    protected boolean isEnvironmentValid() {
+	    // don't run the test in jquery
+        return super.isEnvironmentValid() && !environment.isLibrary("jquery");
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseApiTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseApiTest.java
@@ -1,0 +1,200 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import java.util.List;
+
+import org.junit.After;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.ibm.commons.runtime.Application;
+import com.ibm.commons.runtime.Context;
+import com.ibm.commons.runtime.RuntimeFactory;
+import com.ibm.commons.runtime.impl.app.RuntimeFactoryStandalone;
+import com.ibm.commons.util.StringUtil;
+import com.ibm.commons.util.io.json.JsonException;
+import com.ibm.commons.util.io.json.JsonJavaFactory;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.commons.util.io.json.JsonParser;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.security.authentication.password.PasswordException;
+import com.ibm.sbt.services.endpoints.BasicEndpoint;
+import com.ibm.sbt.services.endpoints.EndpointFactory;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseApiTest extends BaseTest {
+
+    private Application application;
+    private Context context;
+    
+    public BaseApiTest() {
+        RuntimeFactory runtimeFactory = new RuntimeFactoryStandalone() {
+            @Override
+            public Context initContext(Application application, Object request, Object response) {
+                Context context = super.initContext(application, request, response);
+                TestEnvironmentFactory.getEnvironment().decorateContext(context);
+                return context;
+            }
+        };
+        application = runtimeFactory.initApplication(null);
+        createContext();
+    }
+
+    /**
+     * Return the endpoint name to use
+     */
+    public String getEndpointName() {
+        if (environment.isSmartCloud()) {
+            return "smartcloud";
+        } else {
+            return "connections";
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+        return "json";
+    }
+
+    /**
+     * Create the context (if needed)
+     */
+    protected Context createContext() {
+        if (context == null) {
+            context = Context.init(application, null, null);
+        }
+        return context;
+    }
+    
+    /**
+     * Destroy the context
+     */
+    @After
+    public void destroyContext() {
+        if (context != null) {
+            Context.destroy(context);
+            context = null;
+        }
+    }
+    
+    /**
+     * @throws PasswordException
+     */
+    protected void loginConnections() throws AuthenticationException {
+        BasicEndpoint endpoint = (BasicEndpoint)EndpointFactory.getEndpoint(getEndpointName());
+        String username = null;
+        String password = null;            
+        if (environment.isSmartCloud()) {
+            username = getProperty(TestEnvironment.PROP_OAUTH10_USERNAME);
+            password = getProperty(TestEnvironment.PROP_OAUTH10_PASSWORD);            
+        } else {
+            username = getProperty(TestEnvironment.PROP_BASIC_USERNAME);
+            password = getProperty(TestEnvironment.PROP_BASIC_PASSWORD);            
+        }
+        endpoint.login(username, password, true);
+    }
+    
+    /**
+     * @param snippetId
+     * @return
+     */
+    protected JavaScriptPreviewPage executeSnippet(String snippetId) {
+        return executeSnippet(snippetId, 0);
+    }
+    
+    /**
+     * @param snippetId
+     * @return
+     */
+    protected JavaScriptPreviewPage executeSnippet(String snippetId, long delay) {
+        ResultPage resultPage = launchSnippet(snippetId, authType, delay);
+        JavaScriptPreviewPage previewPage = new JavaScriptPreviewPage(resultPage);
+        Trace.log(previewPage.getText());
+        return previewPage;
+    }
+    
+    /**
+     * Wait the specified interval for a json list with the specified number of entries
+     */
+    public WebElement waitForJsonList(final int count, final int secs) {
+        return waitForJsonList(count, null, secs);
+    }
+    
+    /**
+     * Wait the specified interval for a json list with the specified number of entries
+     */
+    public WebElement waitForJsonList(final int count, final JsonValidator jsonValidator, final int secs) {
+        try {
+            return (new WebDriverWait(environment.getWebDriver(), secs)).until(new ExpectedCondition<WebElement>() {
+                @Override
+                public WebElement apply(WebDriver webDriver) {
+                    WebElement element = webDriver.findElement(By.id("json"));
+                    String text = element.getText();
+                    if (StringUtil.isNotEmpty(text)) {
+                        try {
+                            List jsonList = (List)JsonParser.fromJson(JsonJavaFactory.instanceEx, text);
+                            if (jsonList.size() >= count) {
+                                if (jsonValidator != null) {
+                                    for (int i=0; i<jsonList.size(); i++) {
+                                        Object object = jsonList.get(i);
+                                        if (object instanceof JsonJavaObject) {
+                                            if (!jsonValidator.isValid(i, (JsonJavaObject)object)) {
+                                                return null;
+                                            }
+                                        }
+                                    }
+                                }
+                                return element;
+                            }
+                        } catch (JsonException je) {}
+                    }
+                    return null;
+                }
+            });
+        } catch (Exception e) {
+            return null;
+        }
+    }
+    
+    /**
+     * Interface used to check the content of a JSON object
+     */
+    public interface JsonValidator {
+        
+        /**
+         * Return true if the JSON object is in valid state for test validation
+         */
+        boolean isValid(int index, JsonJavaObject json);
+        
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAuthJavaServiceTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAuthJavaServiceTest.java
@@ -1,0 +1,32 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseAuthJavaServiceTest extends BaseServiceTest {
+    
+    public BaseAuthJavaServiceTest() {
+        snippetType = SnippetType.JAVA;
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAuthServiceTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseAuthServiceTest.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.security.authentication.password.PasswordException;
+import com.ibm.sbt.services.client.connections.communities.CommunityService;
+import com.ibm.sbt.services.endpoints.BasicEndpoint;
+import com.ibm.sbt.services.endpoints.EndpointFactory;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseAuthServiceTest extends BaseServiceTest {
+    
+    /**
+     * Default constructor
+     */
+    public BaseAuthServiceTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    /**
+     * @throws PasswordException
+     */
+    protected void loginConnections() throws AuthenticationException {
+        BasicEndpoint endpoint = (BasicEndpoint)EndpointFactory.getEndpoint(CommunityService.DEFAULT_ENDPOINT_NAME);
+        String username = getProperty(TestEnvironment.PROP_BASIC_USERNAME);
+        String password = getProperty(TestEnvironment.PROP_BASIC_PASSWORD);
+        endpoint.login(username, password, true);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseGridTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseGridTest.java
@@ -1,0 +1,255 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.pageobjects.GridPagerPage;
+import com.ibm.sbt.automation.core.test.pageobjects.GridResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.GridSorterPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseGridTest extends BaseTest {
+	
+	public BaseGridTest() {
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+    
+    /**
+     * Return true if a Grid was created on the page i.e. could find table, tbody and multiple tr's
+     * @return
+     */
+    protected boolean checkGrid(String snippetId) {
+        return checkGrid(snippetId, false, false);
+    }
+    
+    @Override
+    protected boolean isEnvironmentValid() {
+    	return super.isEnvironmentValid() && !environment.isLibrary("jquery");
+    }
+    /**
+     * Return true if a Grid was created on the page i.e. could find table, tbody and multiple tr's
+     * @return
+     */
+    protected boolean checkGrid(String snippetId, boolean hasPager) {
+        return checkGrid(snippetId, hasPager, false);
+    }
+    
+    protected boolean checkGrid(String snippetId, boolean hasPager, boolean hasSorter){
+        GridResultPage resultPage = launchGrid(snippetId);
+        
+        return checkGrid(resultPage, hasPager, hasSorter, snippetId);
+    }
+    
+    /**
+     * Return true if a Grid was created on the page i.e. could find table, tbody and multiple tr's
+     * @return
+     */
+    protected boolean checkGrid(GridResultPage resultPage, boolean hasPager, boolean hasSorter, String snippetId) {
+
+       if(resultPage.getText().contains("Empty")){
+    	   return true;
+       }
+        
+        WebElement table = resultPage.getTable();
+        if (table == null) {
+        	Assert.fail("Unable to find table for snippet: " + snippetId);
+        }
+        
+        WebElement tbody = resultPage.getTableBody();
+        if (tbody == null) {
+        	Assert.fail("Unable to find tbody for snippet: " + snippetId);
+        }
+        
+        List<WebElement> rows = resultPage.getTableRows();
+        if (rows == null || rows.isEmpty()) {
+        	Assert.fail("Unable to find rows for snippet: " + snippetId);
+        }
+        
+        boolean pagerOk = true;
+        /*if (hasPager) {
+        	//creating a string array to hold the text value of each row
+        	//because when the next page link is clicked rows.get(i).getText, will not work because
+        	//the element is no longer attached to the dom
+        	String[] tableRowText = new String[rows.size()];
+        	for(int i=0;i<tableRowText.length;i++){
+        		tableRowText[i] = rows.get(i).getText();
+        	}
+        	
+        	//check that when next is clicked a new set of results is displayed,
+        	//by comparing with results from the previous page
+            pagerOk = checkPager(resultPage,tableRowText);
+            
+            if (!pagerOk) {
+            	Assert.fail("Unable to page for snippet: " + snippetId);
+            }            
+        }*/
+        
+        boolean sorterOk = true;
+       /* if (hasSorter) {
+        	
+        	List<WebElement> rowsafterPaging = resultPage.getTableRows();
+        	String[] tableRowText = new String[rowsafterPaging.size()];
+        	for(int i=0;i<tableRowText.length;i++){
+        		tableRowText[i] = rowsafterPaging.get(i).getText();
+        	}
+        	
+            sorterOk = checkSorter(resultPage,tableRowText);
+            
+            if (!sorterOk) {
+            	Assert.fail("Unable to sort for snippet: " + snippetId);
+            }            
+        }*/
+        return (table != null) && (tbody != null) && (rows != null && !rows.isEmpty()) && pagerOk && sorterOk;
+    }
+        
+    /**
+     * @param resultPage
+     * @return
+     */
+    protected boolean checkPager(GridResultPage gridPage,String[] rows) {
+        GridPagerPage gridPager = gridPage.getGridPager();
+        
+        //If paging is available
+        if (gridPager.canPageNext()){
+        	gridPager.nextPage();
+        	//wait for the page number to change
+        	waitForText("/html/body/div[3]/div/div/div[2]", 5, "5 - 10");
+        	// wait for the rows of the grid to load after changing page
+        	waitForChildren("table", "tbody/tr[5]", 10);
+        } else {
+        	return true;
+        }
+        
+        //Check that the results of the grid have changed
+        boolean nextPageLinkIsWorking = true;
+        List<WebElement> rowsAfterNextPageWasClicked = gridPage.getTableRows();
+        for(int i=0;i<rowsAfterNextPageWasClicked.size();i++){
+        	//if the set of rows in page 2 is different than the set of rows in page 1
+        	//then the pager is working. - if the rows do not change, then pager is not working
+        	
+        	//System.out.println(rows[i]+" == "+rowsAfterNextPageWasClicked.get(i).getText());
+        	if(rows[i].equals(rowsAfterNextPageWasClicked.get(i).getText())){
+               	Assert.fail("Same row after paging next " + rows[i] + " == " + rowsAfterNextPageWasClicked.get(i).getText());
+        		nextPageLinkIsWorking = false; 
+        	}
+        }
+   
+        //If we can move back a page
+        if (gridPager.canPagePrevious()){
+        	//move back to the first page
+        	gridPager.previousPage(gridPage);
+           	//wait to go back to page 1
+        	waitForText("/html/body/div[3]/div/div/div[2]", 5, "0 - 5");
+        	//wait for the rows of the grid to load after changing page
+        	waitForChildren("table", "tbody/tr[5]", 5);
+        } else {
+        	//we should be able to go back after clicking next, if we can't return false;
+           	Assert.fail("Unable to page to previous: " + gridPage.getGridPager().getPagerDiv().getText());
+        	return false;
+        }
+        
+        //check that the results of clicking previous are the same as what we has originally
+        boolean previousPageLinkIsWorking = true;
+        List<WebElement> rowsAfterPrevWasClicked = gridPage.getTableRows();
+        for(int i=0;i<rowsAfterPrevWasClicked.size();i++){
+        	//if the set of rows in page 2 is different than the set of rows in page 1
+        	//then the sorter is working. - if the rows do not change, then pager is not working
+        	if(!rows[i].equals(rowsAfterPrevWasClicked.get(i).getText())){
+               	Assert.fail("Same row after paging previous " + rows[i] + " == " + rowsAfterPrevWasClicked.get(i).getText());
+        		previousPageLinkIsWorking = false;
+        	}
+        }
+         return previousPageLinkIsWorking && nextPageLinkIsWorking;
+    }
+
+    /**
+     * @param resultPage
+     * @return
+     */
+    protected boolean checkSorter(GridResultPage resultPage, String[] rows) {
+    	boolean sortingIsOkay = true;
+    	
+    	GridSorterPage sortPage = resultPage.getSortingPager();
+
+    	sortPage.SortByFirstSortAnchor();
+    	
+    	//wait for the rows of the grid to load after changing page
+    	waitForChildren("table", "tbody/tr[5]", 5);
+    	
+    	List<WebElement> rowsAfterSorting = resultPage.getTableRows();
+    	
+    	//Compare the the table rows before the sort to after the sort, they should have changed
+    	for(int i=0;i<rows.length;i++){
+    		
+    		//if no change in results, sorting has done nothing
+    		if(rows[i] == rowsAfterSorting.get(i).getText()){
+    			sortingIsOkay = false;
+    		}
+    	}
+    	
+
+        return sortingIsOkay;
+    }
+
+    /**
+     * Launch the grid snippet and return a GridResultPage
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected GridResultPage launchGrid(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return wrapResultPage(resultPage);
+    }
+    
+    /**
+     * Wrap the environment result page in a GridResultPage
+     * 
+     * @param resultPage
+     * @return
+     */
+    protected GridResultPage wrapResultPage(ResultPage resultPage) {
+        return new GridResultPage(resultPage);
+    }
+
+    /**
+     * most grid samples use this div and not the content div to inject themselves;
+     * further extend this on specific tests if they fill another div after being
+     * authenticated
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "table";
+    }
+    
+    @Override
+    public String getAuthenticatedCondition() {
+    	// TODO Auto-generated method stub
+    	return "tagName";
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseGridTestSetup.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseGridTestSetup.java
@@ -1,0 +1,253 @@
+package com.ibm.sbt.automation.core.test;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.services.client.ClientServicesException;
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityService;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+import com.ibm.sbt.services.client.connections.files.FileService;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileCreationParameters;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class BaseGridTestSetup extends BaseApiTest{
+	
+	/**The FileService for performing File related methods.*/
+	protected FileService fileService;
+	
+	/**fileEntry represents a Test File That will be created */
+	protected FileEntry fileEntry;
+	
+	/**folder represents a folder which will be created for testing*/
+	protected FileEntry folder;
+	
+	/**Fail the Test if the deletion fails */
+	private boolean failIfAfterDeletionFails = true;
+	
+	/**the Community Service is used to perform community related actions */
+	private CommunityService communityService;
+	
+	/**the Id of the community that is created by the createCommunity Method
+	 * this is stored so that the community can be deleted later. */
+	private String testCommunityID;
+	
+	/**Constructor*/
+	public BaseGridTestSetup(){
+		
+	}
+	
+	/**
+	 * create a community for testing
+	 * @param title
+	 * @param type
+	 * @param content
+	 * @param tags
+	 * @param retry
+	 * @return
+	 */
+	public Community createCommunity(String title, String type, String content, String tags, boolean retry) {
+        Community community = null;
+        try {
+            loginConnections();
+            CommunityService communityService = getCommunityService();
+            
+        	long start = System.currentTimeMillis();
+            community = communityService.newCommunity();
+            community.setTitle(title+start);
+            community.setCommunityType(type);
+            community.setContent(content);
+            community.setTags(tags);
+            String communityUuid = communityService.createCommunity(community);
+            testCommunityID = communityUuid;
+            
+            community = communityService.getCommunity(communityUuid);
+            
+            long duration = System.currentTimeMillis() - start;
+            Trace.log("Created test community: "+communityUuid + " took "+duration+"(ms)");
+        } catch (AuthenticationException pe) {
+        	if (pe.getCause() != null) {
+        		pe.getCause().printStackTrace();
+        	}
+            Assert.fail("Error authenicating: " + pe.getMessage());
+        } catch (CommunityServiceException cse) {
+        	// TODO remove this when we upgrade the QSI
+        	Throwable t = cse.getCause();
+        	if (t instanceof ClientServicesException) {
+        		ClientServicesException csex = (ClientServicesException)t;
+        		int statusCode = csex.getResponseStatusCode();
+        		if (statusCode == 500 && retry) {
+        			return createCommunity(title, type, content, tags, false);
+        		}
+        	}
+            fail("Error creating test community", cse);
+        } 
+        
+        return community;
+    }
+	
+	/**
+	 * Delete the community that was created by the create community method.
+	 */
+	public void deleteCommunity() {
+        if (testCommunityID != null) {
+            try {
+            	loginConnections();
+                CommunityService communityService = getCommunityService();
+                communityService.deleteCommunity(testCommunityID);
+            } catch (AuthenticationException pe) {
+            	if (pe.getCause() != null) {
+            		pe.getCause().printStackTrace();
+            	}
+                Assert.fail("Error authenicating: " + pe.getMessage());
+            } catch (CommunityServiceException cse) {
+                fail("Error deleting community "+testCommunityID, cse);
+            }
+        }
+    }
+	
+	protected CommunityService getCommunityService() {
+        if (communityService == null) {
+            communityService = new CommunityService(getEndpointName());
+        }
+        return communityService;
+    }
+	
+	protected void setFailIfAfterDeletionFails(boolean failIfAfterDeletionFails) {
+		this.failIfAfterDeletionFails = failIfAfterDeletionFails;
+	}
+	
+	protected FileService getFileService() {
+		try {
+			loginConnections();
+		} catch (AuthenticationException e) {
+			Assert.fail("Error logging in to Connections " + e.getMessage());
+			e.printStackTrace();
+			return null;
+		}
+		
+
+		if (fileService == null) {
+			fileService = new FileService(getEndpointName());
+		}
+		return fileService;
+	}
+	
+	public void createFolder() {
+		setFailIfAfterDeletionFails(true);
+		fileService = getFileService();
+		try {
+			folder = fileService.createFolder("TestFolder");		
+			fileService.pinFolder(folder.getFileId());
+			Trace.log("Created test folder: " + folder.getFileId());			
+		} catch (FileServiceException e) {
+			e.printStackTrace();
+			Assert.fail("Error creating test folder: " + e.getMessage());
+		}
+	}
+
+	public void createFile() {
+
+		try {
+			setFailIfAfterDeletionFails(true);
+			fileService = getFileService();
+			String content = "Content uploaded by Grid Setup";
+			String id = "File" + System.currentTimeMillis() + ".txt";
+
+			
+			FileCreationParameters p = new FileCreationParameters();
+			p.visibility = FileCreationParameters.Visibility.PUBLIC;
+			p.tags = new ArrayList<String>();
+			p.tags.add("text");
+			Map<String, String> params = p.buildParameters();			
+			
+			fileEntry = fileService.upload(new ByteArrayInputStream(content.getBytes()), id, content.length(), params);
+			
+			//delete the file and folder so there are items in the "trash"
+			deleteFileAndQuit();
+			
+			//recreate the folder and files 
+			createFolder();
+			fileEntry = fileService.upload(new ByteArrayInputStream(content.getBytes()), id, content.length(), params);
+
+			params = new HashMap<String, String>();
+			fileService.addCommentToFile(fileEntry, "Comment added by Grid Setup", params);
+			fileService.pinFile(fileEntry.getFileId());
+			if(folder != null){
+				fileService.addFileToFolder(fileEntry.getFileId(), folder.getFileId());
+			}else{
+				createFolder();
+				fileService.addFileToFolder(fileEntry.getFileId(), folder.getFileId());
+			}
+			
+			
+			Trace.log("Created test file: " + fileEntry.getFileId());
+		} catch (FileServiceException fse) {
+			fileEntry = null;
+	        fse.printStackTrace();
+			Assert.fail("Error creating test file: " + fse.getMessage());
+		}
+	}
+	
+	public void deleteFileAndQuit() {
+		if (fileEntry != null) {
+			try {
+				fileService.deleteFile(fileEntry.getFileId());
+			} catch (FileServiceException fse) {
+				fileEntry = null;
+				if (failIfAfterDeletionFails()) {
+					Assert.fail("Error deleting test file: " + fse.getMessage());
+					fse.printStackTrace();
+				}
+			}
+		}
+		if (folder != null) {
+			try {
+				fileService.deleteFolder(folder.getFileId());
+			} catch (FileServiceException fse) {
+				folder = null;
+				if (failIfAfterDeletionFails()) {
+					Assert.fail("Error deleting test folder: " + fse.getMessage());
+					fse.printStackTrace();
+				}
+			}
+		}
+
+	}
+	
+	public void emptyTrash(){
+		try {
+			fileService.deleteAllFilesFromRecycleBin();
+		} catch (FileServiceException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+	
+	 protected void fail(String message, CommunityServiceException cse) {
+	    	String failure = message;
+	    	
+	    	Throwable cause = cse.getCause();
+	    	if (cause != null) {
+	    		cause.printStackTrace();
+	    		failure += ", " + cause.getMessage();
+	    	} else {
+	    		cse.printStackTrace();
+	    		failure += ", " + cse.getMessage();
+	    	}
+	    	
+	    	Assert.fail(failure);
+	    }
+	
+	protected boolean failIfAfterDeletionFails() {
+		return failIfAfterDeletionFails;
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseJavaServiceTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseJavaServiceTest.java
@@ -1,0 +1,32 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseJavaServiceTest extends BaseServiceTest {
+    
+    public BaseJavaServiceTest() {
+        setSnippetType(SnippetType.JAVA);
+        setAuthType(AuthType.NONE);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseSampleFrameworkTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseSampleFrameworkTest.java
@@ -1,0 +1,118 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.SampleFrameworkResultPage;
+
+/**
+ * @author Francis
+ * @date 24 May 2013
+ */
+public class BaseSampleFrameworkTest extends BaseTest {
+
+    public BaseSampleFrameworkTest() {
+        authType = AuthType.NONE;
+    }
+
+    /**
+     * Launch the Sample Framework
+     * 
+     * @param snippetId
+     * @return the result page
+     */
+    protected SampleFrameworkResultPage launchSampleFramework() {
+        ResultPage resultPage = super.launchSnippet("");
+        return wrapResultPage(resultPage);
+    }
+
+    /**
+     * Wrap the environment result page in a SampleFrameworkResultPage
+     * 
+     * @param resultPage
+     * @return the result page
+     */
+    protected SampleFrameworkResultPage wrapResultPage(ResultPage resultPage) {
+        return new SampleFrameworkResultPage(resultPage);
+    }
+
+    @Override
+    protected boolean isEnvironmentValid() {
+        return super.isEnvironmentValid();
+    }
+    
+    public void toIframeContext(SampleFrameworkResultPage resultPage) {
+        WebElement iframeNode = resultPage.getPreviewFrame();
+        resultPage.getWebDriver().switchTo().frame(iframeNode);
+    }
+    
+    public void clickLeafNode(SampleFrameworkResultPage resultPage) {
+        WebElement leafNode = resultPage.getTreeLeaf();
+        leafNode.click();
+    }
+    
+    /*
+     * Check if the tree is displayed on the page
+     * 
+     * @param snippetId - the sample framework page
+     * @return true if displayed
+     */
+    public boolean checkTree(SampleFrameworkResultPage resultPage) {
+        return resultPage.getTree().isDisplayed();
+    }
+    
+    public boolean checkSmartcloudNavBar(SampleFrameworkResultPage resultPage){
+        return resultPage.getSmartcloudNavBar().isDisplayed();
+    }
+    
+    /*
+     * Check if the Sample Framework's main content is displayed on the page
+     * 
+     * @param resultPage - The sample framework page
+     * @return true if displayed
+     */
+    public boolean checkMainContent(SampleFrameworkResultPage resultPage) {
+        return resultPage.getMainContent().isDisplayed();
+    }
+    
+    /*
+     * Check if clicking a leaf node populates the iframe. NOTE: Switch context to the iframe first.
+     * 
+     * @param snippetId - the sample framework page
+     * @return true if displayed
+     */
+    public boolean checkIframe(SampleFrameworkResultPage resultPage) {
+        WebDriverWait wait = new WebDriverWait(resultPage.getWebDriver(), 20l);
+        WebElement iframeBody = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("body")));
+        String bodyClass = iframeBody.getAttribute("class");
+        
+        return bodyClass != null;
+    }
+   
+@Override
+public String getAuthenticatedCondition() {
+    return "idWithText";
+}
+@Override
+public String getAuthenticatedMatch() {
+    return "tree";
+}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseServiceTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class BaseServiceTest extends BaseTest {
+    
+    private String noErrorMsg;
+    private String expectedErrorMsg;
+    
+    private final String[] ErrorMessages = {
+                "Error received. Error Code",
+                "Error, unable to load:",
+                "Caused by: com.ibm.sbt.services.client.ClientServicesException",
+                "Exception occurred",
+                "Caused by:",
+                "HTTP Status 500",
+                "HTTP Status 404",
+                "Problem occurred",
+                "Username:"//when stuck on login screen
+    };
+    
+    /**
+     * 
+     * @return
+     */
+    protected boolean checkNoError(String snippetId, boolean allowEmpty) {
+        String text = executeSnippet(snippetId);
+        System.out.println("executeSnippet: "+text);
+        return containsNoError(text, allowEmpty);
+    }
+
+    /**
+     * 
+     * @return
+     */
+    protected boolean checkNoError(String snippetId) {
+        return checkNoError(snippetId, false);
+    }
+
+    /**
+     * 
+     * @return
+     */
+    protected boolean checkExpected(String snippetId, String expected) {
+        String text = executeSnippet(snippetId);
+        return matchesExpected(text, expected);
+    }
+    
+    
+    /*
+     * Return true if the result page contains no error message.
+     */
+    protected boolean containsNoError(String result) {
+    	return containsNoError(result, false);
+    }
+    
+    /*
+     * Return true if the result page contains no error message.
+     */
+    protected boolean containsNoError(String result, boolean allowEmpty) {
+        boolean retVal = true;
+        if (!allowEmpty && StringUtil.isEmpty(result)) {
+            noErrorMsg = "Empty result was returned for: " + getSnippetId();
+            retVal = false;
+        } else {
+            for (int i=0; i<ErrorMessages.length; i++) {
+                if (result.contains(ErrorMessages[i])) {
+                    noErrorMsg = "Error message for: " + getSnippetId() + ": " + result;
+                    retVal = false;
+                }
+            }
+        }
+        if (!retVal) {
+            Trace.log(noErrorMsg);
+        }
+        return retVal;
+    }
+
+    /*
+     * Return true if the result page contains or matches the expected result.
+     */
+    protected boolean matchesExpected(String result, String expected) {
+        boolean matches = result.equalsIgnoreCase(expected) || result.contains(expected);
+        if (!matches) {
+            expectedErrorMsg = "Match failure for " + getSnippetId() + 
+                " expected: '" + expected + "' result: '" + result + "'";
+            Trace.log(expectedErrorMsg);
+        }
+        return matches;
+    }
+    
+    /**
+     * @return the noErrorMsg
+     */
+    public String getNoErrorMsg() {
+        return noErrorMsg;
+    }
+    
+    /**
+     * @return the expectedErrorMsg
+     */
+    public String getExpectedErrorMsg() {
+        return expectedErrorMsg;
+    }
+    
+    /**
+     * @param snippetId
+     * @return
+     */
+    protected JavaScriptPreviewPage executeSnippet1(String snippetId) {
+    	 ResultPage resultPage = launchSnippet(snippetId, authType, 0);
+         JavaScriptPreviewPage previewPage = new JavaScriptPreviewPage(resultPage);
+         Trace.log(previewPage.getText());
+         return previewPage;
+    }
+
+    /**
+     * @param snippetId
+     * @return
+     */
+    protected String executeSnippet(String snippetId) {
+        ResultPage resultPage = launchSnippet(snippetId, authType);
+        String text =  resultPage.getText();
+        
+        //dumpResultPage(resultPage);
+        
+        if (text != null && text.startsWith("Show Snippet Code")) {
+            text = text.substring("Show Snippet Code".length());
+        }
+        return (text == null) ? null : text.trim();
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseTest.java
@@ -1,0 +1,377 @@
+package com.ibm.sbt.automation.core.test;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.openqa.selenium.By;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mkataria
+ * @author mwallace
+ * 
+ * @date Jan 23, 2013
+ */
+public abstract class BaseTest {
+
+	protected TestEnvironment environment;
+
+	protected AuthType authType = AuthType.NONE;
+	protected SnippetType snippetType = SnippetType.JAVASCRIPT;
+
+	private String snippetId;
+	private Map<String, String> snippetParams = new HashMap<String, String>();
+
+    private boolean resultsReady = false;
+	
+	public static enum AuthType {
+	    NONE, AUTO_DETECT, BASIC, OAUTH10, OAUTH20
+	};
+	
+    public static enum SnippetType {
+        JAVASCRIPT, JAVA, JAVASCRIPTFRAMEWORK, JAVAFRAMEWORK
+    };
+    
+    public static final String ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    public static final SimpleDateFormat dateFormat = new SimpleDateFormat(ISO_FORMAT);
+    static {
+        TimeZone utc = TimeZone.getTimeZone("UTC");
+        dateFormat.setTimeZone(utc);
+    }
+    
+	/**
+	 * Create the environment to use with this test
+	 */
+	public BaseTest() {
+	    environment = initTestEnvironment();
+	}
+	
+    /**
+     * Default behaviour before each test execution
+     */
+    @Before
+    public void assumeValidEnvironment() {
+        Assume.assumeTrue(isEnvironmentValid());
+    }
+    
+    /**
+     * Default behaviour after each test execution
+     */
+    @After
+    public void doQuit() {
+    	takeScreenshot();
+    	
+    	logTransport();
+    	
+    	if (environment.isQuitDriver()) {
+            environment.quitDriver();
+        }        
+    }
+
+    /**
+     * <p>override this method if you want the test to be run only
+     * when a specific condition is met, i.e. not on juery
+     * or only if dojo version is greather than 1.6
+     * remember to and it with super implementation!</p>
+     * <p>i.e. <pre>return super.isEnvironmentValid() && !environment.isLibrary("jquery");</pre></p>
+     * @return
+     */
+    protected boolean isEnvironmentValid() {
+        return true;
+    }
+    
+    /**
+     * Takes a screenshots from the current browser window,
+     * on a best effort basis (screenshots must be enabled, configured,
+     * the tests need file write permission to the configured path etc)
+     */
+	public void takeScreenshot() {
+        try {
+            if (environment.isTakeScreenshots()) {
+                WebDriver wd = environment.getCurrentDriver();
+                if (wd instanceof TakesScreenshot) {
+                    File snap = ((TakesScreenshot) wd).getScreenshotAs(OutputType.FILE);
+                    File dest = new File(environment.getScreenshotsPath(), this.getClass().getName());
+                    FileUtils.copyFileToDirectory(snap, dest);
+                }
+            }
+        } catch (Throwable t) {
+            System.err.println("Unable to take snapshot because: " + t.getMessage());
+        }
+	}
+	
+	public void logTransport() {
+		if (!environment.isDebugTransport()) {
+			return;
+		}
+		
+		WebDriver webDriver = environment.getCurrentDriver();
+		WebElement mockData = webDriver.findElement(By.id("mockData"));
+		if (mockData != null) {
+			Trace.log(mockData.getText());
+		}
+	}
+	
+	/**
+	 * Return the specified property from the test environment
+	 * 
+	 * @param name
+	 * @return
+	 */
+	public String getProperty(String name) {
+	    return environment.getProperty(name);
+	}
+	
+	/**
+	 * Set the authentication type to use for this test
+	 * @param authType
+	 */
+	public void setAuthType(AuthType authType) {
+	    this.authType = authType;
+	}
+	
+    /**
+     * Set the authentication type to use for this test
+     * @param authType
+     */
+    public void setAuthType(AuthType authType, boolean forcedReauth) {
+        this.authType = authType;
+        if (forcedReauth) cleanBrowserState();
+    }
+
+    /**
+     * @return the authType
+     */
+    public AuthType getAuthType() {
+        return authType;
+    }
+    
+    /**
+     * @param snippetType the snippetType to set
+     */
+    public void setSnippetType(SnippetType snippetType) {
+        this.snippetType = snippetType;
+    }
+    
+    /**
+     * @return the snippetType
+     */
+    public SnippetType getSnippetType() {
+        return snippetType;
+    }
+	
+	/**
+	 * Set the snippet id
+	 * 
+	 * @param snippetId
+	 */
+    public void setSnippetId(String snippetId) {
+        this.snippetId = snippetId;
+    }
+
+    /**
+     * Return the snippet id
+     * 
+     * @return
+     */
+    public String getSnippetId() {
+		return snippetId;
+	}
+    
+    /**
+     * Add a nippet param which will be passed to the snippet when it is invoked
+     * @param key
+     * @param value
+     */
+    public void addSnippetParam(String key, String value) {
+        snippetParams.put(key, value);
+    }
+    
+    /**
+     * Add a snippet param which will be passed to the snippet when it is invoked
+     * @param key
+     * @param value
+     */
+    public void addSnippetParam(String key, String[] values) {
+        snippetParams.put(key, StringUtil.concatStrings(values, ',', true));
+    }
+    
+    /**
+     * Return a map of parameters which should be passed from the test to the snippet
+     * @return
+     */
+    public Map<String, String> getSnippetParams() {
+        return snippetParams;
+    }
+    
+    /**
+     * Return the current test environment
+     * 
+     * @return
+     */
+	public TestEnvironment getTestEnvironment() {
+		return environment;
+	}
+	
+    /**
+     * Launch the specified snippet
+     */
+    public ResultPage launchSnippet(String snippetId) {
+        return launchSnippet(snippetId, authType);
+    }
+    
+	/**
+	 * Launch the specified snippet
+	 */
+    public ResultPage launchSnippet(String snippetId, AuthType authType) {
+        return launchSnippet(snippetId, authType, 0);
+    }
+    
+    /**
+     * Launch the specified snippet
+     */
+    public ResultPage launchSnippet(String snippetId, AuthType authType, long delay) {
+        assertNotNull("Expected a non null snippetId", snippetId);
+        setSnippetId(snippetId);
+        setAuthType(authType);
+        
+        ResultPage resultPage = environment.launchSnippet(this);
+        assertNotNull("Null result from snippet: "+snippetId, resultPage);
+
+        if (delay > 0) {
+            // optional delay to allow a test to return results
+            try {
+                Thread.sleep(delay);
+            } catch(InterruptedException ie) {
+            }
+            //TODO: this should not be necessary, investigate why is there
+            resultPage = environment.getPageObject(resultPage.getWebDriver());
+        }
+        
+        return resultPage;
+    }
+    
+    /**
+     * Wait for the test result to be present
+     */
+    public WebElement waitForResult(int timeout) {
+        WebElement elementMatch = environment.waitForElement(getAuthenticatedMatch(), timeout, getAuthenticatedCondition());
+        if (elementMatch!=null) {
+            this.setResultsReady();
+        }
+        return elementMatch;
+    }
+    
+    /**
+     * Wait for a specific element to be present
+     */
+    public WebElement waitForElement(final String match, final int secs, final String condition) {
+        return environment.waitForElement(match, secs, condition);
+    }
+    
+    /**
+     * Wait the specified interval for the specified web element to be available with specified text value
+     */
+    public WebElement waitForText(final String id, final String match, final int secs) {
+        return environment.waitForText(id, match, secs);
+    }
+    
+    public WebElement waitForText(final String xPath, final int seconds, final String expectedText){
+    	return environment.waitForText(xPath, seconds, expectedText);
+    }
+        
+    /**
+     * Wait the specified interval for the specified web element to be available with any text value
+     */
+    public WebElement waitForText(final String id, final int secs) {
+        return environment.waitForText(id, secs);
+    }
+     
+    /**
+     * Wait the specified interval for the specified web element to be available with the specified children
+     */
+    public WebElement waitForChildren(String tagName, String xpath, int timeout){
+    	return environment.waitForChildren(tagName, xpath, timeout);
+    }
+    
+    /**
+     * Return a WebDriver for the window with the specified title
+     */
+    public WebDriver findPopup(String title) {
+        return environment.findPopup(title);
+    }
+    
+    /**
+     * Dump the specified result page to the trace log
+     */
+    public void dumpResultPage(ResultPage resultPage) {
+        WebElement webElement = resultPage.getWebElement();
+        environment.dumpWebElement(webElement);
+    }
+   
+    /**
+     * Return the condition used to confirm authentication
+     */
+    public String getAuthenticatedCondition() {
+        return "idWithText";
+    }
+    
+    /**
+     * Return the match used to confirm authentication
+     */
+    public String getAuthenticatedMatch() {
+        return "content";
+    }
+
+    /*
+     * Initialize the TestEnvironment to use
+     */
+    protected TestEnvironment initTestEnvironment() {
+        return TestEnvironmentFactory.getEnvironment();
+    }
+    
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[ Snippet Id: ").append(snippetId);
+        sb.append(", Snippet Type: ").append(snippetType);
+        sb.append(", Authorization Type: ").append(authType);
+        sb.append(", Authenticated Condition: ").append(getAuthenticatedCondition());
+        sb.append(", Authenticated Match: ").append(getAuthenticatedCondition());
+        sb.append(" ]");
+        return sb.toString();
+    }
+
+    private void cleanBrowserState() {
+        environment.cleanBrowserState();
+     }
+
+    public boolean isResultsReady() {
+        return resultsReady;
+    }
+
+    public void setResultsReady() {
+        this.resultsReady = true;
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseVCardTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseVCardTest.java
@@ -1,0 +1,86 @@
+package com.ibm.sbt.automation.core.test;
+
+import java.util.List;
+import org.openqa.selenium.WebElement;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.VCardResultPage;
+
+public class BaseVCardTest extends BaseTest{
+	
+	/**
+	 * Check if the vCard is displayed on the page
+	 * @param snippetId
+	 * @return true if displayed
+	 */
+	protected boolean checkVCard(String snippetId) {
+		VCardResultPage resultPage = launchVCard(snippetId);
+		return resultPage.getVCardSpan().isDisplayed();
+	}
+	
+	protected boolean checkCommunityVCard(String snippetId) {
+		VCardResultPage resultPage = launchVCard(snippetId);
+		
+		boolean pageDisplayed = resultPage.getVCardSpan().isDisplayed(); // revert to checking the span for now.
+		//boolean communityCardNavDisplayed = resultPage.waitForCommunityCardNav().isDisplayed();
+		
+		return pageDisplayed;// && communityCardNavDisplayed;
+	}
+	
+	protected boolean checkProfileVCard(String snippetId) {
+		VCardResultPage resultPage = launchVCard(snippetId);
+		
+		return checkProfileVCard(resultPage);
+	}
+	
+	protected boolean checkProfileVCard(VCardResultPage resultPage) {
+        boolean pageDisplayed = resultPage.isDisplayed();
+        WebElement cardAttachPoint = resultPage.getCardAttachPoint();
+        boolean profileCardDisplayable = resultPage.isProfileCardDisplayable(cardAttachPoint);
+        
+        return pageDisplayed && profileCardDisplayable;
+    }
+	
+	protected boolean checkProfileVCards(String snippetId){
+		VCardResultPage resultPage = launchVCard(snippetId);
+		
+		boolean pageDisplayed = resultPage.isDisplayed();
+        List<WebElement> cardList = resultPage.getCardDivs();
+		boolean profileCardsDisplayable = resultPage.areProfileCardsDisplayable(cardList);
+		
+		
+		return pageDisplayed && profileCardsDisplayable;
+	}
+	
+	protected boolean checkProfileVCardInline(String snippetId) {
+		VCardResultPage resultPage = launchVCard(snippetId);
+		
+		boolean pageDisplayed = resultPage.isDisplayed();
+		boolean profileInlineCardDisplayed = resultPage.getInlineProfileCardDiv().isDisplayed();
+		
+		return pageDisplayed && profileInlineCardDisplayed;
+	}
+	
+	/**
+	 * Launch the vCard snippet 
+	 * @param snippetId
+	 * @return the result page
+	 */
+	protected VCardResultPage launchVCard(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return wrapResultPage(resultPage);
+	}
+	
+	 /**
+     * Wrap the environment result page in a VCardResultPage 
+     * @param resultPage
+     * @return the result page
+     */	
+	protected VCardResultPage wrapResultPage(ResultPage resultPage) {
+		return new VCardResultPage(resultPage);
+	}
+	
+    @Override
+    protected boolean isEnvironmentValid() {
+    	return super.isEnvironmentValid() && !environment.isLibrary("jquery");
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseWrapperTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/BaseWrapperTest.java
@@ -1,0 +1,84 @@
+package com.ibm.sbt.automation.core.test;
+
+import org.openqa.selenium.WebElement;
+import com.ibm.sbt.automation.core.test.pageobjects.GridResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.VCardResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.WrapperResultPage;
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 16 Jul 2013
+ */
+public class BaseWrapperTest extends BaseTest {
+    /**
+     * Default constructor
+     */
+    public BaseWrapperTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    /**
+     * Check if the FileGrid is present inside the iframe.
+     * @param snippetId
+     * @return true if displayed
+     */
+    protected boolean checkFileGridWrapper(String snippetId) {
+        WrapperResultPage resultPage = launchSnippet(snippetId);
+        switchContextToIframe(resultPage, resultPage.getFileGridFrame());
+        GridResultPage innerIframePage = new GridResultPage(resultPage);
+        innerIframePage.gridId="innerGridDiv";
+        BaseGridTest gridTest = new BaseGridTest();
+        
+        return gridTest.checkGrid(innerIframePage, true, true, snippetId);
+    }
+    
+    /**
+     * Check if the VCard is present inside the iframe.
+     * @param snippetId
+     * @return
+     */
+    protected boolean checkProfileCardWrapper(String snippetId){
+        WrapperResultPage resultPage = launchSnippet(snippetId);
+        switchContextToIframe(resultPage, resultPage.getProfileCardFrame());
+        VCardResultPage innerIframePage = new VCardResultPage(resultPage);
+        BaseVCardTest vCardTest = new BaseVCardTest();
+        
+        return vCardTest.checkProfileVCard(innerIframePage);
+    }
+
+    /**
+     * Launch the ActivityStream snippet 
+     * @param snippetId
+     * @return the result page
+     */
+    @Override
+    public WrapperResultPage launchSnippet(String snippetId) {
+        WrapperResultPage resultPage = new WrapperResultPage(super.launchSnippet(snippetId, authType));
+        return resultPage;
+    }
+    
+    protected WrapperResultPage switchContextToIframe(WrapperResultPage resultPage, WebElement iframe){
+        resultPage.getWebDriver().switchTo().frame(iframe);
+        return resultPage;
+    }
+    
+    @Override
+    protected boolean isEnvironmentValid() {
+        return super.isEnvironmentValid() && !environment.isLibrary("jquery");
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseActivitiesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseActivitiesTest.java
@@ -1,0 +1,14 @@
+/**
+ * 
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+
+/**
+ * @author mwallace
+ *
+ */
+public class BaseActivitiesTest extends BaseApiTest {
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseActivityStreamsTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseActivityStreamsTest.java
@@ -1,0 +1,174 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.services.client.SBTServiceException;
+import com.ibm.sbt.services.client.connections.activitystreams.ActivityStreamService;
+import com.ibm.sbt.services.client.connections.activitystreams.model.ActivityStreamEntity;
+import com.ibm.sbt.services.client.connections.activitystreams.ActivityStreamEntityList;  
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityService;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 10 May 2013
+ */
+
+public class BaseActivityStreamsTest extends BaseApiTest {
+    
+    protected ActivityStreamService activityStreamService;
+    protected ActivityStreamEntity asEntry;
+    protected boolean postEntry = true;
+
+    public BaseActivityStreamsTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    protected ActivityStreamService getActivityStreamService() {
+        if (activityStreamService == null) {
+            activityStreamService = new ActivityStreamService();
+        }
+        return activityStreamService;
+    }
+    
+    protected ActivityStreamEntity getLastCreatedEntry() {
+        try {
+            loginConnections();
+            ActivityStreamService asService = getActivityStreamService();
+            ActivityStreamEntityList entries = asService.getAllUpdates();
+            asEntry = entries.iterator().next();
+            Trace.log("Last created entry: "+asEntry.getId());
+        } catch (AuthenticationException pe) {
+            Assert.fail("Error authenicating: " + pe.getMessage());
+            pe.printStackTrace();
+        } catch (SBTServiceException e) {
+        	Assert.fail("SBTServiceException: " + e.getMessage());
+            e.printStackTrace();
+		}
+        return asEntry;
+    }
+
+    
+    protected void createEntry(String userType, String groupType, String applicationType) {
+    	createContext();
+    	try {
+			loginConnections();
+		} catch (AuthenticationException e1) {
+			Assert.fail("AuthenticationException: "+e1.getMessage());
+		}
+    	JsonJavaObject postPayload = new JsonJavaObject();
+    	
+		JsonJavaObject actor = new JsonJavaObject();
+        actor.putString("id", "@me");
+
+		JsonJavaObject object = new JsonJavaObject();
+		object.putString("id", "objectid");
+		object.putString("displayName", "Display Name for Misscrblogging sameple");
+		postPayload.putObject("actor", actor);
+		postPayload.putString("verb", "@invite");
+		postPayload.putObject("object", object);
+
+		ActivityStreamService service = new ActivityStreamService();
+		try {
+			service.postEntry(userType, groupType, applicationType, postPayload);
+		} catch (SBTServiceException e) {
+			Assert.fail("SBTServiceException: " + e.getMessage());
+		}
+    }
+    
+    protected void createCommunityWithTags(String tags) {
+    	createContext();
+    	CommunityService communityService = new CommunityService();
+    	Community community = null;
+    	try{
+			community = communityService.newCommunity();
+			community.setTitle("Test Community" + System.currentTimeMillis());
+			community.setContent("Test Community created to test Activity Streams");
+			community.setTags(tags);
+			String communityId = communityService.createCommunity(community);
+    	}catch(CommunityServiceException cse){
+    		Assert.assertNull("CommunityServiceException in testing SearchByFilters");
+    	}
+    }
+    
+    protected String getLastEntryId(List jsonList){
+    	JsonJavaObject jjo = null;
+    	String id = null;
+    	if(jsonList.iterator().hasNext()){
+    		jjo = (JsonJavaObject)jsonList.iterator().next();
+    		id = jjo.getJsonObject("dataHandler").getJsonObject("data").getJsonObject("object").getString("id");
+    	}
+    	return id;
+    }
+    
+    protected boolean isLatestEntryFound(List jsonList, String latestEntry){
+    	JsonJavaObject jjo = null;
+    	String id = null;
+    	while(jsonList.iterator().hasNext()){
+    		jjo = (JsonJavaObject)jsonList.iterator().next();
+    		id = jjo.getJsonObject("dataHandler").getJsonObject("data").getJsonObject("object").getString("id");
+    		if(latestEntry.equals(id)){
+    			return true;
+    		}
+    	}
+    	return false;
+    }
+    
+    protected void postAStatusUpdate() {
+    	createContext();
+    	try {
+			loginConnections();
+		} catch (AuthenticationException e1) {
+			Assert.fail("AuthenticationException: "+e1.getMessage());
+		}
+    	JsonJavaObject postPayload = new JsonJavaObject();
+    	
+		JsonJavaObject actor = new JsonJavaObject();
+        actor.putString("id", "@me");
+
+		JsonJavaObject object = new JsonJavaObject();
+		object.putString("id", "objectid");
+		object.putString("displayName", "Display Name for Misscrblogging sameple");
+		postPayload.putObject("actor", actor);
+		postPayload.putString("verb", "@invite");
+		postPayload.putObject("object", object);
+
+		ActivityStreamService service = new ActivityStreamService();
+		try {
+			service.postEntry("@me", "@status", "@all", postPayload);
+		} catch (SBTServiceException e) {
+			Assert.fail("SBTServiceException: " + e.getMessage());
+		}
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseCommunitiesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseCommunitiesTest.java
@@ -1,0 +1,303 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.services.client.ClientServicesException;
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityService;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+import com.ibm.sbt.services.client.connections.communities.Member;
+import com.ibm.sbt.services.client.connections.communities.MemberList;
+
+
+
+/**
+ * @author mwallace
+ *  
+ * @date 13 Mar 2013
+ */
+public class BaseCommunitiesTest extends BaseApiTest {
+    
+    protected boolean createCommunity = true;
+    protected CommunityService communityService;
+    protected Community community;
+
+    public BaseCommunitiesTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Before
+    public void createCommunity() {
+        createContext();
+        if (createCommunity) {
+        	String type = "public";
+        	if (environment.isSmartCloud()) {
+        		type = "private";
+        	}
+        	String name = createCommunityName();
+        	//System.out.println(name);
+            community = createCommunity(name, type, name, "tag1,tag2,tag3");
+        }
+    }
+    
+    @After
+    public void deleteCommunityAndQuit() {
+    	deleteCommunity(community);
+    	community = null;
+    	destroyContext();
+    }
+    
+    protected String createCommunityName() {
+    	return this.getClass().getName() + "#" + this.hashCode() + " Community - " + System.currentTimeMillis();
+    }
+    
+    protected CommunityService getCommunityService() {
+        if (communityService == null) {
+            communityService = new CommunityService(getEndpointName());
+        }
+        return communityService;
+    }
+    
+    protected void assertCommunityValid(JsonJavaObject json) {
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(community.getTitle(), json.getString("getTitle"));
+        Assert.assertEquals(community.getSummary(), json.getString("getSummary"));
+        Assert.assertEquals(community.getContent(), json.getString("getContent"));
+        Assert.assertEquals(community.getCommunityUrl(), json.getString("getCommunityUrl"));
+        Assert.assertEquals(community.getLogoUrl(), json.getString("getLogoUrl"));
+        Assert.assertEquals(community.getMemberCount(), json.getInt("getMemberCount"));
+        Assert.assertEquals(community.getCommunityType(), json.getString("getCommunityType"));
+        Assert.assertEquals(community.getAuthor().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+        Assert.assertEquals(community.getAuthor().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+        Assert.assertEquals(community.getAuthor().getUserid(), json.getJsonObject("getAuthor").getString("authorUserid"));
+        Assert.assertEquals(community.getContributor().getName(), json.getJsonObject("getContributor").getString("contributorName"));
+        Assert.assertEquals(community.getContributor().getEmail(), json.getJsonObject("getContributor").getString("contributorEmail"));
+        Assert.assertEquals(community.getContributor().getUserid(), json.getJsonObject("getContributor").getString("contributorUserid"));
+    }
+    
+    protected void assertMemberValid(JsonJavaObject json, String communityUuid, String name, String userid, String email, String role) {
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(communityUuid, json.getString("getCommunityUuid"));
+        Assert.assertEquals(name, json.getString("getName"));
+        Assert.assertEquals(userid, json.getString("getUserid"));
+        if (!environment.isSmartCloud()) {
+        	Assert.assertTrue("Expect match "+email+" <> "+json.getString("getEmail"), email.equalsIgnoreCase(json.getString("getEmail")));
+        }
+        Assert.assertEquals(role, json.getString("getRole"));
+    }
+    
+    protected Community getLastCreatedCommunity() {
+        Community community = null;
+        try {
+            loginConnections();
+            
+            CommunityService communityService = getCommunityService();
+            Collection<Community> communities = communityService.getMyCommunities();
+            community = communities.iterator().next();
+            Trace.log("Last created community: "+community.getCommunityUuid());
+            Trace.log("Last created community: "+community.getPublished());
+            Iterator<Community> i = communities.iterator();
+            while (i.hasNext()) {
+            	Community c= i.next();
+            	Trace.log("Last created community: "+c.getCommunityUuid());
+            	Trace.log("Last created community: "+c.getTitle());
+            	Trace.log("Last created community: "+c.getPublished());
+            }
+        } catch (AuthenticationException pe) {
+        	if (pe.getCause() != null) {
+        		pe.getCause().printStackTrace();
+        	}
+            Assert.fail("Error authenicating: " + pe.getMessage());
+        } catch (CommunityServiceException cse) {
+            fail("Error getting last created community", cse);
+        } 
+        
+        return community;
+    }
+    
+    protected Community getCommunity(String communityUuid) {
+        return getCommunity(communityUuid, true);
+    }
+    
+    protected Community getCommunity(String communityUuid, boolean failOnCse) {
+        Community community = null;
+        try {
+            loginConnections();
+            
+            CommunityService communityService = getCommunityService();
+            community = communityService.getCommunity(communityUuid);
+            Trace.log("Got community: "+community.getCommunityUuid());
+        } catch (AuthenticationException pe) {
+        	if (pe.getCause() != null) {
+        		pe.getCause().printStackTrace();
+        	}
+            Assert.fail("Error authenicating: " + pe.getMessage());
+        } catch (CommunityServiceException cse) {
+        	if (failOnCse) {
+        		fail("Error retrieving community", cse);
+        	}
+        } 
+        return community;
+    }
+    
+    protected Community createCommunity(String title, String type, String content, String tags) {
+    	return createCommunity(title, type, content, tags, true);
+    }
+    
+    protected Community createCommunity(String title, String type, String content, String tags, boolean retry) {
+        Community community = null;
+        try {
+            loginConnections();
+            CommunityService communityService = getCommunityService();
+            
+        	long start = System.currentTimeMillis();
+            community = communityService.newCommunity();
+            community.setTitle(title);
+            community.setCommunityType(type);
+            community.setContent(content);
+            community.setTags(tags);
+            String communityUuid = communityService.createCommunity(community);
+            community = communityService.getCommunity(communityUuid);
+            
+            long duration = System.currentTimeMillis() - start;
+            Trace.log("Created test community: "+communityUuid + " took "+duration+"(ms)");
+        } catch (AuthenticationException pe) {
+        	if (pe.getCause() != null) {
+        		pe.getCause().printStackTrace();
+        	}
+            Assert.fail("Error authenicating: " + pe.getMessage());
+        } catch (CommunityServiceException cse) {
+        	// TODO remove this when we upgrade the QSI
+        	Throwable t = cse.getCause();
+        	if (t instanceof ClientServicesException) {
+        		ClientServicesException csex = (ClientServicesException)t;
+        		int statusCode = csex.getResponseStatusCode();
+        		if (statusCode == 500 && retry) {
+        			return createCommunity(title + " (retry)", type, content, tags, false);
+        		}
+        	}
+            fail("Error creating test community with title: '"+title+"'", cse);
+        } 
+        
+        return community;
+    }
+
+    protected void deleteCommunity(Community community) {
+        if (community != null) {
+            try {
+            	loginConnections();
+                CommunityService communityService = getCommunityService();
+                communityService.deleteCommunity(community);
+            } catch (AuthenticationException pe) {
+            	if (pe.getCause() != null) {
+            		pe.getCause().printStackTrace();
+            	}
+                Assert.fail("Error authenicating: " + pe.getMessage());
+            } catch (CommunityServiceException cse) {
+                community = null;
+            	// check if community delete failed because
+            	// community was already deleted
+            	Throwable t = cse.getCause();
+            	if (t instanceof ClientServicesException) {
+            		ClientServicesException csex = (ClientServicesException)t;
+            		int statusCode = csex.getResponseStatusCode();
+            		if (statusCode == 404) {
+            			Trace.log(this.getClass().getName() + " attempt to delete already deleted Community: " + csex.getLocalizedMessage());
+            			return;
+            		}
+            	}
+                fail("Error deleting community "+community, cse);
+            }
+        }
+    }
+    
+    protected void deleteCommunity(String communityId) {
+        if (communityId != null) {
+            try {
+            	loginConnections();
+                CommunityService communityService = getCommunityService();
+                communityService.deleteCommunity(communityId);
+            } catch (AuthenticationException pe) {
+            	if (pe.getCause() != null) {
+            		pe.getCause().printStackTrace();
+            	}
+                Assert.fail("Error authenicating: " + pe.getMessage());
+            } catch (CommunityServiceException cse) {
+                fail("Error deleting community "+communityId, cse);
+            }
+        }
+    }
+    
+    protected boolean addMember(Community community, String id, String role) {
+        try {
+            CommunityService communityService = getCommunityService();
+            Member member = new Member(communityService, id, null, null);
+            member.setRole(role);
+            boolean added = communityService.addMember(community, member);
+            Assert.assertTrue("Unable to add member: "+id, added);
+            Trace.log("Added member: "+id);
+            return added;
+        } catch (CommunityServiceException cse) {
+            fail("Error adding member", cse);
+        } 
+        return false;
+    }
+
+    protected boolean hasMember(Community community, String id) {
+        try {
+            CommunityService communityService = getCommunityService();
+            MemberList memberList = communityService.getMembers(community);
+            for (int i=0; i<memberList.size(); i++) {
+            	Member member = (Member)memberList.get(i);
+                if (id.equals(member.getEmail()) || id.equals(member.getUserid())) {
+                    return true;
+                }
+            }
+        } catch (CommunityServiceException cse) {
+            fail("Error getting members", cse);
+        } 
+        return false;
+    }
+    
+    protected void fail(String message, CommunityServiceException cse) {
+    	String failure = message;
+    	
+    	Throwable cause = cse.getCause();
+    	if (cause != null) {
+    		cause.printStackTrace();
+    		failure += ", " + cause.getMessage();
+    	} else {
+    		cse.printStackTrace();
+    		failure += ", " + cse.getMessage();
+    	}
+    	
+    	Assert.fail(failure);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseFilesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseFilesTest.java
@@ -1,0 +1,197 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.Assert;
+
+import com.ibm.commons.runtime.Application;
+import com.ibm.commons.runtime.Context;
+import com.ibm.commons.runtime.RuntimeFactory;
+import com.ibm.commons.runtime.impl.app.RuntimeFactoryStandalone;
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.services.client.connections.files.FileService;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileCreationParameters;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+
+/** @author mwallace
+ * 
+ * @date 13 Mar 2013 */
+public class BaseFilesTest extends BaseApiTest {
+
+	protected FileService fileService;
+	protected FileEntry fileEntry;
+	protected FileEntry folder;
+	private boolean failIfAfterDeletionFails = true;
+
+	private final String[] ErrorMessages = { "Error received. Error Code", "Error, unable to load:",
+			"Caused by: com.ibm.sbt.services.client.ClientServicesException", "Exception occurred", "Caused by:", "HTTP Status 500", "HTTP Status 404" };
+	private String noErrorMsg = null;
+
+	public BaseFilesTest() {
+		super();
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+
+	protected boolean failIfAfterDeletionFails() {
+		return failIfAfterDeletionFails;
+	}
+
+	protected void setFailIfAfterDeletionFails(boolean failIfAfterDeletionFails) {
+		this.failIfAfterDeletionFails = failIfAfterDeletionFails;
+	}
+
+	protected FileService getFileService() {
+		try {
+			loginConnections();
+		} catch (AuthenticationException e) {
+			Assert.fail("Error logging in to Connections " + e.getMessage());
+			e.printStackTrace();
+			return null;
+		}
+		setFailIfAfterDeletionFails(true);
+
+		if (fileService == null) {
+			fileService = new FileService(getEndpointName());
+		}
+		return fileService;
+	}
+	
+	public void createFolder() {
+		setFailIfAfterDeletionFails(true);
+		fileService = getFileService();
+		try {
+			folder = fileService.createFolder("TestFolder");		
+			Trace.log("Created test folder: " + folder.getFileId());			
+		} catch (FileServiceException e) {
+			e.printStackTrace();
+			Assert.fail("Error creating test folder: " + e.getMessage());
+		}
+	}
+
+	public void createFile() {
+
+		try {
+			setFailIfAfterDeletionFails(true);
+			fileService = getFileService();
+			String content = "Content uploaded by Create Delete File java sample";
+			String id = "File" + System.currentTimeMillis() + ".txt";
+
+			
+			FileCreationParameters p = new FileCreationParameters();
+			p.visibility = FileCreationParameters.Visibility.PUBLIC;
+			p.tags = new ArrayList<String>();
+			p.tags.add("text");
+			Map<String, String> params = p.buildParameters();			
+			
+			fileEntry = fileService.upload(new ByteArrayInputStream(content.getBytes()), id, content.length(), params);
+
+			params = new HashMap<String, String>();
+			fileService.addCommentToFile(fileEntry, "Comment added by BaseFilesTest", params);
+
+			Trace.log("Created test file: " + fileEntry.getFileId());
+		} catch (FileServiceException fse) {
+			fileEntry = null;
+	        fse.printStackTrace();
+			Assert.fail("Error creating test file: " + fse.getMessage());
+		}
+	}
+
+	public void deleteFileAndQuit() {
+		if (fileEntry != null) {
+			try {
+				fileService.deleteFile(fileEntry.getFileId());
+			} catch (FileServiceException fse) {
+				fileEntry = null;
+				if (failIfAfterDeletionFails()) {
+					Assert.fail("Error deleting test file: " + fse.getMessage());
+					fse.printStackTrace();
+				}
+			}
+		}
+		if (folder != null) {
+			try {
+				fileService.deleteFolder(folder.getFileId());
+			} catch (FileServiceException fse) {
+				folder = null;
+				if (failIfAfterDeletionFails()) {
+					Assert.fail("Error deleting test folder: " + fse.getMessage());
+					fse.printStackTrace();
+				}
+			}
+		}
+
+	}
+
+	/** @return */
+	protected boolean checkNoError(String snippetId) {
+		String text = executeSnippet1(snippetId);
+		return containsNoError(text);
+	}
+
+	/** @param snippetId
+	 * @return */
+	protected String executeSnippet1(String snippetId) {
+		ResultPage resultPage = launchSnippet(snippetId, authType);
+		String text = resultPage.getText();
+
+		// dumpResultPage(resultPage);
+
+		if (text != null && text.startsWith("Show Snippet Code")) {
+			text = text.substring("Show Snippet Code".length());
+		}
+		return (text == null) ? null : text.trim();
+	}
+
+	/*
+	 * Return true if the result page contains no error message. */
+	protected boolean containsNoError(String result) {
+		boolean retVal = true;	
+		if (StringUtil.isEmpty(result)) {
+			noErrorMsg  = "Empty result was returned for: " + getSnippetId();
+			retVal = false;
+		} else {
+			for (int i = 0; i < ErrorMessages.length; i++) {
+				if (result.contains(ErrorMessages[i])) {
+					noErrorMsg = "Error message for: " + getSnippetId() + ": " + result;
+					retVal = false;
+				}
+			}
+		}
+		if (!retVal) {
+			Trace.log(noErrorMsg);
+		}
+		return retVal;
+	}
+	
+	/**
+     * @return the noErrorMsg
+     */
+    public String getNoErrorMsg() {
+        return noErrorMsg;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseForumsTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseForumsTest.java
@@ -1,0 +1,16 @@
+/**
+ * 
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+
+/**
+ * @author mwallace
+ *
+ */
+public class BaseForumsTest extends BaseApiTest {
+	
+	protected boolean createForum = true;
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseProfilesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseProfilesTest.java
@@ -1,0 +1,71 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import junit.framework.Assert;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.services.client.connections.profiles.Profile;
+import com.ibm.sbt.services.client.connections.profiles.ProfileService;
+import com.ibm.sbt.services.client.connections.profiles.ProfileServiceException;
+
+/**
+ * @author mwallace
+ * @author Vimal Dhupar
+ *  
+ * @date 19 Mar 2013
+ */
+public class BaseProfilesTest extends BaseApiTest {
+    
+    protected ProfileService profileService;
+
+    public BaseProfilesTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    public Profile getProfile(String userId) {
+        createContext();
+        
+        ProfileService profileService = getProfileService();
+        Profile profile = null;
+        try {
+            profile = profileService.getProfile(userId);
+        } catch (ProfileServiceException pse) {
+            Assert.fail("Error get profile: " + pse.getMessage());
+            pse.printStackTrace();
+        } 
+        return profile;
+    }
+    
+    protected ProfileService getProfileService() {
+        if (profileService == null) {
+            profileService = new ProfileService();
+        }
+        return profileService;
+    }
+
+    protected void validate(Profile profile, JsonJavaObject json) {
+        Assert.assertEquals(profile.getUserid(), json.getString("getUserid"));
+        Assert.assertEquals(profile.getDisplayName(), json.getString("getName"));
+        Assert.assertEquals(profile.getEmail(), json.getString("getEmail"));
+        Assert.assertEquals(profile.getThumbnailUrl(), json.getString("getThumbnailUrl"));
+        Assert.assertEquals(profile.getTitle(), json.getString("getJobTitle"));
+        Assert.assertEquals(StringUtil.isEmpty(profile.getDepartment()), StringUtil.isEmpty(json.getString("getDepartment")));
+        Assert.assertEquals(profile.getPhoneNumber(), json.getString("getTelephoneNumber"));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseSearchTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/connections/BaseSearchTest.java
@@ -1,0 +1,56 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.connections;
+
+import junit.framework.Assert;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+
+/**
+ * @author mwallace
+ *  
+ * @date 15 Jun 2013
+ */
+public class BaseSearchTest extends BaseApiTest {
+    
+    public BaseSearchTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    protected void assertResultValid(JsonJavaObject json, boolean hasScore) {
+    	assertResultValid(json, hasScore, false);
+    }
+    
+    protected void assertResultValid(JsonJavaObject json) {
+    	assertResultValid(json, false, false);
+    }
+    
+    protected void assertResultValid(JsonJavaObject json, boolean hasScore, boolean hasContent) {
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertNotNull(json.getString("getTitle"));
+        if (hasScore) {
+        	Assert.assertNotNull(json.getString("getScore"));
+        } else {
+            Assert.assertNotNull(json.getString("getRank"));
+        }
+        Assert.assertNotNull(json.getString("getUpdated"));
+        if (hasContent) {
+        	Assert.assertNotNull(json.getString("getContent"));
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeFlightsPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeFlightsPage.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+package com.ibm.sbt.automation.core.test.pageobjects.AcmeSample;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class AcmeFlightsPage {
+	
+	private AcmeResultPage flightsPage;
+	
+	//elements on the page
+	private WebElement flightsTable;
+	private WebElement bookFlightButton;
+	
+	//xpath/ids to get the elements
+	private final String flightTableId = "flightsTable";
+	private final String bookButtonXpath = "tbody/tr[3]/td[6]/button";            //the xPath for the book button for flight 103
+	
+	
+	public AcmeFlightsPage(AcmeResultPage resultPage){
+		
+		this.flightsPage = resultPage;
+		this.flightsTable = flightsPage.getWebElement().findElement(By.id(flightTableId));
+		
+		this.bookFlightButton = this.flightsTable.findElement(By.xpath(bookButtonXpath));
+	}
+
+	public void clickTheBookButton(){
+		bookFlightButton.click();
+	}
+	
+	public boolean isFlightsTableDisplayed(){
+		return flightsTable.isDisplayed();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeMyFlightPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeMyFlightPage.java
@@ -1,0 +1,60 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects.AcmeSample;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class AcmeMyFlightPage {
+	
+	private AcmeResultPage myFlightsPage;
+	
+	//page elements
+	private WebElement myFlightsTable;
+	
+	
+	//ids/xPath to retrieve elements
+	private final String myFlightsTableId = "myFlightsTable";
+	
+	public AcmeMyFlightPage(AcmeResultPage resultPage){
+		
+		this.myFlightsPage = resultPage;
+		
+		myFlightsTable = this.myFlightsPage.getWebElement().findElement(By.id(myFlightsTableId));
+	}
+	
+	public boolean checkFlight103IsBooked(){
+		
+		boolean flight103IsBooked = false;
+		
+		List<WebElement> flights = getMyFlights();
+		
+		for(int i=0;i<flights.size();i++){
+			if(flights.get(i).getText().contains("103")){
+				flight103IsBooked = true;
+			}
+		}
+
+		return flight103IsBooked;
+	}
+	
+	public List<WebElement> getMyFlights(){
+		List<WebElement> flights = myFlightsTable.findElements(By.tagName("tr"));
+		return flights;
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeNavigationPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeNavigationPage.java
@@ -1,0 +1,81 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects.AcmeSample;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class AcmeNavigationPage {
+	
+	//The Page
+	private AcmeResultPage navPage;
+	
+	//Navigation Links
+	private WebElement navBar;
+	private WebElement homePage;
+	private WebElement flightsPageLink;
+	private WebElement myFlightsPageLink;
+	private WebElement flightStatusPageLink;
+	private WebElement checkInAreaPageLink;
+	private WebElement servicesPageLink;
+	
+	
+	//Xpath/ids to find the 
+	private final String navBarId = "navBar";
+	private final String homeLink = "ul/li";
+	private final String flightsLink = "ul/li[2]";
+	private final String myFlightsLink = "ul/li[3]";
+	private final String flightStatusLink = "ul/li[4]";
+	private final String checkinLink = "ul/li[5]";
+	private final String servicesLink = "ul/li[6]";
+	
+	public AcmeNavigationPage(AcmeResultPage resultPage){
+		
+		this.navPage = resultPage;
+		
+		this.navBar = navPage.getWebElement().findElement(By.id(navBarId));
+		this.homePage = navBar.findElement(By.xpath(homeLink));
+		this.flightsPageLink = navBar.findElement(By.xpath(flightsLink));
+		this.myFlightsPageLink = navBar.findElement(By.xpath(myFlightsLink));
+		this.flightStatusPageLink = navBar.findElement(By.xpath(flightStatusLink));
+		this.checkInAreaPageLink = navBar.findElement(By.xpath(checkinLink));
+		this.servicesPageLink = navBar.findElement(By.xpath(servicesLink));
+	}
+	
+	public void goToHomePage(){
+		this.homePage.click();
+	}
+	
+	public void goToFlightsPage(){
+		this.flightsPageLink.click();
+	}
+	
+	public void goToMyFlightsPage(){
+		this.myFlightsPageLink.click();
+	}
+	
+	public void goToFlightStatusPage(){
+		this.flightStatusPageLink.click();
+	}
+	
+	public void goToCheckinPage(){
+		this.checkInAreaPageLink.click();
+	}
+	
+	public void goToServicesPage(){
+		this.servicesPageLink.click();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/AcmeSample/AcmeResultPage.java
@@ -1,0 +1,67 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects.AcmeSample;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author David Ryan
+ * 
+ * @date 27 Mar 2013
+ */
+public class AcmeResultPage extends BaseResultPage {
+
+    @FindBy(how = How.XPATH, using = "/html/body")
+    
+    private final String homePageMainContentId = "mainContainer";
+    
+    private WebElement content;
+    private ResultPage delegate;
+    
+    public AcmeResultPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+    
+    public WebElement getMainContent(){
+    	return getWebElement().findElement(By.id(homePageMainContentId));
+    }
+    
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getText()
+     */
+    @Override
+    public String getText() {
+        return content.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return delegate.getWebElement();
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/BaseResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/BaseResultPage.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.WebDriver;
+
+/**
+ * @author mwallace
+ *  
+ * @date 6 Mar 2013
+ */
+public abstract class BaseResultPage implements ResultPage {
+    
+    private WebDriver webDriver;
+    
+    /**
+     * @param webDriver the webDriver to set
+     */
+    public void setWebDriver(WebDriver webDriver) {
+        this.webDriver = webDriver;
+    }
+    
+    /**
+     * @return the webDriver
+     */
+    public WebDriver getWebDriver() {
+        return webDriver;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridPagerPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridPagerPage.java
@@ -1,0 +1,149 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class GridPagerPage {
+    
+    private GridResultPage gridPage;
+    private WebElement pagerDiv;
+    private WebElement pagerResultDiv;
+    
+    private int start;
+    private int end;
+    private int count;
+    
+    public String PagerXPath = "div/div[1]";
+    public String PagerResultXPath = "div[2]";
+   
+    public String PagerNextXPath = "ul/li[2]/a";
+    public String PagerPreviousXPath = "ul/li[1]/a";
+
+    public GridPagerPage(GridResultPage gridPage) {
+        this.gridPage = gridPage;
+        
+        pagerDiv = gridPage.getGridContainer().findElement(By.xpath(PagerXPath));        
+        pagerResultDiv = pagerDiv.findElement(By.xpath(PagerResultXPath));
+        
+        int[] results = parsePagerResult();
+        start = results[0];
+        end = results[1];
+        count = results[2];
+    }
+    
+    /**
+     * @return the start
+     */
+    public int getStart() {
+        return start;
+    }
+    
+    /**
+     * @return the end
+     */
+    public int getEnd() {
+        return end;
+    }
+    
+    /**
+     * @return the count
+     */
+    public int getCount() {
+        return count;
+    }
+
+    /**
+     * Return a WebElement for the pager div that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getPagerDiv() {
+        return pagerDiv;
+    }
+
+    /**
+     * Return a WebElement for the pager result div that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getPagerResultDiv() {
+        return pagerResultDiv;
+    }
+    
+    /**
+     * Return true if you should be able to page forward
+     * 
+     * @return
+     */
+    public boolean canPageNext() {
+        return (end < count);
+    }
+    
+    /**
+     * Return true if you should be able to page backward
+     * 
+     * @return
+     */
+    public boolean canPagePrevious() {
+        return (count > 0);
+    }
+    
+    /**
+     * Click the next anchor
+     */
+    public void nextPage() {
+        WebElement nextAnchor = pagerDiv.findElement(By.xpath(PagerNextXPath));
+        nextAnchor.click();
+    }
+    
+    /**
+     * Click the next anchor
+     */
+    public void previousPage(GridResultPage gridPage) {
+        pagerDiv = gridPage.getGridContainer().findElement(By.xpath(PagerXPath));
+        WebElement previousAnchor = pagerDiv.findElement(By.xpath(PagerPreviousXPath));
+        previousAnchor.click();
+
+    }
+    
+    // Internals
+    
+    /*
+     * This will be a string like this "0 - 5 of 29"
+     * 
+     * TODO need to handle localized versions of the pager results
+     */
+    private int[] parsePagerResult() {
+        String pagerResult = pagerResultDiv.getText();
+
+        String[] parts = StringUtil.splitString(pagerResult, ' ');
+        int[] results = new int[3];
+        results[0] = Integer.parseInt(parts[0]);
+        results[1] = Integer.parseInt(parts[2]);
+        results[2] = Integer.parseInt(parts[4]);
+        return results;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridResultPage.java
@@ -1,0 +1,115 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class GridResultPage extends BaseResultPage {
+    
+    private ResultPage delegate;
+    /* The div containing the grid on this page */
+    
+    //public String GridContainerCSS = "div[id^='sbt_controls_grid_Grid_']";
+    public String gridId = "gridDiv";
+   
+    public GridResultPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+    	return delegate.getWebElement();
+    }
+    
+    /**
+     * Return the WebElement for the grid container on this page
+     * @return the container
+     */
+    public WebElement getGridContainer() {
+    	//return getWebElement().findElement(By.cssSelector(GridContainerCSS));
+    	return delegate.getWebElement().findElement(By.id(gridId));
+    }
+    
+    /**
+     * Return the table WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getTable() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElement(By.tagName("table"));
+    }
+    
+    /**
+     * Return the tbody WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getTableBody() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElement(By.tagName("tbody"));
+    }
+    
+    /**
+     * Return a list of tr WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public List<WebElement> getTableRows() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElements(By.tagName("tr"));
+    }
+    
+    /**
+     * Return a WebElement for the pager div that was created on this page
+     * 
+     * @return
+     */
+    public GridPagerPage getGridPager() {
+        return new GridPagerPage(this);
+    }
+    
+    /**
+     * Return a WebElement for the sort div that was created on this page
+     * 
+     * @return
+     */
+    public GridSorterPage getSortingPager() {
+        return new GridSorterPage(this);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridSorterPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/GridSorterPage.java
@@ -1,0 +1,41 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.*/
+
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class GridSorterPage {
+	
+	private GridResultPage gridPage;
+    private WebElement sortingDiv;
+    private WebElement sortAnchor;
+    
+    public String sortingXPath = "div/div[2]";
+    public String sortAnchorXPath = "ul/li[2]/a";  
+    
+    public GridSorterPage(GridResultPage gridPage) {
+        this.gridPage = gridPage;
+        sortingDiv = gridPage.getGridContainer().findElement(By.xpath(sortingXPath));        
+        sortAnchor = sortingDiv.findElement(By.xpath(sortAnchorXPath));        
+    }
+    
+    
+    public void SortByFirstSortAnchor(){
+    	sortAnchor.click();
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/JavaScriptPreviewPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/JavaScriptPreviewPage.java
@@ -1,0 +1,96 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonException;
+import com.ibm.commons.util.io.json.JsonJavaFactory;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.commons.util.io.json.JsonParser;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class JavaScriptPreviewPage extends BaseResultPage {
+    
+    private ResultPage delegate;
+    
+    public JavaScriptPreviewPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return delegate.getWebElement();
+    }
+    
+    /**
+     * Return the contents of the content div
+     */
+    public String getContent() {
+        WebElement webElement = getWebElement();
+        return webElement.findElement(By.id("content")).getText();
+    }
+    
+    /**
+     * Return the contents of the json div as a JSON object
+     */
+    public JsonJavaObject getJson() {
+        WebElement webElement = getWebElement();
+        String text = webElement.findElement(By.id("json")).getText();
+        try {
+            return (JsonJavaObject)JsonParser.fromJson(JsonJavaFactory.instanceEx, text);
+        } catch (Throwable t) {
+        	Assert.fail("Unable to parse JSON Object from: " + text);
+            return null;
+        }
+    }
+
+    /**
+     * Return the contents of the json div as a list of JSON objects
+     */
+    public List getJsonList() {
+        WebElement webElement = getWebElement();
+        String text = webElement.findElement(By.id("json")).getText();
+        try {
+            return (List)JsonParser.fromJson(JsonJavaFactory.instanceEx, text);
+        } catch (Throwable t) {
+        	Assert.fail("Unable to parse JSON List from: " + text);
+            return null;
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/JavaScriptTesterPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/JavaScriptTesterPage.java
@@ -1,0 +1,98 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public class JavaScriptTesterPage extends BaseResultPage {
+    
+    private ResultPage delegate;
+    
+    public JavaScriptTesterPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return delegate.getWebElement();
+    }
+    
+    /**
+     * Return the contents of the result div
+     */
+    public String getResult() {
+        WebElement webElement = getWebElement();
+        return webElement.findElement(By.id("result")).getText();
+    }
+    
+    public boolean isPass() {
+        String result = getResult();
+        return result.startsWith("Pass");
+    }
+    
+    public boolean isFail() {
+        String result = getResult();
+        return result.startsWith("Fail");
+    }
+
+    public String getFailReason() {
+        String result = getResult();
+        if (result.startsWith("Fail: ")) {
+            return result.substring("Fail: ".length());
+        }
+        return null;
+    }
+
+    /**
+     * Return the contents of the result div
+     */
+    public String getTrace() {
+        WebElement webElement = getWebElement();
+        String text = webElement.findElement(By.id("trace")).getText();
+        return StringUtil.isEmpty(text) ? "Page contained no trace." : text;
+    }
+
+    /**
+     * Return the contents of the result div
+     */
+    public String getError() {
+        WebElement webElement = getWebElement();
+        String text = webElement.findElement(By.id("error")).getText();
+        return StringUtil.isEmpty(text) ? "Page contained no error." : text;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/ListResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/ListResultPage.java
@@ -1,0 +1,71 @@
+/**
+ * 
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * @author mwallace
+ *
+ */
+public class ListResultPage extends BaseResultPage {
+
+    private ResultPage delegate;
+    
+    public String gridId = "gridDiv";
+   
+    public ListResultPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+    	return delegate.getWebElement();
+    }
+    
+    /**
+     * Return the WebElement for the grid container on this page
+     * @return the container
+     */
+    public WebElement getGridContainer() {
+    	return delegate.getWebElement().findElement(By.id(gridId));
+    }
+    
+    /**
+     * Return the ul WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getList() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElement(By.tagName("ul"));
+    }
+    
+    /**
+     * Return a list of li WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public List<WebElement> getListItems() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElements(By.tagName("li"));
+    }
+    	
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/PanelResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/PanelResultPage.java
@@ -1,0 +1,74 @@
+/**
+ * 
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+
+/**
+ * @author mwallace
+ *
+ */
+public class PanelResultPage extends BaseResultPage {
+
+    private ResultPage delegate;
+    
+    public String gridId = "gridDiv";
+   
+    public PanelResultPage(ResultPage delegate) {
+        this.delegate = delegate;
+        
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+    	return delegate.getWebElement();
+    }
+    
+    /**
+     * Return the WebElement for the grid container on this page
+     * @return the container
+     */
+    public WebElement getGridContainer() {
+    	return delegate.getWebElement().findElement(By.id(gridId));
+    }
+    
+    /**
+     * Return the ul WebElement for the Grid that was created on this page
+     * 
+     * @return
+     */
+    public WebElement getPanel() {
+        WebElement resultEl = getWebElement();
+        return resultEl.findElement(By.tagName("ul"));
+    }
+    
+    public String getPhotoUrl() {
+    	WebElement resultEl = getWebElement();
+        WebElement img = resultEl.findElement(By.tagName("img"));
+        return (img == null) ? null : img.getAttribute("src");
+    }
+    
+    public String[] getDetails() {
+    	String text = getText();
+    	return StringUtil.splitString(text, '\n');
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/PlaygroundResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/PlaygroundResultPage.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ * @author mwallace 
+ * 
+ * @date 5 Mar 2013
+ */
+public class PlaygroundResultPage extends BaseResultPage {
+
+    @FindBy(how = How.XPATH, using = "/html/body")
+    private WebElement content;
+
+    
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getText()
+     */
+    @Override
+    public String getText() {
+        return content.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return content;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/ResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/ResultPage.java
@@ -1,0 +1,55 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+/**
+ * @author mwallace
+ *  
+ * @date 5 Mar 2013
+ */
+public interface ResultPage {
+
+    /**
+     * Return the page content as a string
+     * 
+     * @return
+     */
+    public String getText();
+    
+    /**
+     * Return the page content as a web element
+     * @return
+     */
+    public WebElement getWebElement();
+    
+    /**
+     * Return the web driver
+     * 
+     * @return
+     */
+    public WebDriver getWebDriver();
+
+    /**
+     * Set the web driver
+     * 
+     * @param webDriver
+     */
+    public void setWebDriver(WebDriver webDriver);
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/SampleFrameworkResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/SampleFrameworkResultPage.java
@@ -1,0 +1,246 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * @author Francis
+ * @date 24 May 2013
+ */
+public class SampleFrameworkResultPage extends BaseResultPage {
+
+    private ResultPage delegate;
+
+    /*
+     * ids
+     */
+    public static final String JSSNIPPETDIV = "jsContents";
+    public static final String JSPSNIPPETDIV = "jspContents";
+    public static final String HTMLSNIPPETDIV = "htmlContents";
+    public static final String CSSSNIPPETDIV = "cssContents";
+    public static final String DOCSNIPPETDIV = "docContents";
+    public static final String TREE = "tree";
+    public static final String EXPANDALL = "expandAll";
+    public static final String COLLAPSEALL = "collapseAll";
+    public static final String SNIPPETCONTAINER = "snippetContainer";
+    public static final String RUNBUTTON = "runButton";
+    public static final String DEBUGBUTTON = "debugButton";
+    public static final String SHOWHTMLBUTTON = "showHtmlButton";
+    public static final String SHOWHTMLPOPOUT = "showHtmlPopout";
+    public static final String PREVIEWFRAME = "previewFrame";
+    public static final String DEMOCONTAINER = "demoContainer";
+    public static final String SMARTCLOUDNAVBAR = "nav_bar_include";
+    /*
+     * classes
+     */
+    public static final String LEAFNODECLASS = "leafNode";
+    public static final String SNIPPETNAVBARCLASS = ".nav.nav-tabs";
+    public static final String MAINCONTENTCLASS = ".row-fluid";
+    
+    public SampleFrameworkResultPage(ResultPage delegate) {
+        this.delegate = delegate;
+        setWebDriver(delegate.getWebDriver());
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+     */
+    @Override
+    public String getText() {
+        return delegate.getText();
+    }
+
+    /*
+     * (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return delegate.getWebElement();
+    }
+
+    /**
+     * Return the html span WebElement which must be there for a card to appear.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getMainContent() {
+        return getWebElement().findElement(By.cssSelector(MAINCONTENTCLASS));
+    }
+
+    /**
+     * Return the tree of the sample framework page.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getTree() {
+        return getWebElement().findElement(By.id(TREE));
+    }
+    
+    /**
+     * Return the smartcloud navigation bar of the sample framework page.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getSmartcloudNavBar() {
+        return getWebElement().findElement(By.id(SMARTCLOUDNAVBAR));
+    }
+    
+    public WebElement getExpandAllButton(){
+        return getWebElement().findElement(By.id(EXPANDALL));
+    }
+    
+    public WebElement getCollpaseAllButton(){
+        return getWebElement().findElement(By.id(COLLAPSEALL));
+    }
+    
+    /**
+     * Return a leaf node. Useful for testing if a click on the leaf node works.
+     * @return
+     */
+    public WebElement getTreeLeaf() {
+        List<WebElement> leafNodes = getWebElement().findElements(By.className(LEAFNODECLASS));
+        if (leafNodes.size() == 0){
+            getExpandAllButton().click();
+            leafNodes = getWebElement().findElements(By.className(LEAFNODECLASS));
+        }
+        
+        return leafNodes.get(0);
+    }
+    
+    /**
+     * Return the div containing the code and documentation snippets.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getSnippetContainer() {
+        return getWebElement().findElement(By.id(SNIPPETCONTAINER));
+    }
+    
+    /**
+     * Return the div which contains the snippet of js code.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getJsSnippetDiv() {
+        return getWebElement().findElement(By.id(JSSNIPPETDIV));
+    }
+    
+    /**
+     * Return the div which contains the snippet of js code.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getJspSnippetDiv() {
+        return getWebElement().findElement(By.id(JSPSNIPPETDIV));
+    }
+    
+    /**
+     * Return the div which contains the snippet of html code.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getHtmlSnippetDiv() {
+        return getWebElement().findElement(By.id(HTMLSNIPPETDIV));
+    }
+    
+    /**
+     * Return the div which contains the snippet of css code.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getCssSnippetDiv() {
+        return getWebElement().findElement(By.id(CSSSNIPPETDIV));
+    }
+    
+    /**
+     * Return the div which contains the snippet of doc.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getDocSnippetDiv() {
+        return getWebElement().findElement(By.id(DOCSNIPPETDIV));
+    }
+    
+    /**
+     * Return the navbar which switches between code divs.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getCodeNav() {
+        return getWebElement().findElement(By.cssSelector(SNIPPETNAVBARCLASS));
+        
+    }
+
+    /**
+     * Return the div containing the run/debug/show html buttons and the demo iframe.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getDemoContainer() {
+        return getWebElement().findElement(By.id("DEMOCONTAINER"));
+    }
+
+    /**
+     * Return the run button.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getRunButton() {
+        return getWebElement().findElement(By.id(RUNBUTTON));
+    }
+
+    /**
+     * Return the debug button.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getDebugButton() {
+        return getWebElement().findElement(By.id(DEBUGBUTTON));
+    }
+
+    /**
+     * Return the show html button.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getShowHtmlButton() {
+        return getWebElement().findElement(By.id(SHOWHTMLBUTTON));
+    }
+
+    /**
+     * Return the iframe containing the snippet preview.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getPreviewFrame() {
+        return getWebElement().findElement(By.id(PREVIEWFRAME));
+    }
+    
+    /**
+     * Return the div which shows the generated html.
+     * 
+     * @return the WebElement
+     */
+    public WebElement getHtmlPopout() {
+        return getWebElement().findElement(By.id(SHOWHTMLPOPOUT));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/SbtWebResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/SbtWebResultPage.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ * @author mwallace 
+ * 
+ * @date 5 Mar 2013
+ */
+public class SbtWebResultPage extends BaseResultPage {
+
+    @FindBy(how = How.XPATH, using = "/html/body")
+    
+    private WebElement content;
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getText()
+     */
+    @Override
+    public String getText() {
+        return content.getText();
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.environment.pageobjects.ContentPage#getWebElement()
+     */
+    @Override
+    public WebElement getWebElement() {
+        return content;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/VCardResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/VCardResultPage.java
@@ -1,0 +1,129 @@
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+public class VCardResultPage extends BaseResultPage{
+	
+	private ResultPage delegate;
+	
+	public VCardResultPage(ResultPage delegate) {
+		this.delegate = delegate;
+        setWebDriver(delegate.getWebDriver());
+	}
+	
+	/* (non-Javadoc)
+	 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+	 */
+	@Override
+	public String getText() {
+		return delegate.getText();
+	}
+
+	/* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+	@Override
+	public WebElement getWebElement() {
+		return delegate.getWebElement();
+	}
+	
+	/**
+	 * Return the html span WebElement which must be there for a card to appear.
+	 * @return the WebElement
+	 */
+	public WebElement getVCardSpan() {
+		// We do a partial match here on the span id of the control. It corresponds across all vCard snippets.
+		return getWebElement().findElement(By.cssSelector("span[id^='uniqName_']"));
+	}
+	
+	/**
+	 * Check that the vCard container is displayed on the page
+	 * @return true if displayed
+	 */
+	public boolean isDisplayed() {
+		return getVCardSpan().isDisplayed();
+	}
+	/**
+	 * Get the html a WebElement which is clicked in the case of non-inline cards.
+	 * 
+	 * @return the WebElement
+	 */
+	public WebElement getCardAttachPoint(){
+		return getVCardSpan().findElement(By.xpath(".//a"));
+	}
+	
+	/**
+	 * Get the html div WebElement which contains the VCards when they are rendered. This does not work for inline profile cards, use getInlineProfileCardDiv instead.
+	 * 
+	 * @return the WebElement
+	 */
+	public WebElement getCardDiv(){
+		return getWebElement().findElement(By.id("cardDiv"));
+	}
+	
+	/**
+	 * Get the html ul representing the navigation options in the community card. 
+	 * 
+	 * @return the WebElement
+	 */
+	public WebElement waitForCommunityCardNav(){
+		WebDriverWait wait = new WebDriverWait(getWebDriver(), 5);
+		WebElement result = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("bizCardNav"))); // wait until the community card nav is available.
+		
+		return result;
+	}
+	
+	public List<WebElement> getCardDivs(){
+		return getWebElement().findElements(By.cssSelector("span[id^='uniqName_'] a"));
+	}
+	
+	/**
+	 * Returns the html div WebElement which contains the inline profile VCard.
+	 * 
+	 * @return the WebElement
+	 */
+	public WebElement getInlineProfileCardDiv(){
+		return getVCardSpan().findElement(By.xpath(".//span//div"));
+	}
+	
+	/**
+	 * Check multiple profile cards for displayability.
+	 * 
+	 * @param cardAttachPoints An array containing the attach points of each card
+	 * @return true if all cards could be displayed, false otherwise
+	 */
+	public boolean areProfileCardsDisplayable(List<WebElement> cardAttachPoints){
+		for(WebElement cardAttachPoint: cardAttachPoints){
+			if(!isProfileCardDisplayable(cardAttachPoint))
+				return false;
+		}
+		
+		return true;
+	}
+	
+	/**
+	 * This method hovers over the card's attach point and then clicks the hover menu which appears. This should bring up the VCard.
+	 * 
+	 * @return True if the ProfileCard appeared, false if not.
+	 */
+	public boolean isProfileCardDisplayable(WebElement cardAttachPoint){
+		WebDriver driver = getWebDriver();
+		
+		new Actions(driver).moveToElement(cardAttachPoint).perform(); // hover over the attachpoint to make the semtagmenu appear.
+		
+		WebDriverWait wait = new WebDriverWait(driver, 2);
+		WebElement semtagmenu = wait.until(ExpectedConditions.elementToBeClickable(By.id("semtagmenu"))); // wait until the hover menu is clickable.
+		
+		WebElement semTagHoverMenu = semtagmenu.findElement(By.xpath(".//a"));
+		new Actions(driver).click(semTagHoverMenu).perform(); // click the hovering menu
+		WebElement vCardDiv = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id("cardDiv")));
+		
+		return vCardDiv.isDisplayed();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/WrapperResultPage.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/pageobjects/WrapperResultPage.java
@@ -1,0 +1,79 @@
+package com.ibm.sbt.automation.core.test.pageobjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class WrapperResultPage extends BaseResultPage{
+	
+	private ResultPage delegate;
+	
+	public WrapperResultPage(ResultPage delegate) {
+		this.delegate = delegate;
+        setWebDriver(delegate.getWebDriver());
+	}
+	
+	/* (non-Javadoc)
+	 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+	 */
+	@Override
+	public String getText() {
+		return delegate.getText();
+	}
+
+	/* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement()
+     */
+	@Override
+	public WebElement getWebElement() {
+		return delegate.getWebElement();
+	}
+	
+	/**
+	 * Return the WebElement containing the ActivityStream's iframe on this page
+	 * @return the WebElement
+	 */
+	public WebElement getActivityStreamFrame() {
+		return getFrame(By.cssSelector("iframe[id^='uniqName_']"));
+	}
+	
+	public WebElement getFileGridFrame(){
+	    return getFrame(By.cssSelector("iframe[id^='uniqName_']"));
+	}
+	
+	public WebElement getProfileCardFrame(){
+	    return getFrame(By.cssSelector("iframe[id^='uniqName_']"));
+	}
+	
+	/**
+	 * Get the frame that this page wraps.
+	 * @param by
+	 * @return
+	 */
+	public WebElement getFrame(By by){
+	    return getWebElement().findElement(by);
+	}
+	
+	/**
+	 * Return the WebElement containing the ActivityStream on this page, switch to the iframe context first.
+	 * @return the WebElement
+	 */
+	public WebElement getActivityStream() {
+		return getWebElement().findElement(By.cssSelector("#activityStream"));
+	}
+	
+	/**
+	 * Return the ul WebElement containing the list of news items on the page, switch to the iframe context first.
+	 * @return
+	 */
+	public WebElement getNewsFeedNode() {
+		return getWebElement().findElement(By.cssSelector("[dojoattachpoint=\"newsFeedNode\"]"));
+	}
+	
+	/**
+	 * Check that the ActivityStream container is displayed on the page
+	 * @return true if displayed
+	 */
+	public boolean isDisplayed() {
+		return getActivityStream().isDisplayed();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/smartcloud/BaseProfilesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/test/smartcloud/BaseProfilesTest.java
@@ -1,0 +1,70 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.automation.core.test.smartcloud;
+
+import junit.framework.Assert;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.services.client.smartcloud.profiles.Profile;
+import com.ibm.sbt.services.client.smartcloud.profiles.ProfileService;
+import com.ibm.sbt.services.client.smartcloud.profiles.ProfileServiceException;
+
+/**
+ * @author mwallace
+ * @author Vimal Dhupar
+ *  
+ * @date 19 Mar 2013
+ */
+public class BaseProfilesTest extends BaseApiTest {
+    
+    protected ProfileService profileService;
+
+    public BaseProfilesTest() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    public Profile getProfile(String userId) {
+        createContext();
+        
+        ProfileService profileService = getProfileService();
+        Profile profile = null;
+        try {
+            profile = profileService.getProfile(userId);
+        } catch (ProfileServiceException pse) {
+            Assert.fail("Error get profile: " + pse.getMessage());
+            pse.printStackTrace();
+        } 
+        return profile;
+    }
+    
+    protected ProfileService getProfileService() {
+        if (profileService == null) {
+            profileService = new ProfileService("smartcloud");
+        }
+        return profileService;
+    }
+
+    protected void validate(Profile profile, JsonJavaObject json) {
+        Assert.assertEquals(profile.getId(), json.getString("getUserid"));
+        Assert.assertEquals(profile.getDisplayName(), json.getString("getName"));
+        Assert.assertEquals(profile.getEmail(), json.getString("getEmail"));
+        Assert.assertEquals(profile.getThumbnailUrl(), json.getString("getThumbnailUrl"));
+        Assert.assertEquals(profile.getTitle(), json.getString("getJobTitle"));
+        Assert.assertEquals(profile.getDepartment(), json.getString("getDepartment"));
+        Assert.assertEquals(profile.getPhoneNumber(), json.getString("getTelephoneNumber"));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/utils/Trace.java
+++ b/test/selenium/com.ibm.sbt.automation.core/src/com/ibm/sbt/automation/core/utils/Trace.java
@@ -1,0 +1,35 @@
+package com.ibm.sbt.automation.core.utils;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author mkataria
+ * @date Feb 6, 2013
+ */
+public class Trace {
+
+	public static void log(String msg) {
+		TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+		if (environment != null && "true".equalsIgnoreCase(environment.getProperty(TestEnvironment.PROP_ENABLED_TRACE))) {
+			System.out.println(msg);
+		}
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/.classpath
+++ b/test/selenium/com.ibm.sbt.automation.test/.classpath
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="test">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/test/selenium/com.ibm.sbt.automation.test/.jazzignore
+++ b/test/selenium/com.ibm.sbt.automation.test/.jazzignore
@@ -1,0 +1,24 @@
+### Jazz Ignore 0
+# Default value for core.ignore.recursive is *.class
+#  Changing this value changes check-in behaviour for the entire project. 
+#
+# Default value for core.ignore is bin
+#  Changing this value changes check-in behaviour for the local directory.
+#
+# Ignored files and folders will not be committed, but may be modified during
+# accept or update.
+# Ignore properties should contain a space separated list of filename patterns.
+# Each pattern is case sensitive and surrounded by braces ('{' and '}'). 
+# "*" matches zero or more characters, and "?" matches single characters. 
+#
+#   e.g: {*.sh} {\.*}    ignores shell scripts and hidden files
+
+# NOTE: modifying ignore files will not change the ignore status of derived 
+# resources.
+
+core.ignore.recursive= \
+	{*.class} 
+
+core.ignore= \
+	{.project} \
+	{bin} 

--- a/test/selenium/com.ibm.sbt.automation.test/.project
+++ b/test/selenium/com.ibm.sbt.automation.test/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.ibm.sbt.automation.test</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/test/selenium/com.ibm.sbt.automation.test/pom.xml
+++ b/test/selenium/com.ibm.sbt.automation.test/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>com.ibm.sbt.automation.test</artifactId>
+
+  <parent>
+    <groupId>com.ibm.sbt.test</groupId>
+    <artifactId>test.parent</artifactId>
+    <version>1.0.0</version>
+    <relativePath>../../../build/test</relativePath>
+  </parent>
+  
+  <dependencies>
+    <dependency>
+    <groupId>org.seleniumhq.selenium</groupId>
+    <artifactId>selenium-java</artifactId>
+    <version>2.32.0</version>
+  </dependency>
+  <!-- Change to version 10.5.3.0 --> 
+        <dependency>
+        <groupId>com.ibm.sbt.sdk</groupId>
+        <artifactId>com.ibm.commons</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>com.ibm.sbt.sdk</groupId>
+        <artifactId>com.ibm.commons.xml</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>com.ibm.sbt.sdk</groupId>
+        <artifactId>com.ibm.commons.runtime</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+        <groupId>com.ibm.sbt.sdk</groupId>
+        <artifactId>com.ibm.sbt.core</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ibm.sbt.test</groupId>
+      <artifactId>com.ibm.sbt.automation.core</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/test/selenium/com.ibm.sbt.automation.test/src/META-INF/managed-beans.xml
+++ b/test/selenium/com.ibm.sbt.automation.test/src/META-INF/managed-beans.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<faces-config>
+	<!-- Credential store physical implementation -->
+	<managed-bean>
+		<managed-bean-name>CredStore</managed-bean-name>
+		<managed-bean-class>com.ibm.sbt.security.credential.store.MemoryStore</managed-bean-class>
+		<managed-bean-scope>application</managed-bean-scope>
+	</managed-bean>
+
+	<!-- Default Environment -->
+	<managed-bean>
+		<managed-bean-name>defaultEnvironment</managed-bean-name>
+		<managed-bean-class>com.ibm.sbt.jslibrary.SBTEnvironment</managed-bean-class>
+		<managed-bean-scope>application</managed-bean-scope>
+		<managed-property>
+			<property-name>endpoints</property-name>
+			<value>connections</value>
+		</managed-property>
+		<managed-property>
+			<property-name>properties</property-name>
+			<value></value>
+		</managed-property>
+	</managed-bean>
+	
+	<!-- Connections -->
+	<managed-bean>
+		<managed-bean-name>connections</managed-bean-name>
+		<managed-bean-class>com.ibm.sbt.services.endpoints.ConnectionsBasicEndpoint</managed-bean-class>
+		<managed-bean-scope>session</managed-bean-scope>
+		<managed-property>
+			<property-name>url</property-name>
+			<value>https://qs.renovations.com:444/</value>
+		</managed-property>
+		<managed-property>
+			<property-name>apiVersion</property-name>
+			<value>4.0</value>
+		</managed-property>
+		<managed-property>
+			<property-name>forceTrustSSLCertificate</property-name>
+			<value>true</value>
+		</managed-property>
+	</managed-bean>
+	
+	<!-- SmartCloud Connections -->
+	<managed-bean>
+		<managed-bean-name>smartcloud</managed-bean-name>
+		<managed-bean-class>com.ibm.sbt.services.endpoints.SmartCloudBasicEndpoint</managed-bean-class>
+		<managed-bean-scope>session</managed-bean-scope>
+		<managed-property>
+			<property-name>url</property-name>
+			<value>https://apps.na.collabserv.com</value>
+		</managed-property>
+		<managed-property>
+			<property-name>apiVersion</property-name>
+			<value>3.0</value>
+		</managed-property>
+		<managed-property>
+			<property-name>forceTrustSSLCertificate</property-name>
+			<value>true</value>
+		</managed-property>
+	</managed-bean>	
+</faces-config>

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/AllTests.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/AllTests.java
@@ -1,0 +1,17 @@
+package com.ibm.sbt;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.test.AcmeTestSuite;
+import com.ibm.sbt.test.js.SmartCloudTestSuite;
+
+/**
+ * @author Lorenzo Boccaccia 
+ * @date May 31, 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CheckinTestSuite.class, SbtTestSuite.class, SbtxTestSuite.class, AcmeTestSuite.class, SmartCloudTestSuite.class })
+public class AllTests {
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/CheckinTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/CheckinTestSuite.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+    com.ibm.sbt.test.java.connections.CommunitiesTestSuite.class,
+    com.ibm.sbt.test.js.smartcloud.ProfilesTestSuite.class })
+public class CheckinTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/SbtTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/SbtTestSuite.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.ControlsTestSuite;
+import com.ibm.sbt.test.JavaScriptTestSuite;
+import com.ibm.sbt.test.JavaTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ JavaScriptTestSuite.class, JavaTestSuite.class, ControlsTestSuite.class })
+public class SbtTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/SbtxTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/SbtxTestSuite.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.BaseTestSuite;
+import com.ibm.sbt.test.js.ConnectionsTestSuite;
+import com.ibm.sbt.test.js.SmartCloudTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ })
+public class SbtxTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/AcmeTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/AcmeTestSuite.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.samples.acme.TestAcmeSampleApp;
+
+/**
+ * @author David Ryan
+ * 
+ * @date 30 May 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ TestAcmeSampleApp.class })
+public class AcmeTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/ControlsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/ControlsTestSuite.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.controls.ActivityStreamTestSuite;
+import com.ibm.sbt.test.controls.CommunitiesGridTestSuite;
+import com.ibm.sbt.test.controls.FilesGridTestSuite;
+import com.ibm.sbt.test.controls.GridTestSuite;
+import com.ibm.sbt.test.controls.ProfilesGridTestSuite;
+import com.ibm.sbt.test.controls.VCardTestSuite;
+import com.ibm.sbt.test.controls.WrapperTestSuite;
+import com.ibm.sbt.test.controls.grid.profiles.MyProfilePanel;
+import com.ibm.sbt.test.controls.grid.profiles.ProfilePanel;
+import com.ibm.sbt.test.controls.grid.profiles.ProfileTags;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GridTestSuite.class, CommunitiesGridTestSuite.class,
+		FilesGridTestSuite.class, ProfilesGridTestSuite.class,
+		VCardTestSuite.class, ActivityStreamTestSuite.class,
+		WrapperTestSuite.class })
+public class ControlsTestSuite {
+	@AfterClass
+	public static void cleanup() {
+		TestEnvironment.cleanup();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/GridsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/GridsTestSuite.java
@@ -1,0 +1,44 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.controls.CommunitiesGridTestSuite;
+import com.ibm.sbt.test.controls.FilesGridTestSuite;
+import com.ibm.sbt.test.controls.ForumGridTestSuite;
+import com.ibm.sbt.test.controls.GridTestSuite;
+import com.ibm.sbt.test.controls.MySocialGridTestSuite;
+import com.ibm.sbt.test.controls.ProfilesGridTestSuite;
+
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GridTestSuite.class, CommunitiesGridTestSuite.class, FilesGridTestSuite.class, ForumGridTestSuite.class, ProfilesGridTestSuite.class, MySocialGridTestSuite.class})
+public class GridsTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/JavaScriptTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/JavaScriptTestSuite.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.AuthenticationTestSuite;
+import com.ibm.sbt.test.js.BaseTestSuite;
+import com.ibm.sbt.test.js.ConnectionsTestSuite;
+import com.ibm.sbt.test.js.ConnectionsTestSuite;
+import com.ibm.sbt.test.js.SmartCloudTestSuite;
+import com.ibm.sbt.test.js.SmartCloudTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ AuthenticationTestSuite.class, BaseTestSuite.class, ConnectionsTestSuite.class })
+public class JavaScriptTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/JavaTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/JavaTestSuite.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.AuthenticationTestSuite;
+import com.ibm.sbt.test.java.ConnectionsTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ AuthenticationTestSuite.class, ConnectionsTestSuite.class })
+public class JavaTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/MarksTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/MarksTestSuite.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunityJson;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunityTags;
+import com.ibm.sbt.test.js.connections.files.api.AddCommentToFile;
+import com.ibm.sbt.test.js.connections.profiles.api.GetProfile;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ UpdateCommunityTags.class, GetProfile.class, AddCommentToFile.class })
+public class MarksTestSuite {
+    @BeforeClass
+    public static void init() {
+    	//System.setProperty(TestEnvironment.PROP_JAVASCRIPT_LIB, "jquery180");
+        //TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        //environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+    	//TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        //environment.disableSmartCloud();
+        //TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/RefactorTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/RefactorTestSuite.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.BaseTestSuite;
+import com.ibm.sbt.test.js.connections.CommunitiesTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ BaseTestSuite.class, CommunitiesTestSuite.class })
+public class RefactorTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ActivityStreamTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ActivityStreamTestSuite.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.test.controls.activitystream.AdvancedConfig;
+import com.ibm.sbt.test.controls.activitystream.CommunityRecentUpdates;
+import com.ibm.sbt.test.controls.activitystream.CommunityStatusUpdates;
+import com.ibm.sbt.test.controls.activitystream.MultipleViews;
+import com.ibm.sbt.test.controls.activitystream.SimpleConfig;
+import com.ibm.sbt.test.controls.activitystream.SimpleStream;
+import com.ibm.sbt.test.controls.activitystream.SimpleStreamAllExtensions;
+
+/**
+ * @author Francis
+ * 
+ * @date 15 Apr 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ AdvancedConfig.class, CommunityRecentUpdates.class, CommunityStatusUpdates.class, MultipleViews.class, SimpleConfig.class, SimpleStream.class, SimpleStreamAllExtensions.class})
+public class ActivityStreamTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/CommunitiesGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/CommunitiesGridTestSuite.java
@@ -1,0 +1,54 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.test.BaseGridTestSetup;
+import com.ibm.sbt.test.controls.grid.communities.BootstrapCommunitiesGrid;
+import com.ibm.sbt.test.controls.grid.communities.CommunityActionGrid;
+import com.ibm.sbt.test.controls.grid.communities.CustomTemplateCommunity;
+import com.ibm.sbt.test.controls.grid.communities.MyCommunitiesGrid;
+import com.ibm.sbt.test.controls.grid.communities.OneClickToJoin;
+import com.ibm.sbt.test.controls.grid.communities.PublicCommunitiesDijit;
+import com.ibm.sbt.test.controls.grid.communities.PublicCommunitiesGrid;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ BootstrapCommunitiesGrid.class, CommunityActionGrid.class, CustomTemplateCommunity.class, MyCommunitiesGrid.class,OneClickToJoin.class, PublicCommunitiesDijit.class,
+        PublicCommunitiesGrid.class })
+public class CommunitiesGridTestSuite {
+	private static BaseGridTestSetup setup ;
+	 
+	@BeforeClass
+	public static void setup(){
+		setup = new BaseGridTestSetup();
+		setup.createCommunity("TestCommunity", "public", "content", "TestTag, tag2", false);
+	}
+	
+	@AfterClass
+    public static void cleanup() {
+		setup.deleteCommunity();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/FilesGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/FilesGridTestSuite.java
@@ -1,0 +1,58 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.test.BaseGridTestSetup;
+import com.ibm.sbt.test.controls.grid.files.FileAction;
+import com.ibm.sbt.test.controls.grid.files.FileComments;
+import com.ibm.sbt.test.controls.grid.files.FileShares;
+import com.ibm.sbt.test.controls.grid.files.MyActiveFolders;
+import com.ibm.sbt.test.controls.grid.files.MyFiles;
+import com.ibm.sbt.test.controls.grid.files.MyFilesDijit;
+import com.ibm.sbt.test.controls.grid.files.MyFolders;
+import com.ibm.sbt.test.controls.grid.files.PinnedFiles;
+import com.ibm.sbt.test.controls.grid.files.PinnedFolders;
+import com.ibm.sbt.test.controls.grid.files.PublicFiles;
+import com.ibm.sbt.test.controls.grid.files.PublicFolders;
+import com.ibm.sbt.test.controls.grid.files.RecycledFiles;
+
+@RunWith(Suite.class)
+@SuiteClasses({ FileAction.class, FileComments.class, FileShares.class, MyActiveFolders.class, MyFiles.class, MyFilesDijit.class, PinnedFiles.class,
+        PinnedFolders.class, PublicFiles.class, PublicFolders.class, RecycledFiles.class, MyFolders.class })
+public class FilesGridTestSuite {
+    
+	private static BaseGridTestSetup setup ;
+	 
+	@BeforeClass
+	public static void setup(){
+		setup = new BaseGridTestSetup();
+		setup.createFolder();
+		setup.createFile();
+	}
+	
+	@AfterClass
+    public static void cleanup() {
+		
+    	setup.deleteFileAndQuit();
+    	setup.emptyTrash();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ForumGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ForumGridTestSuite.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.test.BaseGridTestSetup;
+import com.ibm.sbt.test.controls.grid.forum.MyForums;
+import com.ibm.sbt.test.controls.grid.forum.PublicForums;
+
+/**
+ * @author David Ryan	
+ * 
+ * @date 20 August 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ PublicForums.class, MyForums.class })
+public class ForumGridTestSuite {
+	private static BaseGridTestSetup setup ;
+	 
+	@BeforeClass
+	public static void setup(){
+		setup = new BaseGridTestSetup();
+		setup.createCommunity("TestCommunity", "public", "content", "TestTag, tag2", false);
+	}
+	
+	@AfterClass
+    public static void cleanup() {
+		setup.deleteCommunity();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/GridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/GridTestSuite.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.test.BaseGridTestSetup;
+import com.ibm.sbt.test.controls.grid.CommunityRenderer;
+import com.ibm.sbt.test.controls.grid.ConnectionsRenderer;
+import com.ibm.sbt.test.controls.grid.Grid;
+import com.ibm.sbt.test.controls.grid.TemplatedGridRow;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CommunityRenderer.class, ConnectionsRenderer.class, Grid.class, TemplatedGridRow.class })
+public class GridTestSuite {
+	private static BaseGridTestSetup setup ;
+	 
+	@BeforeClass
+	public static void setup(){
+		setup = new BaseGridTestSetup();
+		setup.createCommunity("TestCommunity", "public", "content", "TestTag, tag2", false);
+	}
+	
+	@AfterClass
+    public static void cleanup() {
+		setup.deleteCommunity();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/MySocialGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/MySocialGridTestSuite.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.sample.app.mySocial.MyColleagues;
+import com.ibm.sbt.test.sample.app.mySocial.MyCommunities;
+import com.ibm.sbt.test.sample.app.mySocial.MyFiles;
+
+/**
+ * @author David Ryan
+ * 
+ * @date 19 June 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ MyFiles.class, MyColleagues.class, MyCommunities.class })
+public class MySocialGridTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ProfilesGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/ProfilesGridTestSuite.java
@@ -1,0 +1,48 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.controls.grid.profiles.Colleagues;
+import com.ibm.sbt.test.controls.grid.profiles.MyColleagues;
+import com.ibm.sbt.test.controls.grid.profiles.MyProfilePanel;
+import com.ibm.sbt.test.controls.grid.profiles.ProfileAction;
+import com.ibm.sbt.test.controls.grid.profiles.ProfilePanel;
+import com.ibm.sbt.test.controls.grid.profiles.ProfileTagSearch;
+import com.ibm.sbt.test.controls.grid.profiles.ProfileTags;
+import com.ibm.sbt.test.controls.grid.profiles.ReportingChain;
+import com.ibm.sbt.test.controls.grid.profiles.ProfileSearch;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+// TODO ConnectionsInCommon, DirectReports. Getting 'Empty' on local environment
+
+@RunWith(Suite.class)
+@SuiteClasses({ Colleagues.class, MyColleagues.class,
+	ProfileAction.class, ReportingChain.class, ProfileTags.class,
+	ProfilePanel.class, MyProfilePanel.class, ProfileSearch.class,
+	ProfileTagSearch.class })
+public class ProfilesGridTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/SearchGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/SearchGridTestSuite.java
@@ -1,0 +1,55 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.controls.grid.search.SearchActivitiesPublic;
+import com.ibm.sbt.test.controls.grid.search.SearchAll;
+import com.ibm.sbt.test.controls.grid.search.SearchBlogsPublic;
+import com.ibm.sbt.test.controls.grid.search.SearchBookmarks;
+import com.ibm.sbt.test.controls.grid.search.SearchCommunitiesPublic;
+import com.ibm.sbt.test.controls.grid.search.SearchFiles;
+import com.ibm.sbt.test.controls.grid.search.SearchForums;
+import com.ibm.sbt.test.controls.grid.search.SearchProfilesPublic;
+import com.ibm.sbt.test.controls.grid.search.SearchStatusUpdates;
+import com.ibm.sbt.test.controls.grid.search.SearchWikis;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ SearchActivitiesPublic.class,
+	SearchAll.class, SearchBlogsPublic.class, SearchBookmarks.class,
+	SearchCommunitiesPublic.class, SearchFiles.class,
+	SearchForums.class, SearchProfilesPublic.class,
+	SearchStatusUpdates.class, SearchWikis.class })
+public class SearchGridTestSuite {
+	 
+	@BeforeClass
+	public static void setup(){
+	}
+	
+	@AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/VCardTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/VCardTestSuite.java
@@ -1,0 +1,26 @@
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.controls.vcard.CommunityVCard;
+import com.ibm.sbt.test.controls.vcard.ProfileVCard;
+import com.ibm.sbt.test.controls.vcard.ProfileVCardEmail;
+import com.ibm.sbt.test.controls.vcard.ProfileVCardInline;
+import com.ibm.sbt.test.controls.vcard.ProfileVCards;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ * 
+ * Need to further extend classes to test more than just a controls existence.
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CommunityVCard.class, ProfileVCard.class, ProfileVCardEmail.class, ProfileVCardInline.class, ProfileVCards.class })
+public class VCardTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/WrapperTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/WrapperTestSuite.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.controls;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.test.controls.wrappers.FileGridWrapper;
+import com.ibm.sbt.test.controls.wrappers.ProfileCardWrapper;
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 16 Jul 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ FileGridWrapper.class, ProfileCardWrapper.class})
+public class WrapperTestSuite {
+
+    @AfterClass
+    public static void cleanup() {
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/AdvancedConfig.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/AdvancedConfig.java
@@ -1,0 +1,32 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class AdvancedConfig extends BaseActivityStreamTest {
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_AdvancedConfig"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/CommunityRecentUpdates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/CommunityRecentUpdates.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class CommunityRecentUpdates extends BaseActivityStreamTest {
+	
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_CommunityRecentUpdates"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/CommunityStatusUpdates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/CommunityStatusUpdates.java
@@ -1,0 +1,32 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class CommunityStatusUpdates extends BaseActivityStreamTest {
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_CommunityStatusUpdates"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/MultipleViews.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/MultipleViews.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class MultipleViews extends BaseActivityStreamTest {
+	
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_MultipleViews"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleConfig.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleConfig.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class SimpleConfig extends BaseActivityStreamTest {
+	
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_SimpleConfig"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleStream.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleStream.java
@@ -1,0 +1,32 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class SimpleStream extends BaseActivityStreamTest {
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_SimpleStream"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleStreamAllExtensions.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/SimpleStreamAllExtensions.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class SimpleStreamAllExtensions extends BaseActivityStreamTest {
+	
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_SimpleStreamAllExtensions"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/UpdateswithTag.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/activitystream/UpdateswithTag.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.activitystream;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseActivityStreamTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 26 Mar 2013
+ */
+public class UpdateswithTag extends BaseActivityStreamTest {
+	
+	@Test
+	public void testActivityStream() {
+		assertTrue("Expected the ActivityStream to generate a news node", checkActivityStream("Social_ActivityStreams_Controls_UpdatesWithTag"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/CommunityRenderer.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/CommunityRenderer.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class CommunityRenderer extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Toolkit_Controls_Grid_CommunityRenderer", true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/ConnectionsRenderer.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/ConnectionsRenderer.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ConnectionsRenderer extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Toolkit_Controls_Grid_ConnectionsRenderer", true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/Grid.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/Grid.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class Grid extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Toolkit_Controls_Grid_Grid"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/TemplatedGridRow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/TemplatedGridRow.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class TemplatedGridRow extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Toolkit_Controls_Grid_TemplatedGridRow"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/AddMembersToCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/AddMembersToCommunities.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class AddMembersToCommunities extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_AddMembersToCommunities"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/BootstrapCommunitiesGrid.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/BootstrapCommunitiesGrid.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class BootstrapCommunitiesGrid extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_BootstrapCommunitiesGrid"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/CommunityActionGrid.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/CommunityActionGrid.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class CommunityActionGrid extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_CommunityActionGrid",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/CustomTemplateCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/CustomTemplateCommunity.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class CustomTemplateCommunity extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_CustomTemplateCommunity",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/MyCommunitiesGrid.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/MyCommunitiesGrid.java
@@ -1,0 +1,37 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MyCommunitiesGrid extends BaseGridTest {
+
+    @Test @Ignore
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_MyCommunitiesGrid",true,true));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/OneClickToJoin.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/OneClickToJoin.java
@@ -1,0 +1,39 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * 
+ * @date May 2013
+ */
+public class OneClickToJoin extends BaseGridTest {
+
+	
+	
+    @Test 
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_OneClickToJoin"));
+        
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/PublicCommunitiesDijit.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/PublicCommunitiesDijit.java
@@ -1,0 +1,43 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class PublicCommunitiesDijit extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_PublicCommunitiesDijit"));
+    }
+    
+    @Override
+    protected boolean isEnvironmentValid() {
+    	if (!environment.isLibrary("dojo")) return false;
+    	if (!environment.isLibraryVersionGreatherThan("160")) return false;
+    	return super.isEnvironmentValid();
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/PublicCommunitiesGrid.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/communities/PublicCommunitiesGrid.java
@@ -1,0 +1,36 @@
+/*
+ * � Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class PublicCommunitiesGrid extends BaseGridTest {
+
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Communities_Controls_PublicCommunitiesGrid",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileAction.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileAction.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class FileAction extends BaseGridTest {
+
+    @Test
+    public void fileActionTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_FileAction",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileComments.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileComments.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class FileComments extends BaseGridTest {
+
+    @Test
+    public void fileCommentsTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_FileComments",true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileShares.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/FileShares.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class FileShares extends BaseGridTest {
+
+    @Test
+    public void fileSharesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_FileShares",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyActiveFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyActiveFolders.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class MyActiveFolders extends BaseGridTest {
+
+    @Test
+    public void myActiveFoldersTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_MyActiveFolders",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFiles.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class MyFiles extends BaseGridTest {
+
+    @Test
+    public void myFilesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_MyFiles",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFilesBootstrap.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFilesBootstrap.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 19 June 2013
+ */
+public class MyFilesBootstrap extends BaseGridTest {
+
+    @Test
+    public void myFilesBootstrapTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_My_Files_Bootstrap"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFilesDijit.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFilesDijit.java
@@ -1,0 +1,42 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class MyFilesDijit extends BaseGridTest {
+
+    @Test
+    public void myFilesDijitTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_MyFilesDijit"));
+    }
+
+    @Override
+    protected boolean isEnvironmentValid() {
+    	if (!environment.isLibrary("dojo")) return false;
+    	if (!environment.isLibraryVersionGreatherThan("160")) return false;
+    	return super.isEnvironmentValid();
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/MyFolders.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class MyFolders extends BaseGridTest {
+
+    @Test
+    public void MyFoldersTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_MyFolders",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PinnedFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PinnedFiles.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class PinnedFiles extends BaseGridTest {
+
+    @Test
+    public void pinnedFilesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_PinnedFiles",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PinnedFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PinnedFolders.java
@@ -1,0 +1,35 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class PinnedFolders extends BaseGridTest {
+
+    @Test
+    public void pinnedFoldersTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_PinnedFolders"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PublicFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PublicFiles.java
@@ -1,0 +1,33 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class PublicFiles extends BaseGridTest {
+
+    @Test
+    public void publicFilesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_PublicFiles",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PublicFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/PublicFolders.java
@@ -1,0 +1,33 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class PublicFolders extends BaseGridTest {
+
+    @Test
+    public void publicFoldersTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_PublicFolders",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/RecycledFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/files/RecycledFiles.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 7 Mar 2013
+ */
+public class RecycledFiles extends BaseGridTest {
+
+    @Test
+    public void recycledFilesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Files_Controls_RecycledFiles",true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/forum/MyForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/forum/MyForums.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.forum;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 20 August 2013
+ */
+public class MyForums extends BaseGridTest {
+
+    @Test
+    public void myForumsTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Forums_Controls_MyForums",false,false));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/forum/PublicForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/forum/PublicForums.java
@@ -1,0 +1,35 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.forum;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 20 August 2013
+ */
+public class PublicForums extends BaseGridTest {
+
+    @Test
+    public void publicForumsTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Forums_Controls_PublicForums",false,false));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/Colleagues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/Colleagues.java
@@ -1,0 +1,39 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class Colleagues extends BaseGridTest {
+	
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void colleaguesGridTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_Colleagues",true,true));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/MyColleagues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/MyColleagues.java
@@ -1,0 +1,40 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 19 June 2013
+ */
+public class MyColleagues extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return  super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void myColleaguesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_My_Colleagues"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/MyProfilePanel.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/MyProfilePanel.java
@@ -1,0 +1,97 @@
+/**
+ * 
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.PanelResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mwallace
+ *
+ */
+public class MyProfilePanel extends BaseTest {
+
+	/**
+	 * Constructor
+	 */
+	public MyProfilePanel() {
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+	
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isLibrary("jquery") && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testProfilePanel() {
+        assertTrue("Expected the test to generate a grid", checkPanel("Social_Profiles_Controls_MyProfilePanel"));
+    }																
+
+    /**
+     * Check the panel
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected boolean checkPanel(String snippetId) {
+    	PanelResultPage resultPage = launchPanel(snippetId);
+        
+        return checkPanel(resultPage, snippetId);
+    }
+    
+    /**
+     * Launch the list snippet and return a PanelResultPage
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected PanelResultPage launchPanel(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return new PanelResultPage(resultPage);
+    }
+    
+    /**
+     * Return true if a Panel was created on the page i.e. could find ul, multiple li's
+     * @return
+     */
+    protected boolean checkPanel(PanelResultPage resultPage, String snippetId) {
+       Trace.log("Panel result page: " + resultPage.getText());
+       
+       String photoUrl = resultPage.getPhotoUrl();
+       Assert.assertFalse("Invalid photo url", StringUtil.isEmpty(photoUrl));
+       
+       String[] details = resultPage.getDetails();
+       Assert.assertFalse("Invalid details", details == null || details.length == 0);
+       Assert.assertEquals("Invalid details", 4, details.length);
+       
+       return true;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+    	return getProperty("sample.displayName1");
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+    	return "linkText";
+    }
+    	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileAction.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileAction.java
@@ -1,0 +1,41 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class ProfileAction extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return  super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void profileActionTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_ProfileAction"));
+    }
+
+}
+

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfilePanel.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfilePanel.java
@@ -1,0 +1,90 @@
+/**
+ * 
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.PanelResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mwallace
+ *
+ */
+public class ProfilePanel extends BaseTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isLibrary("jquery") && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testProfilePanel() {
+        assertTrue("Expected the test to generate a grid", checkPanel("Social_Profiles_Controls_ProfilePanel"));
+    }																
+
+    /**
+     * Check the panel
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected boolean checkPanel(String snippetId) {
+    	PanelResultPage resultPage = launchPanel(snippetId);
+        
+        return checkPanel(resultPage, snippetId);
+    }
+    
+    /**
+     * Launch the list snippet and return a PanelResultPage
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected PanelResultPage launchPanel(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return new PanelResultPage(resultPage);
+    }
+    
+    /**
+     * Return true if a Panel was created on the page i.e. could find ul, multiple li's
+     * @return
+     */
+    protected boolean checkPanel(PanelResultPage resultPage, String snippetId) {
+       Trace.log("Panel result page: " + resultPage.getText());
+       
+       String photoUrl = resultPage.getPhotoUrl();
+       Assert.assertFalse("Invalid photo url", StringUtil.isEmpty(photoUrl));
+       
+       String[] details = resultPage.getDetails();
+       Assert.assertFalse("Invalid details", details == null || details.length == 0);
+       Assert.assertEquals("Invalid details", 4, details.length);
+       
+       return true;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+    	return getProperty("sample.displayName1");
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+    	return "linkText";
+    }
+    	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileSearch.java
@@ -1,0 +1,40 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class ProfileSearch extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testSearchGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_ProfileSearch",true));
+    }																
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileTagSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileTagSearch.java
@@ -1,0 +1,41 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class ProfileTagSearch extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testSearchGrid() {
+    	addSnippetParam("sample.profileTags", "it");
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_ProfileTagSearch",true));
+    }																
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ProfileTags.java
@@ -1,0 +1,115 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ListResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mwallace
+ * @date 14 Aug 2013
+ */
+public class ProfileTags extends BaseTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isLibrary("jquery") && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testTaggedBy() {
+        assertTrue("Expected the test to generate a list", checkList("Social_Profiles_Controls_ProfileTaggedBy"));
+    }																
+
+    @Test
+    public void testTagsFor() {
+        assertTrue("Expected the test to generate a list", checkList("Social_Profiles_Controls_ProfileTagsFor"));
+    }																
+
+    /**
+     * Check the list
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected boolean checkList(String snippetId) {
+    	ListResultPage resultPage = launchList(snippetId);
+        
+        return checkList(resultPage, snippetId);
+    }
+    
+    /**
+     * Launch the list snippet and return a ListResultPage
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected ListResultPage launchList(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return new ListResultPage(resultPage);
+    }
+    
+    /**
+     * Return true if a List was created on the page i.e. could find ul, multiple li's
+     * @return
+     */
+    protected boolean checkList(ListResultPage resultPage, String snippetId) {
+       Trace.log("List result page: " + resultPage.getText());
+       if(resultPage.getText().contains("Empty")){
+    	   return true;
+       }
+        
+        WebElement ul = resultPage.getList();
+        if (ul == null) {
+        	Assert.fail("Unable to find list for snippet: " + snippetId);
+        }
+        
+        List<WebElement> items = resultPage.getListItems();
+        if (items == null || items.isEmpty()) {
+        	Assert.fail("Unable to find items for snippet: " + snippetId);
+        }
+        
+        return true;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "ul";
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+    	return "tagName";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ReportingChain.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/profiles/ReportingChain.java
@@ -1,0 +1,40 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.controls.grid.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class ReportingChain extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void testReportingChainGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_Controls_ReportingChain",true));
+    }																
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchActivitiesPublic.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchActivitiesPublic.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchActivitiesPublic extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchActivitiesPublic",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchAll.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchAll.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchAll extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchAll",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchBlogsPublic.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchBlogsPublic.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchBlogsPublic extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchBlogsPublic",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchBookmarks.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchBookmarks.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchBookmarks extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchBookmarks",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchCommunitiesPublic.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchCommunitiesPublic.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchCommunitiesPublic extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchCommunitiesPublic",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchFiles.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchFiles extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchFiles",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchForums.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchForums extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchForums",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchProfilesPublic.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchProfilesPublic.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchProfilesPublic extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchProfilesPublic",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchStatusUpdates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchStatusUpdates.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchStatusUpdates extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchStatusUpdates",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchWikis.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/grid/search/SearchWikis.java
@@ -1,0 +1,34 @@
+package com.ibm.sbt.test.controls.grid.search;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 25 Jun 2013
+ */
+public class SearchWikis extends BaseGridTest {
+    @Test
+    public void testGrid() {
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Search_Controls_SearchWikis",true,true));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/CommunityVCard.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/CommunityVCard.java
@@ -1,0 +1,18 @@
+package com.ibm.sbt.test.controls.vcard;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseVCardTest;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ */
+public class CommunityVCard extends BaseVCardTest{
+	
+	@Test
+	public void testCommunityVCard() {
+		assertTrue("Expected to find the Community vCard on the page", checkCommunityVCard("Social_Communities_Controls_CommunityVCard"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCard.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCard.java
@@ -1,0 +1,18 @@
+package com.ibm.sbt.test.controls.vcard;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseVCardTest;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ */
+public class ProfileVCard extends BaseVCardTest{
+	
+	@Test
+	public void testProfileVCard() {
+		assertTrue("Expected to trigger the vcard's appearance by hovering and clicking", checkProfileVCard("Social_Profiles_Controls_ProfileVCard"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCardEmail.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCardEmail.java
@@ -1,0 +1,18 @@
+package com.ibm.sbt.test.controls.vcard;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseVCardTest;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ */
+public class ProfileVCardEmail extends BaseVCardTest{
+	
+	@Test
+	public void testProfileVCardEmail() {
+		assertTrue("Expected to trigger the vcard's appearance by hovering and clicking", checkProfileVCard("Social_Profiles_Controls_ProfileVCardEmail"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCardInline.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCardInline.java
@@ -1,0 +1,18 @@
+package com.ibm.sbt.test.controls.vcard;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseVCardTest;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ */
+public class ProfileVCardInline extends BaseVCardTest{
+
+	@Test
+	public void testProfileVCardInline() {
+		assertTrue("Expected to find the Inline Profile vCard on the page", checkProfileVCardInline("Social_Profiles_Controls_ProfileVCardInline"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCards.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/vcard/ProfileVCards.java
@@ -1,0 +1,18 @@
+package com.ibm.sbt.test.controls.vcard;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseVCardTest;
+
+/**
+ * @author sberrybyrne
+ * @date 20 Mar 2013
+ */
+public class ProfileVCards extends BaseVCardTest{
+
+	@Test
+	public void testProfileVCards() {
+		assertTrue("Expected to find the card attachpoints and trigger the appearance of the vcards on the page", super.checkProfileVCards("Social_Profiles_Controls_ProfileVCards"));
+	}
+	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/wrappers/FileGridWrapper.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/wrappers/FileGridWrapper.java
@@ -1,0 +1,33 @@
+package com.ibm.sbt.test.controls.wrappers;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseWrapperTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 16 Jul 2013
+ */
+public class FileGridWrapper extends BaseWrapperTest {
+
+    @Test
+    public void testFileGridWrapper() {
+        assertTrue("Expected the test to generate a grid in an iframe", checkFileGridWrapper("Social_Files_Controls_FileGridWrapper"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/wrappers/ProfileCardWrapper.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/controls/wrappers/ProfileCardWrapper.java
@@ -1,0 +1,31 @@
+package com.ibm.sbt.test.controls.wrappers;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseWrapperTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 16 Jul 2013
+ */
+public class ProfileCardWrapper extends BaseWrapperTest {
+    @Test
+    public void testProfileCardWrapper() {
+        assertTrue("Expected to find a fully functional VCard in an iframe", checkProfileCardWrapper("Social_Profiles_Controls_ProfileVCardWrapper"));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/AuthenticationTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/AuthenticationTestSuite.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.authentication.GetMyCommunities;
+import com.ibm.sbt.test.java.authentication.GetMyProfile;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetMyCommunities.class, GetMyProfile.class })
+public class AuthenticationTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/ConnectionsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/ConnectionsTestSuite.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.connections.ActivityStreamsTestSuite;
+import com.ibm.sbt.test.java.connections.CommunitiesTestSuite;
+import com.ibm.sbt.test.java.connections.FilesTestSuite;
+import com.ibm.sbt.test.java.connections.ProfilesTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ActivityStreamsTestSuite.class, CommunitiesTestSuite.class, FilesTestSuite.class, ProfilesTestSuite.class })
+public class ConnectionsTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/SmartCloudTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/SmartCloudTestSuite.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.java.smartcloud.CommunitiesTestSuite;
+import com.ibm.sbt.test.java.smartcloud.FilesTestSuite;
+import com.ibm.sbt.test.java.smartcloud.ProfilesTestSuite;
+
+/**
+ * @author fmoloney
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CommunitiesTestSuite.class, FilesTestSuite.class, ProfilesTestSuite.class })
+public class SmartCloudTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/authentication/GetMyCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/authentication/GetMyCommunities.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 9 Mar 2013
+ */
+public class GetMyCommunities extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void testNoError() {
+        setAuthType(AuthType.AUTO_DETECT);
+        boolean result = checkNoError("Authentication_Basic_Connections_Get_My_Communities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/authentication/GetMyProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/authentication/GetMyProfile.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+
+/**
+ * @author mwallace
+ * 
+ * @date 9 Mar 2013
+ */
+public class GetMyProfile extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Authentication_OAuth1_SmartCloud_Get_My_Profile");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/ActivityStreamsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/ActivityStreamsTestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.connections.activitystreams.CommunitiesIFollow;
+import com.ibm.sbt.test.java.connections.activitystreams.MyNetworkUpdates;
+import com.ibm.sbt.test.java.connections.activitystreams.PeopleIFollow;
+import com.ibm.sbt.test.java.connections.activitystreams.PostEvent;
+import com.ibm.sbt.test.java.connections.activitystreams.PostEventWithEmbeddedExperience;
+import com.ibm.sbt.test.java.connections.activitystreams.Search;
+import com.ibm.sbt.test.java.connections.activitystreams.SearchByTag;
+import com.ibm.sbt.test.java.connections.activitystreams.UpdatesFromSpecificCommunity;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CommunitiesIFollow.class, MyNetworkUpdates.class, PeopleIFollow.class, PostEvent.class, PostEventWithEmbeddedExperience.class, Search.class,
+        SearchByTag.class, UpdatesFromSpecificCommunity.class }) 
+public class ActivityStreamsTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/CommunitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/CommunitiesTestSuite.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.connections.communities.AddMember;
+import com.ibm.sbt.test.java.connections.communities.RemoveMember;
+import com.ibm.sbt.test.java.connections.communities.CreateCommunity;
+import com.ibm.sbt.test.java.connections.communities.GetCommunityBookmarks;
+import com.ibm.sbt.test.java.connections.communities.GetForumTopics;
+import com.ibm.sbt.test.java.connections.communities.GetCommunityMembers;
+import com.ibm.sbt.test.java.connections.communities.GetMyCommunities;
+import com.ibm.sbt.test.java.connections.communities.GetPublicCommunities;
+import com.ibm.sbt.test.java.connections.communities.UpdateCommunityTags;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ AddMember.class, RemoveMember.class, CreateCommunity.class, GetCommunityBookmarks.class, GetForumTopics.class,
+        GetCommunityMembers.class, GetMyCommunities.class, GetPublicCommunities.class, UpdateCommunityTags.class })
+public class CommunitiesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/FilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/FilesTestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.connections.files.AddCommentToFile;
+import com.ibm.sbt.test.java.connections.files.AddRemoveTag;
+import com.ibm.sbt.test.java.connections.files.CreateDeleteFile;
+import com.ibm.sbt.test.java.connections.files.GetFileComments;
+import com.ibm.sbt.test.java.connections.files.GetFilesSharedByMe;
+import com.ibm.sbt.test.java.connections.files.GetFilesSharedWithMe;
+import com.ibm.sbt.test.java.connections.files.GetMyFiles;
+import com.ibm.sbt.test.java.connections.files.LockUnlockFile;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ AddCommentToFile.class, AddRemoveTag.class, CreateDeleteFile.class, GetFileComments.class, GetFilesSharedByMe.class, GetFilesSharedWithMe.class,
+        GetMyFiles.class, LockUnlockFile.class })
+public class FilesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/ProfilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/ProfilesTestSuite.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.java.connections.profiles.GetAbout;
+import com.ibm.sbt.test.java.connections.profiles.GetDisplayName;
+import com.ibm.sbt.test.java.connections.profiles.GetId;
+import com.ibm.sbt.test.java.connections.profiles.GetPhoneNumber;
+import com.ibm.sbt.test.java.connections.profiles.GetProfileUrl;
+import com.ibm.sbt.test.java.connections.profiles.GetPronunciationUrl;
+import com.ibm.sbt.test.java.connections.profiles.GetThumbnailUrl;
+import com.ibm.sbt.test.java.connections.profiles.GetTitle;
+import com.ibm.sbt.test.java.connections.profiles.UpdatePhoneNumber;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetAbout.class, GetDisplayName.class, GetId.class, GetPhoneNumber.class, GetProfileUrl.class, GetPronunciationUrl.class,
+        GetThumbnailUrl.class, GetTitle.class, UpdatePhoneNumber.class })
+public class ProfilesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/CommunitiesIFollow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/CommunitiesIFollow.java
@@ -1,0 +1,34 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 24, 2013
+ */
+public class CommunitiesIFollow extends BaseAuthJavaServiceTest {
+
+    @Test @Ignore
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_CommunitiesIFollow");
+        assertTrue(getNoErrorMsg(), result);
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/MyNetworkUpdates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/MyNetworkUpdates.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class MyNetworkUpdates extends BaseAuthJavaServiceTest {
+
+    @Test @Ignore
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_MyNetwork");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PeopleIFollow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PeopleIFollow.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class PeopleIFollow extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_PeopleIFollow");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PostEvent.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PostEvent.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class PostEvent extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_Post_Event");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PostEventWithEmbeddedExperience.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/PostEventWithEmbeddedExperience.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class PostEventWithEmbeddedExperience extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_Post_Event_With_Embedded_Experience");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/Search.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/Search.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class Search extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/SearchByTag.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/SearchByTag.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class SearchByTag extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_SearchByTag");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/UpdatesFromSpecificCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/activitystreams/UpdatesFromSpecificCommunity.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.activitystreams;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Jan 10, 2013
+ */
+public class UpdatesFromSpecificCommunity extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_ActivityStreams_UpdatesFromCommunity");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/AddMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/AddMember.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.communities;
+
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class AddMember extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_AddMember");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/CreateCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/CreateCommunity.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class CreateCommunity extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_CreateCommunity");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityBookmarks.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityBookmarks.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetCommunityBookmarks extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetCommunityBookmarks");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityById.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityById.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetCommunityById extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetCommunityById");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityMembers.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetCommunityMembers.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetCommunityMembers extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetCommunityMembers");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetForumTopics.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetForumTopics.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetForumTopics extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetForumTopics");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetMyCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetMyCommunities.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetMyCommunities extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetMyCommunities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetPublicCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/GetPublicCommunities.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetPublicCommunities extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_GetPublicCommunities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/RemoveMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/RemoveMember.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class RemoveMember extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_RemoveMember");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/UpdateCommunityTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/communities/UpdateCommunityTags.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class UpdateCommunityTags extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Communities_UpdateCommunityTags");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/AddCommentToFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/AddCommentToFile.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class AddCommentToFile extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkExpected("Social_Files_Add_Comment_To_File", "Comment Id :");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/AddRemoveTag.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/AddRemoveTag.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class AddRemoveTag extends BaseAuthJavaServiceTest {
+
+    @Ignore @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Update_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/CreateDeleteFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/CreateDeleteFile.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date Feb 8, 2013
+ */
+public class CreateDeleteFile extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Create_Delete_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/DeleteFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/DeleteFile.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class DeleteFile extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Delete_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFileComments.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFileComments.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetFileComments extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Get_File_Comments");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFilesSharedByMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFilesSharedByMe.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 201
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetFilesSharedByMe extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Get_Files_Shared_By_Me");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFilesSharedWithMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetFilesSharedWithMe.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetFilesSharedWithMe extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Get_Files_Shared_With_Me");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetMyFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/GetMyFiles.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetMyFiles extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Get_My_Files");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/LockUnlockFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/LockUnlockFile.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date Feb 8, 2013
+ */
+public class LockUnlockFile extends BaseAuthJavaServiceTest {
+
+    @Ignore @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Lock_Unlock_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/UploadFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/files/UploadFile.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class UploadFile extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Files_Upload_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetAbout.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetAbout.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetAbout extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetAbout");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetCollegues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetCollegues.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetCollegues extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetColleagues");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetDisplayName.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetDisplayName.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetDisplayName extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetDisplayName");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetId.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetId.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetId extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetId");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetPhoneNumber.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetPhoneNumber.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetPhoneNumber extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetPhoneNumber");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetProfileUrl.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetProfileUrl.java
@@ -1,0 +1,38 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetProfileUrl extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        String expected = getProperty("sample.profileUrl1");
+        boolean result = checkExpected("Social_Profiles_GetProfileUrl", expected);
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetPronunciationUrl.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetPronunciationUrl.java
@@ -1,0 +1,38 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetPronunciationUrl extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        String expected = getProperty("sample.pronunciationUrl1");
+        boolean result = checkExpected("Social_Profiles_GetPronunciationUrl", expected);
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetThumbnailUrl.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetThumbnailUrl.java
@@ -1,0 +1,38 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetThumbnailUrl extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        String expected = getProperty("sample.thumbnailUrl1");
+        boolean result = checkExpected("Social_Profiles_GetThumbnailUrl", expected);
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetTitle.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/GetTitle.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class GetTitle extends BaseJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_GetTitle");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/UpdatePhoneNumber.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/connections/profiles/UpdatePhoneNumber.java
@@ -1,0 +1,37 @@
+package com.ibm.sbt.test.java.connections.profiles;
+
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthJavaServiceTest;
+
+/**
+ * @author mkataria
+ * @date Feb 8, 2013
+ */
+public class UpdatePhoneNumber extends BaseAuthJavaServiceTest {
+
+    @Test
+    public void runTest() {
+        boolean result = checkNoError("Social_Profiles_UpdatePhoneNumber");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/CommunitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/CommunitiesTestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ com.ibm.sbt.test.java.connections.CommunitiesTestSuite.class})
+public class CommunitiesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/FilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/FilesTestSuite.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ com.ibm.sbt.test.java.connections.FilesTestSuite.class })
+public class FilesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/ProfilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/ProfilesTestSuite.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.java.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.java.smartcloud.profiles.GetContactByGUID;
+import com.ibm.sbt.test.java.smartcloud.profiles.GetMyContacts;
+import com.ibm.sbt.test.java.smartcloud.profiles.OAuth1SmartCloudProfiles;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetContactByGUID.class, GetMyContacts.class, OAuth1SmartCloudProfiles.class })
+public class ProfilesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/GetContactByGUID.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/GetContactByGUID.java
@@ -1,0 +1,35 @@
+package com.ibm.sbt.test.java.smartcloud.profiles;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 15 Aug 2013
+ */
+public class GetContactByGUID extends BaseJavaServiceTest{
+
+    @Test
+    public void runTest() {
+        this.authType = AuthType.AUTO_DETECT;
+        boolean result = checkNoError("Social_Profiles_SmartCloud_Get_Contact_by_GUID");
+        assertTrue(getNoErrorMsg(), result);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/GetMyContacts.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/GetMyContacts.java
@@ -1,0 +1,35 @@
+package com.ibm.sbt.test.java.smartcloud.profiles;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 15 Aug 2013
+ */
+public class GetMyContacts extends BaseJavaServiceTest{
+
+    @Test
+    public void runTest() {
+        this.authType = AuthType.AUTO_DETECT;
+        boolean result = checkNoError("Social_Profiles_SmartCloud_Get_My_Contacts");
+        assertTrue(getNoErrorMsg(), result);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/OAuth1SmartCloudProfiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/java/smartcloud/profiles/OAuth1SmartCloudProfiles.java
@@ -1,0 +1,35 @@
+package com.ibm.sbt.test.java.smartcloud.profiles;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseJavaServiceTest;
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+/**
+ * @author Francis 
+ * @date 15 Aug 2013
+ */
+public class OAuth1SmartCloudProfiles extends BaseJavaServiceTest{
+
+    @Test
+    public void runTest() {
+        this.authType = AuthType.AUTO_DETECT;
+        boolean result = checkNoError("Social_Profiles_SmartCloud_OAuth1_Smartcloud_Profiles");
+        assertTrue(getNoErrorMsg(), result);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/AuthenticationTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/AuthenticationTestSuite.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.authentication.Authentication;
+import com.ibm.sbt.test.js.authentication.BasicDialog;
+import com.ibm.sbt.test.js.authentication.BasicMainWindow;
+import com.ibm.sbt.test.js.authentication.BasicPopup;
+import com.ibm.sbt.test.js.authentication.OAuth10MainWindow;
+import com.ibm.sbt.test.js.authentication.OAuth10Popup;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ Authentication.class, 
+    OAuth10MainWindow.class,
+    OAuth10Popup.class,
+    //OAuth20MainWindow.class,
+    //OAuth20Popup.class,
+    BasicMainWindow.class, 
+    BasicDialog.class, 
+    BasicPopup.class })
+public class AuthenticationTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/BaseTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/BaseTestSuite.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.base.BaseEntity;
+import com.ibm.sbt.test.js.base.BaseServiceConstructUrl;
+import com.ibm.sbt.test.js.base.BaseServiceDeleteEntity;
+import com.ibm.sbt.test.js.base.BaseServiceGetEntities;
+import com.ibm.sbt.test.js.base.BaseServiceGetEntity;
+import com.ibm.sbt.test.js.base.BaseServiceUpdateEntity;
+import com.ibm.sbt.test.js.base.BaseServiceValidation;
+import com.ibm.sbt.test.js.base.VCardDataHandler;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+    BaseEntity.class, 
+    BaseServiceValidation.class,
+    BaseServiceConstructUrl.class,
+    BaseServiceGetEntity.class, 
+    BaseServiceDeleteEntity.class,
+    BaseServiceUpdateEntity.class,
+    BaseServiceGetEntities.class, 
+    VCardDataHandler.class })
+public class BaseTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/ConnectionsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/ConnectionsTestSuite.java
@@ -1,0 +1,65 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.connections.ActivitiesRestTestSuite;
+import com.ibm.sbt.test.js.connections.ActivitiesStreamsTestSuite;
+import com.ibm.sbt.test.js.connections.ActivitiesTestSuite;
+import com.ibm.sbt.test.js.connections.BookmarksRestTestSuite;
+import com.ibm.sbt.test.js.connections.CommunitiesRestTestSuite;
+import com.ibm.sbt.test.js.connections.CommunitiesTestSuite;
+import com.ibm.sbt.test.js.connections.FilesTestSuite;
+import com.ibm.sbt.test.js.connections.ForumsRestTestSuite;
+import com.ibm.sbt.test.js.connections.ForumsTestSuite;
+import com.ibm.sbt.test.js.connections.ProfilesRestTestSuite;
+import com.ibm.sbt.test.js.connections.ProfilesTestSuite;
+import com.ibm.sbt.test.js.connections.SearchRestTestSuite;
+import com.ibm.sbt.test.js.connections.SearchTestSuite;
+import com.ibm.sbt.test.sample.SampleFrameworkTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+	ActivitiesTestSuite.class,
+	ActivitiesRestTestSuite.class,
+	ActivitiesStreamsTestSuite.class,
+	BookmarksRestTestSuite.class,
+	CommunitiesRestTestSuite.class, 
+	CommunitiesTestSuite.class, 
+	FilesTestSuite.class, 
+	ForumsTestSuite.class,
+	ForumsRestTestSuite.class,
+	ProfilesRestTestSuite.class,
+	ProfilesTestSuite.class,
+	SearchRestTestSuite.class, 
+	SearchTestSuite.class, 
+	SampleFrameworkTestSuite.class })
+public class ConnectionsTestSuite {
+	@AfterClass
+	public static void cleanup() {
+		TestEnvironment.cleanup();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/SmartCloudTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/SmartCloudTestSuite.java
@@ -1,0 +1,57 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.smartcloud.SearchRestTestSuite;
+import com.ibm.sbt.test.js.smartcloud.SearchTestSuite;
+import com.ibm.sbt.test.js.smartcloud.CommunitiesTestSuite;
+import com.ibm.sbt.test.js.smartcloud.FilesTestSuite;
+import com.ibm.sbt.test.js.smartcloud.ProfilesGridTestSuite;
+import com.ibm.sbt.test.js.smartcloud.ProfilesTestSuite;
+import com.ibm.sbt.test.sample.SampleFrameworkTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CommunitiesTestSuite.class, FilesTestSuite.class,
+		ProfilesTestSuite.class, ProfilesGridTestSuite.class,
+		SearchTestSuite.class, /*SearchRestTestSuite.class,*/
+		SampleFrameworkTestSuite.class })
+public class SmartCloudTestSuite {
+	@BeforeClass
+	public static void init() {
+		TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+		environment.enableSmartCloud();
+	}
+
+	@AfterClass
+	public static void cleanup() {
+		TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+		environment.disableSmartCloud();
+		TestEnvironment.cleanup();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/SmartCloudTestSuiteV20.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/SmartCloudTestSuiteV20.java
@@ -1,0 +1,59 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.java.connections.ActivityStreamsTestSuite;
+import com.ibm.sbt.test.js.connections.ActivitiesStreamsTestSuite;
+import com.ibm.sbt.test.js.smartcloud.SearchRestTestSuite;
+import com.ibm.sbt.test.js.smartcloud.SearchTestSuite;
+import com.ibm.sbt.test.js.smartcloud.CommunitiesTestSuite;
+import com.ibm.sbt.test.js.smartcloud.FilesTestSuite;
+import com.ibm.sbt.test.js.smartcloud.ProfilesGridTestSuite;
+import com.ibm.sbt.test.js.smartcloud.ProfilesTestSuite;
+import com.ibm.sbt.test.sample.SampleFrameworkTestSuite;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ActivitiesStreamsTestSuite.class, ActivityStreamsTestSuite.class, CommunitiesTestSuite.class, FilesTestSuite.class,
+		ProfilesTestSuite.class, ProfilesGridTestSuite.class,
+		SearchTestSuite.class, /*SearchRestTestSuite.class,*/
+		SampleFrameworkTestSuite.class })
+public class SmartCloudTestSuiteV20 {
+	@BeforeClass
+	public static void init() {
+		TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+		environment.enableSmartCloud();
+	}
+
+	@AfterClass
+	public static void cleanup() {
+		TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+		environment.disableSmartCloud();
+		TestEnvironment.cleanup();
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/ToolkitTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/ToolkitTestSuite.java
@@ -1,0 +1,44 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.test.js.sbt.EndpointDelete;
+import com.ibm.sbt.test.js.sbt.EndpointGet;
+import com.ibm.sbt.test.js.sbt.EndpointPost;
+import com.ibm.sbt.test.js.sbt.EndpointPut;
+import com.ibm.sbt.test.js.sbt.LangMixin;
+import com.ibm.sbt.test.js.sbt.ResponseHeaders;
+import com.ibm.sbt.test.js.sbt.TransportGet;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ EndpointDelete.class, EndpointGet.class, EndpointPut.class, EndpointPost.class, LangMixin.class, ResponseHeaders.class, TransportGet.class })
+public class ToolkitTestSuite {
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/Authentication.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/Authentication.java
@@ -1,0 +1,58 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class Authentication extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        setAuthType(AuthType.NONE,true);
+    	ResultPage p = launchSnippet("Authentication_Authentication_Summary");
+        
+        WebDriver webDriver = p.getWebDriver();
+		webDriver.findElement(By.id("logoutsmartcloudOA2"));
+        webDriver.findElement(By.id("loginsmartcloudOA2"));
+        webDriver.findElement(By.id("logoutconnections"));
+        webDriver.findElement(By.id("loginconnections"));
+        webDriver.findElement(By.id("logoutconnectionsOA2"));
+        webDriver.findElement(By.id("loginconnectionsOA2"));
+        webDriver.findElement(By.id("logoutsmartcloud"));
+        webDriver.findElement(By.id("loginsmartcloud"));
+        //Disabling the domino endpoint login/logout buttons.
+        //webDriver.findElement(By.id("logoutdomino"));
+       // webDriver.findElement(By.id("logindomino"));
+        
+    }
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "authenticationTable";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicDialog.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicDialog.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class BasicDialog extends BaseServiceTest {
+
+    @Test
+    public void testBasicAutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT, true);
+        boolean result = checkExpected("Authentication_API_Basic_Dialog", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testBasic() {
+        setAuthType(AuthType.BASIC, true);
+        boolean result = checkExpected("Authentication_API_Basic_Dialog", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicMainWindow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicMainWindow.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class BasicMainWindow extends BaseServiceTest {
+
+    @Test
+    public void testBasicAutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT, true);
+        boolean result = checkExpected("Authentication_API_Basic_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testBasic() {
+        setAuthType(AuthType.BASIC, true);
+        boolean result = checkExpected("Authentication_API_Basic_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicPopup.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/BasicPopup.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class BasicPopup extends BaseAuthServiceTest {
+
+    @Test
+    public void testBasicAutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT, true);
+        boolean result = checkExpected("Authentication_API_Basic_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testBasic() {
+        setAuthType(AuthType.BASIC, true);
+        boolean result = checkExpected("Authentication_API_Basic_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/LoginWithDelay.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/LoginWithDelay.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class LoginWithDelay extends BaseServiceTest {
+
+    @Test
+    public void testLoginWithDelay() {
+        setAuthType(AuthType.AUTO_DETECT, true);
+        boolean result = checkExpected("Test_LoginWithDelay", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth10MainWindow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth10MainWindow.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class OAuth10MainWindow extends BaseServiceTest {
+
+    @Test
+    public void testOAuth10AutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT,true);
+        boolean result = checkExpected("Authentication_API_OAuth10_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testOAuth10() {
+        setAuthType(AuthType.OAUTH10,true);
+        boolean result = checkExpected("Authentication_API_OAuth10_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth10Popup.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth10Popup.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class OAuth10Popup extends BaseAuthServiceTest {
+
+    @Test
+    public void testOAuth10AutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT, true);
+        boolean result = checkExpected("Authentication_API_OAuth10_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testOAuth10() {
+        setAuthType(AuthType.OAUTH10, true);
+        boolean result = checkExpected("Authentication_API_OAuth10_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth20MainWindow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth20MainWindow.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class OAuth20MainWindow extends BaseServiceTest {
+
+    @Test
+    public void testOAuth20AutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT);
+        boolean result = checkExpected("Authentication_API_OAuth20_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testOAuth20() {
+        setAuthType(AuthType.OAUTH10);
+        boolean result = checkExpected("Authentication_API_OAuth20_MainWindow", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth20Popup.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/authentication/OAuth20Popup.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.authentication;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class OAuth20Popup extends BaseAuthServiceTest {
+
+    @Test
+    public void testOAuth20AutoDetect() {
+        setAuthType(AuthType.AUTO_DETECT);
+        boolean result = checkExpected("Authentication_API_OAuth20_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+    @Test
+    public void testOAuth20() {
+        setAuthType(AuthType.OAUTH10);
+        boolean result = checkExpected("Authentication_API_OAuth20_Popup", "Successfully logged in");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/AtomEntity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/AtomEntity.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class AtomEntity extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_AtomEntity";
+        
+    @Test
+    public void testAtomEntity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Iterator<String> properties = json.getProperties();
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseEntity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseEntity.java
@@ -1,0 +1,144 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseEntity extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseEntity";
+    
+    static final ArrayList<String> fooBarBaz = new ArrayList<String>();
+    {
+        fooBarBaz.add("foo");
+        fooBarBaz.add("bar");
+        fooBarBaz.add("baz");
+    }
+    
+    static final ArrayList<String> foo = new ArrayList<String>();
+    {
+        foo.add("foo");
+    }
+    
+    static final ArrayList<Double> eight = new ArrayList<Double>();
+    {
+        eight.add(new Double(8));
+    }
+    
+    static final ArrayList<Boolean> bool = new ArrayList<Boolean>();
+    {
+        bool.add(Boolean.TRUE);
+    }
+    
+    static final ArrayList<String> links = new ArrayList<String>();
+    {
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fblogs%2Froller-ui%2Fblog%2F0EE5A7FA-3434-9A59-4825-7A7000278DAA");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fforums%2Fhtml%2Fsearch%3Fuserid%3D0EE5A7FA-3434-9A59-4825-7A7000278DAA%26name%3DFrank+Adams");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fwikis%2Fhome%2Fsearch%3Fuid%3D0EE5A7FA-3434-9A59-4825-7A7000278DAA%26name%3DFrank+Adams");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Ffiles%2Fapp%2Fperson%2F0EE5A7FA-3434-9A59-4825-7A7000278DAA");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fcommunities%2Fservice%2Fhtml%2Fallcommunities%3Fuserid%3D0EE5A7FA-3434-9A59-4825-7A7000278DAA");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fprofiles%2Fhtml%2FsimpleSearch.do%3FsearchFor%3D0EE5A7FA-3434-9A59-4825-7A7000278DAA%26searchBy%3Duserid");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Fdogear%2Fhtml%3Fuserid%3D0EE5A7FA-3434-9A59-4825-7A7000278DAA");
+        links.add("https%3A%2F%2Fqs.renovations.com%3A444%2Factivities%2Fservice%2Fhtml%2Fmainpage%23dashboard%252Cmyactivities%252Cuserid%253D0EE5A7FA-3434-9A59-4825-7A7000278DAA%252Cname%253DFrank+Adams");
+        links.add("https://qs.renovations.com:444/profiles/atom/profileEntry.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&format=full");
+        links.add("https://qs.renovations.com:444/profiles/atom/profileType.do?type=default");
+        links.add("https://qs.renovations.com:444/profiles/html/profileView.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7");
+        links.add("https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427");
+        links.add("https://qs.renovations.com:444/profiles/audio.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427");
+        links.add("https://qs.renovations.com:444/profiles/vcard/profile.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7");
+    }
+    
+    static final Object[][] Results = new Object[][] {
+            { "userid", "userid123" },
+            { "userid", "foo,bar" },
+            { "null", "Invalid argument for BaseService.setAsString undefined,userid123" },
+            { "undefined", "Invalid argument for BaseService.setAsString undefined,userid123" },
+            { "userid", "[object Object]" },
+            { "userid", "0EE5A7FA-3434-9A59-4825-7A7000278DAA" },
+            { "userid", "0EE5A7FA-3434-9A59-4825-7A7000278DAA" },
+            { "number", new Double(8) },
+            { "number", new Double(8) },
+            { "number", new Double(12) },
+            { "null", "Invalid argument for BaseService.setAsNumber undefined,0" },
+            { "undefined", "Invalid argument for BaseService.setAsNumber undefined,0" },
+            { "number", "Invalid argument for BaseService.setAsNumber number,foo" },
+            { "number", "Invalid argument for BaseService.setAsNumber number,[object Object]" },
+            { "number", "Invalid argument for BaseService.setAsNumber number,foo" },
+            { "number", new Double(12) },
+            { "updated", null}, //"2013-04-30T23:00:00.000Z" },
+            { "updated", null}, //"2013-03-28T21:14:14.649Z" },
+            { "updated", null}, //"2013-04-05T17:15:36.427Z" },
+            { "null", null}, //"Invalid argument for BaseService.setAsDate undefined,Wed May 01 2013 00:00:00 GMT+0100 (GMT Daylight Time)" },
+            { "undefined", "Invalid argument for BaseService.setAsDate undefined,Wed May 01 2013 00:00:00 GMT+0100 (GMT Daylight Time)" },
+            { "updated", "Invalid argument for BaseService.setAsDate updated,foo" },
+            { "updated", "Invalid argument for BaseService.setAsDate updated,[object Object]" },
+            { "updated", "Invalid argument for BaseService.setAsDate updated,foo" },
+            { "updated", null}, //"2013-04-05T17:15:36.427Z" },
+            { "boolean", "true" },
+            { "boolean", "false" },
+            { "boolean", "true" },
+            { "boolean", "true" },
+            { "boolean", "false" },
+            { "null", "Invalid argument for BaseService.setAsBoolean undefined,undefined" },
+            { "undefined", "Invalid argument for BaseService.setAsBoolean undefined,undefined" },
+            { "boolean", "true" },
+            { "boolean", "true" },
+            { "boolean", "true" },
+            { "boolean", "false" },
+            { "a:link/@href", fooBarBaz },
+            { "a:link/@href", fooBarBaz },
+            { "a:link/@href", foo },
+            { "a:link/@href", eight },
+            { "a:link/@href", bool },
+            { "a:link/@href", links },
+            { "null", "Invalid argument for BaseService.setAsArray undefined,foo,bar,baz" },
+            { "undefined", "Invalid argument for BaseService.setAsArray undefined,foo,bar,baz" },
+            { "a:link/@href", links }
+    };
+    
+    @Test
+    @Ignore
+    public void testBaseEntity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Iterator<String> properties = json.getProperties();
+            if (properties.hasNext() && Results[i][1] != null) {
+                String property = properties.next();
+                Object value = json.get(property);
+                Assert.assertEquals(Results[i][0], property);
+                Assert.assertEquals("Match failed ["+i+"] name:"+property+" type:"+value.getClass(), Results[i][1], value);
+            }
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceConstructUrl.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceConstructUrl.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 9 May 2013
+ */
+public class BaseServiceConstructUrl extends BaseApiTest {
+
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceConstructUrl";
+
+    @Test
+    public void testConstructUrl() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("/communities/service/atom/communities/all", json.getString("a"));
+        Assert.assertEquals("/communities/service/atom/communities/all?ps=5&since=2009-01-04T20%3A32%3A31.171Z&email=john%3F%40foo", json.getString("b"));
+        Assert.assertEquals("/communities/service/atom/communities/all?page=1&ps=5&since=2009-01-04T20%3A32%3A31.171Z&email=john%3F%40foo", json.getString("c"));
+        Assert.assertEquals("/communities/service/atom/communities/all?page=1&ps=5&since=2009-01-04T20%3A32%3A31.171Z&email=john%3F%40foo", json.getString("d"));
+        Assert.assertEquals("/connections/opensocial/oauth/rest/activitystreams/", json.getString("e"));
+        Assert.assertEquals("/connections/opensocial/oauth/rest/activitystreams/@me", json.getString("f"));
+        Assert.assertEquals("/connections/opensocial/oauth/rest/activitystreams/@me/@following/@communities", json.getString("g"));
+        Assert.assertEquals("/connections/opensocial/rest/activitystreams/", json.getString("h"));
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceDeleteEntity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceDeleteEntity.java
@@ -1,0 +1,52 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceDeleteEntity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceDeleteEntity";
+    
+    @Test @Ignore
+    public void testDeleteEntity() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(1, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("data"));
+        Assert.assertEquals(200, json.getJsonObject("response").getInt("status"));
+        
+        // community is already deleted
+        community = null;
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceGetEntities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceGetEntities.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceGetEntities extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceGetEntities";
+    
+    public BaseServiceGetEntities() {
+        setAuthType(AuthType.NONE);
+    }
+    
+    @Test
+    public void testGetEntities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertTrue(jsonList.size() > 0);
+        Assert.assertEquals("createEntities", ((JsonJavaObject)jsonList.get(0)).getString("callback"));
+        Assert.assertEquals("createEntity", ((JsonJavaObject)jsonList.get(1)).getString("callback"));
+        Assert.assertEquals("response", ((JsonJavaObject)jsonList.get(jsonList.size() - 1)).getString("callback"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceGetEntity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceGetEntity.java
@@ -1,0 +1,83 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceGetEntity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceGetEntity";
+    
+    public BaseServiceGetEntity() {
+        setAuthType(AuthType.NONE);
+        createCommunity = false;
+    }
+    
+    @Test
+    public void testGetEntityInvalid() {
+        addSnippetParam("sample.communityId", "foo");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse(jsonList.isEmpty());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The community which this resource or page is associated with does not exist.", json.getString("message"));
+    }
+
+    @Test
+    public void testGetEntityNull() {
+        addSnippetParam("sample.communityId", "");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse(jsonList.isEmpty());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument 'undefined', expected valid entity identifier.", json.getString("message"));
+    }
+
+    @Test @Ignore
+    public void testGetEntity() {
+    	// only create a community for this test case
+    	createCommunity = true;
+    	createCommunity();
+    	
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals("createEntity", json.getString("callback"));
+        Assert.assertNotNull(json.getString("data"));
+        json = (JsonJavaObject)jsonList.get(1);
+        Assert.assertNotNull(json.getString("id"));
+        Assert.assertNotNull(json.getString("service"));
+        Assert.assertNotNull(json.getString("dataHandler"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceUpdateEntity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceUpdateEntity.java
@@ -1,0 +1,75 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceUpdateEntity extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceUpdateEntity";
+    
+    public BaseServiceUpdateEntity() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test @Ignore
+    public void testUpdateEntity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(4, jsonList.size());
+        
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals("createEntity", json.getString("callback"));
+        Assert.assertEquals(201, json.getJsonObject("response").getInt("status"));
+        
+        json = (JsonJavaObject)jsonList.get(1);
+        Assert.assertEquals("updateEntity", json.getString("callback"));
+        Assert.assertNotNull(json.getString("data"));
+        
+        json = (JsonJavaObject)jsonList.get(2);
+        Assert.assertEquals("createEntity", json.getString("callback"));
+        Assert.assertNotNull(json.getString("data"));
+        Assert.assertEquals(200, json.getJsonObject("response").getInt("status"));
+        
+        json = (JsonJavaObject)jsonList.get(3);
+        Assert.assertEquals("updateEntity", json.getString("callback"));
+        Assert.assertNotNull(json.getString("data"));
+        Assert.assertEquals(200, json.getJsonObject("response").getInt("status"));
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#waitForResult(int)
+     */
+    @Override
+    public WebElement waitForResult(int timeout) {
+        return waitForJsonList(4, timeout);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceValidation.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceValidation.java
@@ -1,0 +1,56 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceValidation extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceValidation";
+    
+    @Test
+    public void testValidateField() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Iterator<String> properties = json.getJsonProperties();
+            while (properties.hasNext()) {
+                String property = properties.next();
+                if ("pass".equals(property)) {
+                    Assert.assertEquals("pass", json.getString(property));
+                } else {
+                    JsonJavaObject promise = json.getJsonObject(property);
+                    Assert.assertTrue(promise.getBoolean("_rejected"));
+                }
+            }
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/VCardDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/VCardDataHandler.java
@@ -1,0 +1,61 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class VCardDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_VCardDataHandler";
+    
+    public VCardDataHandler() {
+        setAuthType(AuthType.NONE);
+    }
+    
+    @Test
+    public void testVCardDataHandler() {
+        addSnippetParam("sample.comunityId", "foo");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("tag:profiles.ibm.com,2006:entrye0b62b52-6a67-4489-b03b-4eb1f62c73e7\n\t\t\n\t\tFrank Adams\n\t\t2013-04-05T17:15:36.427Z\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\tFrank Adams\n\t\t\t0EE5A7FA-3434-9A59-4825-7A7000278DAA\n\t\t\tFrankAdams@renovations.com\n\t\t\tactive\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\t\n\t\tProfile information for Frank Adams\n\t\t\n\t\t\tBEGIN:VCARD\n\t\t\tVERSION:2.1\n\t\t\tPHOTO;VALUE=URL:https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427\n\t\t\tN:Adams;Frank\n\t\t\tFN:Frank Adams\n\t\t\tHONORIFIC_PREFIX:\n\t\t\tNICKNAME:\n\t\t\tX_PREFERRED_LAST_NAME:\n\t\t\tX_NATIVE_FIRST_NAME:\n\t\t\tX_NATIVE_LAST_NAME:\n\t\t\tX_ALTERNATE_LAST_NAME:\n\t\t\tURL:https://qs.renovations.com:444/profiles/atom/profile.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7\n\t\t\tSOUND;VALUE=URL:https://qs.renovations.com:444/profiles/audio.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427\n\t\t\tEMAIL;INTERNET:FrankAdams@renovations.com\n\t\t\tEMAIL;X_GROUPWARE_MAIL:fadams@gmail.com\n\t\t\tX_BLOG_URL;VALUE=URL:\n\t\t\tTZ:Etc/GMT+12\n\t\t\tX_PREFERRED_LANGUAGE:\n\t\t\tORG:\n\t\t\tX_ORGANIZATION_CODE:\n\t\t\tROLE:\n\t\t\tX_EMPTYPE:\n\t\t\tTITLE:Chief Operating Officer\n\t\t\tX_BUILDING:Building1\n\t\t\tX_FLOOR:Floor1\n\t\t\tX_OFFICE_NUMBER:Office1\n\t\t\tTEL;WORK:55555555\n\t\t\tTEL;CELL: +353 86 81551111\n\t\t\tTEL;FAX:\n\t\t\tTEL;X_IP:\n\t\t\tTEL;PAGER:\n\t\t\tX_PAGER_ID:\n\t\t\tX_PAGER_TYPE:\n\t\t\tX_PAGER_PROVIDER:\n\t\t\tCATEGORIES:acme-airlines-it-staff,it,it-staff,itstaff,my-hero\n\t\t\tX_EXPERIENCE:\n\t\t\tX_DESCRIPTION:User Experience Character - Directory2\n\t\t\tX_MANAGER_UID:lsuarez\n\t\t\tX_IS_MANAGER:N\n\t\t\tX_PROFILE_KEY:e0b62b52-6a67-4489-b03b-4eb1f62c73e7\n\t\t\tUID:0EE5A7FA-3434-9A59-4825-7A7000278DAA\n\t\t\tX_PROFILE_UID:FAdams\n\t\t\tX_LCONN_USERID:0EE5A7FA-3434-9A59-4825-7A7000278DAA\n\t\t\tX_EMPLOYEE_NUMBER:\n\t\t\tX_DEPARTMENT_NUMBER:\n\t\t\tX_DEPARTMENT_TITLE:\n\t\t\tX_SHIFT:\n\t\t\tREV:2013-04-05T17:15:36.427Z\n\t\t\tX_PROFILE_TYPE:default\n\t\t\tEND:VCARD", json.getString("/a:feed/a:entry"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("a:contributor/snx:userid"));
+        Assert.assertEquals("BEGIN:VCARD\n\t\t\tVERSION:2.1\n\t\t\tPHOTO;VALUE=URL:https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427\n\t\t\tN:Adams;Frank\n\t\t\tFN:Frank Adams\n\t\t\tHONORIFIC_PREFIX:\n\t\t\tNICKNAME:\n\t\t\tX_PREFERRED_LAST_NAME:\n\t\t\tX_NATIVE_FIRST_NAME:\n\t\t\tX_NATIVE_LAST_NAME:\n\t\t\tX_ALTERNATE_LAST_NAME:\n\t\t\tURL:https://qs.renovations.com:444/profiles/atom/profile.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7\n\t\t\tSOUND;VALUE=URL:https://qs.renovations.com:444/profiles/audio.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427\n\t\t\tEMAIL;INTERNET:FrankAdams@renovations.com\n\t\t\tEMAIL;X_GROUPWARE_MAIL:fadams@gmail.com\n\t\t\tX_BLOG_URL;VALUE=URL:\n\t\t\tTZ:Etc/GMT+12\n\t\t\tX_PREFERRED_LANGUAGE:\n\t\t\tORG:\n\t\t\tX_ORGANIZATION_CODE:\n\t\t\tROLE:\n\t\t\tX_EMPTYPE:\n\t\t\tTITLE:Chief Operating Officer\n\t\t\tX_BUILDING:Building1\n\t\t\tX_FLOOR:Floor1\n\t\t\tX_OFFICE_NUMBER:Office1\n\t\t\tTEL;WORK:55555555\n\t\t\tTEL;CELL: +353 86 81551111\n\t\t\tTEL;FAX:\n\t\t\tTEL;X_IP:\n\t\t\tTEL;PAGER:\n\t\t\tX_PAGER_ID:\n\t\t\tX_PAGER_TYPE:\n\t\t\tX_PAGER_PROVIDER:\n\t\t\tCATEGORIES:acme-airlines-it-staff,it,it-staff,itstaff,my-hero\n\t\t\tX_EXPERIENCE:\n\t\t\tX_DESCRIPTION:User Experience Character - Directory2\n\t\t\tX_MANAGER_UID:lsuarez\n\t\t\tX_IS_MANAGER:N\n\t\t\tX_PROFILE_KEY:e0b62b52-6a67-4489-b03b-4eb1f62c73e7\n\t\t\tUID:0EE5A7FA-3434-9A59-4825-7A7000278DAA\n\t\t\tX_PROFILE_UID:FAdams\n\t\t\tX_LCONN_USERID:0EE5A7FA-3434-9A59-4825-7A7000278DAA\n\t\t\tX_EMPLOYEE_NUMBER:\n\t\t\tX_DEPARTMENT_NUMBER:\n\t\t\tX_DEPARTMENT_TITLE:\n\t\t\tX_SHIFT:\n\t\t\tREV:2013-04-05T17:15:36.427Z\n\t\t\tX_PROFILE_TYPE:default\n\t\t\tEND:VCARD", json.getString("a:content"));
+        Assert.assertEquals("tag:profiles.ibm.com,2006:entrye0b62b52-6a67-4489-b03b-4eb1f62c73e7", json.getString("a:id"));
+        Assert.assertEquals("Frank Adams", json.getString("a:contributor/a:name"));
+        Assert.assertEquals("FrankAdams@renovations.com", json.getString("a:contributor/a:email"));
+        Assert.assertEquals("Frank Adams", json.getString("a:title"));
+        Assert.assertEquals("2013-04-05T17:15:36.427Z", json.getString("a:updated"));
+        Assert.assertEquals("https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427", json.getString("a:link[@rel='http://www.ibm.com/xmlns/prod/sn/image']/@href"));
+        Assert.assertEquals("Chief Operating Officer", json.getString("TITLE"));
+        Assert.assertEquals("55555555", json.getString("TEL;WORK"));
+        Assert.assertEquals("Building1", json.getString("X_BUILDING"));
+        Assert.assertEquals("Floor1", json.getString("X_FLOOR"));
+        Assert.assertEquals("Office1", json.getString("X_OFFICE_NUMBER"));
+        Assert.assertEquals("Profile information for Frank Adams", json.getString("a:summary"));
+        Assert.assertEquals("fadams@gmail.com", json.getString("EMAIL;X_GROUPWARE_MAIL"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesRestTestSuite.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.activities.rest.GetMyActivities;
+import com.ibm.sbt.test.js.connections.activities.rest.GetMyActivitiesXml;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetMyActivities.class, GetMyActivitiesXml.class })
+public class ActivitiesRestTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesStreamsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesStreamsTestSuite.java
@@ -1,0 +1,74 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetMyActionableView;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetMySavedView;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetMyStatusUpdates;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetNotificationsForMe;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetNotificationsFromMe;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetPublicActivityStream;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetResponsesToMyContent;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetUpdatesFromACommunity;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetUpdatesFromAUser;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetUpdatesFromCommunitiesIFollow;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetUpdatesFromMyNetwork;
+import com.ibm.sbt.test.js.connections.activitystreams.api.GetUpdatesFromPeopleIFollow;
+import com.ibm.sbt.test.js.connections.activitystreams.api.PostAStatusUpdate;
+import com.ibm.sbt.test.js.connections.activitystreams.api.PostEntry;
+import com.ibm.sbt.test.js.connections.activitystreams.api.PostEntryIntoACommunityStream;
+import com.ibm.sbt.test.js.connections.activitystreams.api.PostEntryWithEmbeddedExperience;
+import com.ibm.sbt.test.js.connections.activitystreams.api.SearchByFilters;
+import com.ibm.sbt.test.js.connections.activitystreams.api.SearchByQuery;
+import com.ibm.sbt.test.js.connections.activitystreams.api.SearchByTags;
+
+/**
+ * @author rajmeetbal
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+	PostEntry.class,
+	PostEntryIntoACommunityStream.class,
+	PostAStatusUpdate.class,
+	PostEntryWithEmbeddedExperience.class,
+//	GetMyActionableView.class,
+	GetMySavedView.class,
+	GetMyStatusUpdates.class,
+//	GetNotificationsForMe.class,
+//	GetNotificationsFromMe.class,
+	GetPublicActivityStream.class,
+//	GetResponsesToMyContent.class,
+	GetUpdatesFromACommunity.class,
+	GetUpdatesFromAUser.class,
+	GetUpdatesFromCommunitiesIFollow.class,
+//	GetUpdatesFromMyNetwork.class,
+	GetUpdatesFromPeopleIFollow.class,
+//	SearchByFilters.class,
+//	SearchByTags.class,
+//	SearchByQuery.class
+})
+public class ActivitiesStreamsTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ActivitiesTestSuite.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.activities.api.GetAllActivities;
+import com.ibm.sbt.test.js.connections.activities.api.GetCompletedActivities;
+import com.ibm.sbt.test.js.connections.activities.api.GetMyActivities;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetMyActivities.class, GetCompletedActivities.class, GetAllActivities.class })
+public class ActivitiesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/BookmarksRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/BookmarksRestTestSuite.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.bookmarks.rest.GetAllBookmarksList;
+import com.ibm.sbt.test.js.connections.bookmarks.rest.GetAllBookmarksXml;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetAllBookmarksList.class, GetAllBookmarksXml.class })
+public class BookmarksRestTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/CommunitiesRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/CommunitiesRestTestSuite.java
@@ -1,0 +1,36 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.communities.rest.GetMyCommunitiesXml;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetMyCommunitiesXml.class })
+public class CommunitiesRestTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/CommunitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/CommunitiesTestSuite.java
@@ -1,0 +1,95 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.communities.api.AddCommunityMember;
+import com.ibm.sbt.test.js.connections.communities.api.Community;
+import com.ibm.sbt.test.js.connections.communities.api.CommunityCreateBody;
+import com.ibm.sbt.test.js.connections.communities.api.CommunityEntryDataHandler;
+import com.ibm.sbt.test.js.connections.communities.api.CommunityFeedDataHandler;
+import com.ibm.sbt.test.js.connections.communities.api.CommunityInvitesFeedDataHandler;
+import com.ibm.sbt.test.js.connections.communities.api.CommunityMembersFeedDataHandler;
+import com.ibm.sbt.test.js.connections.communities.api.CreateCommunityInvalidTitle;
+import com.ibm.sbt.test.js.connections.communities.api.CreateCommunityJson;
+import com.ibm.sbt.test.js.connections.communities.api.CreateCommunityLoadIt;
+import com.ibm.sbt.test.js.connections.communities.api.CreateCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.CreateCommunityNew;
+import com.ibm.sbt.test.js.connections.communities.api.CrudCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.DeleteCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.GetCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.GetCommunityMembers;
+import com.ibm.sbt.test.js.connections.communities.api.GetMyCommunities;
+import com.ibm.sbt.test.js.connections.communities.api.GetMyInvites;
+import com.ibm.sbt.test.js.connections.communities.api.GetPublicCommunities;
+import com.ibm.sbt.test.js.connections.communities.api.GetSaveCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.GetSubCommunities;
+import com.ibm.sbt.test.js.connections.communities.api.NewSaveCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.RemoveCommunityMember;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunity;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunityJson;
+import com.ibm.sbt.test.js.connections.communities.api.UpdateCommunityTags;
+import com.ibm.sbt.test.js.connections.communities.api.ValidateBaseCommunitiesTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+    CommunityCreateBody.class,
+    CommunityEntryDataHandler.class, 
+    CommunityFeedDataHandler.class, 
+    CommunityInvitesFeedDataHandler.class,
+    CommunityMembersFeedDataHandler.class,
+    
+    //ValidateBaseCommunitiesTest.class,
+
+    GetPublicCommunities.class,
+    GetMyCommunities.class, 
+    GetMyInvites.class, 
+    GetCommunityMembers.class, 
+    GetSubCommunities.class,
+
+    GetCommunity.class, 
+    Community.class,
+
+    CreateCommunity.class,
+    CreateCommunityNew.class,
+    CreateCommunityJson.class,
+    CreateCommunityLoadIt.class,
+    CreateCommunityInvalidTitle.class,
+    DeleteCommunity.class,
+    UpdateCommunity.class,
+    UpdateCommunityJson.class,
+    UpdateCommunityTags.class,
+    NewSaveCommunity.class,
+    GetSaveCommunity.class,
+    CrudCommunity.class,
+    
+    AddCommunityMember.class,
+    RemoveCommunityMember.class
+})
+public class CommunitiesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/FilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/FilesTestSuite.java
@@ -1,0 +1,78 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.files.GetMyFileComments;
+import com.ibm.sbt.test.js.connections.files.LoadUpdateLockPinDeleteFile;
+import com.ibm.sbt.test.js.connections.files.UploadFile;
+import com.ibm.sbt.test.js.connections.files.api.AddCommentToFile;
+import com.ibm.sbt.test.js.connections.files.api.AddFilesToFolder;
+import com.ibm.sbt.test.js.connections.files.api.DeleteFile;
+import com.ibm.sbt.test.js.connections.files.api.FileAddComment;
+import com.ibm.sbt.test.js.connections.files.api.GetFile;
+import com.ibm.sbt.test.js.connections.files.api.GetFilesSharedByMe;
+import com.ibm.sbt.test.js.connections.files.api.GetFilesSharedWithMe;
+import com.ibm.sbt.test.js.connections.files.api.GetMyFiles;
+import com.ibm.sbt.test.js.connections.files.api.GetMyFolders;
+import com.ibm.sbt.test.js.connections.files.api.GetMyPinnedFiles;
+import com.ibm.sbt.test.js.connections.files.api.GetPublicFileComments;
+import com.ibm.sbt.test.js.connections.files.api.GetPublicFiles;
+import com.ibm.sbt.test.js.connections.files.api.LockAndUnlockFile;
+import com.ibm.sbt.test.js.connections.files.api.PinFileAndRemovePinFromFile;
+import com.ibm.sbt.test.js.connections.files.api.UpdateFile;
+
+/**
+ * @author Vineet Kanwal
+ * 
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 	
+		AddCommentToFile.class,
+		FileAddComment.class,
+		AddFilesToFolder.class,
+		DeleteFile.class,
+		GetFilesSharedByMe.class,
+		GetFilesSharedWithMe.class,
+		GetMyFiles.class,
+		GetMyFolders.class,
+		GetMyPinnedFiles.class,
+		GetPublicFileComments.class,
+		GetPublicFiles.class,
+		PinFileAndRemovePinFromFile.class,
+		LockAndUnlockFile.class,
+		UpdateFile.class,
+		GetFile.class,
+		com.ibm.sbt.test.js.connections.files.AddCommentToFile.class,
+		com.ibm.sbt.test.js.connections.files.GetFilesSharedByMe.class,
+		com.ibm.sbt.test.js.connections.files.GetFilesSharedWithMe.class,
+		GetMyFileComments.class,
+		com.ibm.sbt.test.js.connections.files.GetMyFiles.class,
+		com.ibm.sbt.test.js.connections.files.GetMyFolders.class,
+		com.ibm.sbt.test.js.connections.files.GetPublicFileComments.class,
+		com.ibm.sbt.test.js.connections.files.GetPublicFiles.class,
+		LoadUpdateLockPinDeleteFile.class,
+		UploadFile.class
+    })
+public class FilesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ForumsRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ForumsRestTestSuite.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.forums.rest.GetMyForums;
+import com.ibm.sbt.test.js.connections.forums.rest.GetMyForumsXml;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetMyForums.class, GetMyForumsXml.class })
+public class ForumsRestTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ForumsTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ForumsTestSuite.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.forums.api.GetForums;
+import com.ibm.sbt.test.js.connections.forums.api.GetMyForums;
+import com.ibm.sbt.test.js.connections.forums.api.GetPublicForums;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+	GetMyForums.class, 
+	GetPublicForums.class, 
+	GetForums.class })
+public class ForumsTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ProfilesRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ProfilesRestTestSuite.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.profiles.rest.ReadName;
+import com.ibm.sbt.test.js.connections.profiles.rest.ReadNameAndEmail;
+import com.ibm.sbt.test.js.connections.profiles.rest.ReadProfilePhoto;
+import com.ibm.sbt.test.js.connections.profiles.rest.ReadProfileXml;
+import com.ibm.sbt.test.js.connections.profiles.rest.ReadResponseHeaders;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ ReadName.class, ReadNameAndEmail.class, ReadProfilePhoto.class, ReadProfileXml.class, ReadResponseHeaders.class })
+public class ProfilesRestTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ProfilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/ProfilesTestSuite.java
@@ -1,0 +1,74 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.profiles.api.CheckProfileCache;
+import com.ibm.sbt.test.js.connections.profiles.api.CreateProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.DeleteProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.GetCachedProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.GetColleagues;
+import com.ibm.sbt.test.js.connections.profiles.api.GetPeopleManaged;
+import com.ibm.sbt.test.js.connections.profiles.api.GetProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.GetProfileDemonstrationSnippet;
+import com.ibm.sbt.test.js.connections.profiles.api.GetReportingChain;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileEntryDataHandler;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileEntryHCardFull;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileEntryHCardLite;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileEntryVCardFull;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileEntryVCardLite;
+import com.ibm.sbt.test.js.connections.profiles.api.ProfileFeedDataHandler;
+import com.ibm.sbt.test.js.connections.profiles.api.Search;
+import com.ibm.sbt.test.js.connections.profiles.api.UpdateProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.CreateAndDeleteProfile;
+import com.ibm.sbt.test.js.connections.profiles.api.UpdateProfileDemonstrationSnippet;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+    ProfileEntryDataHandler.class, 
+    ProfileFeedDataHandler.class, 
+    ProfileEntryVCardFull.class, 
+    ProfileEntryVCardLite.class, 
+    ProfileEntryHCardFull.class, 
+    ProfileEntryHCardLite.class,
+    GetProfile.class,
+    GetCachedProfile.class,
+    GetColleagues.class,
+    GetPeopleManaged.class,
+    GetReportingChain.class,
+    CreateProfile.class,
+    DeleteProfile.class,
+    UpdateProfile.class,
+    CreateAndDeleteProfile.class,
+    Search.class,
+    GetProfileDemonstrationSnippet.class,
+    UpdateProfileDemonstrationSnippet.class,
+    CheckProfileCache.class
+    })
+public class ProfilesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/SearchRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/SearchRestTestSuite.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.search.rest.ApplicationSearch;
+import com.ibm.sbt.test.js.connections.search.rest.DateSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyApplicationSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyDateSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyPeopleSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MySearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyTagSearch;
+import com.ibm.sbt.test.js.connections.search.rest.PeopleSearch;
+import com.ibm.sbt.test.js.connections.search.rest.Search;
+import com.ibm.sbt.test.js.connections.search.rest.TagSearch;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ Search.class, MySearch.class, PeopleSearch.class,
+		MyPeopleSearch.class, TagSearch.class, MyTagSearch.class,
+		ApplicationSearch.class, MyApplicationSearch.class, DateSearch.class,
+		MyDateSearch.class })
+public class SearchRestTestSuite {
+	@AfterClass
+	public static void cleanup() {
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/SearchTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/SearchTestSuite.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.test.js.connections.search.PeopleSearch;
+import com.ibm.sbt.test.js.connections.search.api.GetApplications;
+import com.ibm.sbt.test.js.connections.search.api.GetDates;
+import com.ibm.sbt.test.js.connections.search.api.GetMyApplications;
+import com.ibm.sbt.test.js.connections.search.api.GetMyDates;
+import com.ibm.sbt.test.js.connections.search.api.GetMyPeople;
+import com.ibm.sbt.test.js.connections.search.api.GetMyResults;
+import com.ibm.sbt.test.js.connections.search.api.GetMyTags;
+import com.ibm.sbt.test.js.connections.search.api.GetPeople;
+import com.ibm.sbt.test.js.connections.search.api.GetResults;
+import com.ibm.sbt.test.js.connections.search.api.GetTags;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ PeopleSearch.class, GetApplications.class, GetDates.class,
+		GetMyApplications.class, GetMyDates.class, GetMyPeople.class,
+		GetMyResults.class, GetMyTags.class, GetPeople.class, GetResults.class,
+		GetTags.class })
+public class SearchTestSuite {
+	@AfterClass
+	public static void cleanup() {
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetAllActivities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetAllActivities.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activities.api;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetAllActivities extends BaseActivitiesTest {
+
+    static final String SNIPPET_ID = "Social_Activities_API_GetAllActivities";
+    
+    public GetAllActivities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetAllActivities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        // TODO create soem activities
+        //Assert.assertFalse("Get my activities returned no activities", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetCompletedActivities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetCompletedActivities.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activities.api;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.connections.BaseActivitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetCompletedActivities extends BaseActivitiesTest {
+
+    static final String SNIPPET_ID = "Social_Activities_API_GetCompletedActivities";
+    
+    public GetCompletedActivities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetCompletedActivities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        // TODO create soem activities
+        //Assert.assertFalse("Get my activities returned no activities", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetMyActivities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/api/GetMyActivities.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activities.api;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyActivities extends BaseApiTest {
+
+    static final String SNIPPET_ID = "Social_Activities_API_GetMyActivities";
+    
+    public GetMyActivities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetMyActivities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        // TODO create soem activities
+        //Assert.assertFalse("Get my activities returned no activities", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/rest/GetMyActivities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/rest/GetMyActivities.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activities.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyActivities extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Activities_REST_Get_My_Activities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/rest/GetMyActivitiesXml.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activities/rest/GetMyActivitiesXml.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activities.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyActivitiesXml extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Activities_REST_Get_My_Activities_XML");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMyActionableView.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMyActionableView.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetMyActionableView extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetMyActionableView";
+
+    public GetMyActionableView() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetMyActionableView() {
+//    	createEntry("@me","@actions","@all");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetMyActionableView returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMySavedView.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMySavedView.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetMySavedView extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetMySavedView";
+
+    public GetMySavedView() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetMySavedView() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetMySavedView returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMyStatusUpdates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetMyStatusUpdates.java
@@ -1,0 +1,58 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.ClientServicesException;
+import com.ibm.sbt.services.endpoints.Endpoint;
+import com.ibm.sbt.services.endpoints.EndpointFactory;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetMyStatusUpdates extends BaseActivityStreamsTest {
+    
+	static final String SNIPPET_POST_ID = "Social_ActivityStreams_API_PostAStatusUpdate";
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetMyStatusUpdates";
+
+    public GetMyStatusUpdates() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetMyStatusUpdates() {
+    	JavaScriptPreviewPage postPreviewPage = executeSnippet(SNIPPET_POST_ID);
+        JsonJavaObject json = postPreviewPage.getJson();
+        String newUpdateId = json.getJsonObject("entry").getString("id");
+        Assert.assertNotNull("While testing GetMyStatusUpdates new Update Id found null", newUpdateId);
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetMyStatusUpdates returned no results", jsonList.isEmpty());
+        if(!jsonList.isEmpty()){
+        	Assert.assertFalse("While testing GetMyStatusUpdates latest created status update is not found in the list of status updates", !isLatestEntryFound(jsonList, newUpdateId));
+        }	
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetNotificationsForMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetNotificationsForMe.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetNotificationsForMe extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetNotificationsForMe";
+
+    public GetNotificationsForMe() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetNotificationsForMe() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetNotificationsForMe returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetNotificationsFromMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetNotificationsFromMe.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetNotificationsFromMe extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetNotificationsFromMe";
+
+    public GetNotificationsFromMe() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetNotificationsFromMe() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetNotificationsFromMe returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetPublicActivityStream.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetPublicActivityStream.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetPublicActivityStream extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetPublicActivityStream";
+
+    public GetPublicActivityStream() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetPublicActivityStream() {
+    	createEntry("@public","@all","@all");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetPublicActivityStream returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetResponsesToMyContent.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetResponsesToMyContent.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetResponsesToMyContent extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetResponsesToMyContent";
+
+    public GetResponsesToMyContent() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetResponsesToMyContent() {
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetResponsesToMyContent returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromACommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromACommunity.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetUpdatesFromACommunity extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetUpdatesFromACommunity";
+
+    public GetUpdatesFromACommunity() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetUpdatesFromACommunity() {
+    	String commId = getProperty("sample.communityId");
+    	createEntry("urn:lsid:lconn.ibm.com:communities.community:"+commId, "@all", "@all");
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetUpdatesFromACommunity returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromAUser.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromAUser.java
@@ -1,0 +1,54 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetUpdatesFromAUser extends BaseActivityStreamsTest {
+    
+	static final String SNIPPET_POST_ID = "Social_ActivityStreams_API_PostAStatusUpdate";
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetUpdatesFromAUser";
+
+    public GetUpdatesFromAUser() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test @Ignore
+    public void testGetUpdatesFromAUser() {
+    	JavaScriptPreviewPage postPreviewPage = executeSnippet(SNIPPET_POST_ID);
+        JsonJavaObject json = postPreviewPage.getJson();
+        String newUpdateId = json.getJsonObject("entry").getString("id");
+        Assert.assertNotNull("While testing GetMyStatusUpdates new Update Id found null", newUpdateId);
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetUpdatesFromAUser returned no results", jsonList.isEmpty());
+        if(!jsonList.isEmpty()){
+        	Assert.assertFalse("While testing GetMyStatusUpdates latest created status update is not found in the list of status updates", !isLatestEntryFound(jsonList, newUpdateId));
+        }	
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromCommunitiesIFollow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromCommunitiesIFollow.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetUpdatesFromCommunitiesIFollow extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetUpdatesFromCommunitiesIFollow";
+
+    public GetUpdatesFromCommunitiesIFollow() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetUpdatesFromCommunitiesIFollow() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetUpdatesFromAUser returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromMyNetwork.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromMyNetwork.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetUpdatesFromMyNetwork extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetUpdatesFromMyNetwork";
+
+    public GetUpdatesFromMyNetwork() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetUpdatesFromMyNetwork() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetUpdatesFromMyNetwork returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromPeopleIFollow.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/GetUpdatesFromPeopleIFollow.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class GetUpdatesFromPeopleIFollow extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_GetUpdatesFromPeopleIFollow";
+
+    public GetUpdatesFromPeopleIFollow() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testGetUpdatesFromPeopleIFollow() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("GetUpdatesFromPeopleIFollow returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostAStatusUpdate.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostAStatusUpdate.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 19 Mar 2013
+ */
+public class PostAStatusUpdate extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_PostAStatusUpdate";
+    
+    public PostAStatusUpdate() {
+    	postEntry = false;
+    }
+
+    @Test
+    public void testPostAStatusUpdate() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNotNull(json.getJsonObject("entry").getString("id"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntry.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntry.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 19 Mar 2013
+ */
+public class PostEntry extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_PostEntry";
+    
+    public PostEntry() {
+    	postEntry = false;
+    }
+
+    @Test
+    public void testPostEntry() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNotNull(json.getJsonObject("entry").getString("id"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntryIntoACommunityStream.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntryIntoACommunityStream.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 19 Mar 2013
+ */
+public class PostEntryIntoACommunityStream extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_PostEntryIntoACommunityStream";
+    
+    public PostEntryIntoACommunityStream() {
+    	postEntry = false;
+    }
+
+    @Test
+    public void testPostEntryIntoACommunityStream() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNotNull(json.getJsonObject("entry").getString("id"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntryWithEmbeddedExperience.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/PostEntryWithEmbeddedExperience.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 19 Mar 2013
+ */
+public class PostEntryWithEmbeddedExperience extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_PostEntryWithEmbeddedExperience";
+    
+    public PostEntryWithEmbeddedExperience() {
+    	postEntry = false;
+    }
+
+    @Test
+    public void testPostEntryWithEmbeddedExperience() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNotNull(json.getJsonObject("entry").getString("id"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByFilters.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByFilters.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class SearchByFilters extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_SearchByFilters";
+
+    public SearchByFilters() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testSearchByFilters() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("SearchByFilters returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByQuery.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByQuery.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class SearchByQuery extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_SearchByQuery";
+
+    public SearchByQuery() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testSearchByQuery() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("SearchByQuery returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/activitystreams/api/SearchByTags.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.activitystreams.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.connections.BaseActivityStreamsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author rajmeetbal
+ *  
+ * @date 08 May 2013
+ */
+public class SearchByTags extends BaseActivityStreamsTest {
+    
+    static final String SNIPPET_ID = "Social_ActivityStreams_API_SearchByTags";
+
+    public SearchByTags() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testSearchByTags() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("SearchByTags returned no results", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/bookmarks/rest/GetAllBookmarksList.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/bookmarks/rest/GetAllBookmarksList.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.bookmarks.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class GetAllBookmarksList extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Bookmarks_REST_Get_All_Bookmarks_List");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/bookmarks/rest/GetAllBookmarksXml.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/bookmarks/rest/GetAllBookmarksXml.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.bookmarks.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class GetAllBookmarksXml extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Bookmarks_REST_Get_All_Bookmarks_XML");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/AddRemoveCommunityMembers.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/AddRemoveCommunityMembers.java
@@ -1,0 +1,214 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 7 Mar 2013
+ */
+public class AddRemoveCommunityMembers extends BaseTest {
+    
+	public AddRemoveCommunityMembers() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testLoadCommunity() {
+        AddRemoveMembersPage crudPage = launchSnippet();
+        String uuid = crudPage.getLoadedCommunityId();
+        Assert.assertNotNull("Unable to load community", uuid);
+    }
+    
+    @Override
+    public WebElement waitForResult(int timeout) {
+    	return waitForText("success", "Sucessfully loaded community members for:", timeout);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+        return "success";
+    }
+
+    // Internals
+
+    private AddRemoveMembersPage launchSnippet() {
+        ResultPage resultPage = launchSnippet("Social_Communities_Add_Remove_Community_Members");
+
+        waitForText("success", "Sucessfully loaded community members for:", 20);
+
+        return new AddRemoveMembersPage(resultPage);
+    }
+
+    /*
+     * Page object for the Social_Communities_Add_Remove_Community_Members
+     * snippet
+     */
+    class AddRemoveMembersPage extends BaseResultPage {
+
+        private ResultPage delegate;
+
+        public AddRemoveMembersPage(ResultPage delegate) {
+            this.delegate = delegate;
+
+            setWebDriver(delegate.getWebDriver());
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+         */
+        @Override
+        public String getText() {
+            return delegate.getText();
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+         * ()
+         */
+        @Override
+        public WebElement getWebElement() {
+            return delegate.getWebElement();
+        }
+
+        public WebElement getSuccess() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("success"));
+        }
+
+        public WebElement getError() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("error"));
+        }
+
+        public WebElement getCommunityId() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityId"));
+        }
+
+        public WebElement getCommunityTitle() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityTitle"));
+        }
+
+        public WebElement getCommunityMembers() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("membersList"));
+        }
+
+        public WebElement getMemberEmail() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("memberEmail"));
+        }
+
+        public WebElement getRemoveBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("removeBtn"));
+        }
+
+        public WebElement getRefreshBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("refreshBtn"));
+        }
+
+        public WebElement getAddBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("addBtn"));
+        }
+
+        /**
+         * @param tags
+         */
+        public void setMemberEmail(String email) {
+            WebElement communityTags = getMemberEmail();
+            communityTags.clear();
+            communityTags.sendKeys(email);
+        }
+
+        public void clickRemove() {
+            getRemoveBtn().click();
+        }
+
+        public void clickrefresh() {
+            getRefreshBtn().click();
+        }
+
+        public void clickAdd() {
+            getAddBtn().click();
+        }
+
+        /**
+         * Add a new member to the current community
+         */
+        public boolean addMember() {
+            String email = getProperty("sample.email2");
+            return addMember(email);
+        }
+
+        /**
+         * Add a new member to the current community
+         */
+        public boolean addMember(String email) {
+            setMemberEmail(email);
+
+            clickAdd();
+
+            waitForText("success", "Sucessfully loaded community members for:", 30);
+
+            String members = getCommunityMembers().getText();
+            
+            Assert.assertNotNull("Failed to load community members", members);
+
+            return members.contains(email);
+        }
+
+        /**
+         * Return the community id of the community which was loaded
+         */
+        public String getLoadedCommunityId() {
+            waitForText("success", "Sucessfully loaded community members for:", 30);
+
+            String text = getSuccess().getText();
+
+            Assert.assertNotNull("Failed to load community members", text);
+
+            return text.substring("Sucessfully loaded community members for: ".length());
+        }
+
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/CreateUpdateDeleteCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/CreateUpdateDeleteCommunity.java
@@ -1,0 +1,313 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 7 Mar 2013
+ */
+public class CreateUpdateDeleteCommunity extends BaseTest {
+
+    public CreateUpdateDeleteCommunity() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testLoadCommunity() {
+        CreateUpdateDeletePage crudPage = launchSnippet();
+        String uuid = crudPage.getLoadedCommunityId();
+        Assert.assertNotNull("Unable to load community", uuid);
+    }
+
+    @Test
+    public void testCreateCommunity() {
+        CreateUpdateDeletePage crudPage = launchSnippet();
+        String uuid = crudPage.createCommunity();
+        Assert.assertNotNull("Unable to create new community", uuid);
+        boolean deleted = crudPage.deleteCommunity();
+        Assert.assertTrue("Unable to delete a community", deleted);
+    }
+
+    @Test
+    public void testUpdateCommunity() {
+        CreateUpdateDeletePage crudPage = launchSnippet();
+        String uuid = crudPage.createCommunity();
+        Assert.assertNotNull("Unable to create new community", uuid);
+        boolean updated = crudPage.updateCommunity();
+        Assert.assertTrue("Unable to update a community", updated);
+        boolean deleted = crudPage.deleteCommunity();
+        Assert.assertTrue("Unable to delete a community", deleted);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+        return "idWithText";
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+        return "communityId";
+    }
+
+    // Internals
+
+    private CreateUpdateDeletePage launchSnippet() {
+        ResultPage resultPage = launchSnippet("Social_Communities_Create_Update_Delete_Community");
+
+        waitForText("success", "Successfully loaded community:", 20);
+
+        return new CreateUpdateDeletePage(resultPage);
+    }
+
+    /*
+     * Page object for the
+     * Social_Communities_Create_Update_Delete_Community snippet
+     */
+    class CreateUpdateDeletePage extends BaseResultPage {
+
+        private ResultPage delegate;
+
+        public CreateUpdateDeletePage(ResultPage delegate) {
+            this.delegate = delegate;
+
+            setWebDriver(delegate.getWebDriver());
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+         */
+        @Override
+        public String getText() {
+            return delegate.getText();
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+         * ()
+         */
+        @Override
+        public WebElement getWebElement() {
+            return delegate.getWebElement();
+        }
+
+        public WebElement getSuccess() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("success"));
+        }
+
+        public WebElement getError() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("error"));
+        }
+
+        public WebElement getCommunityId() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityId"));
+        }
+
+        public WebElement getCommunityTitle() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityTitle"));
+        }
+
+        public WebElement getCommunityContent() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityContent"));
+        }
+
+        public WebElement getCommunityTags() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("communityTags"));
+        }
+
+        public WebElement getLoadBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("loadBtn"));
+        }
+
+        public WebElement getCreateBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("createBtn"));
+        }
+
+        public WebElement getUpdateBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("updateBtn"));
+        }
+
+        public WebElement getDeleteBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("deleteBtn"));
+        }
+
+        public void setCommunityTags(String tags) {
+            WebElement communityTags = getCommunityTags();
+            communityTags.clear();
+            communityTags.sendKeys(tags);
+        }
+
+        public void setCommunityContent(String content) {
+            WebElement communityContent = getCommunityContent();
+            communityContent.clear();
+            communityContent.sendKeys(content);
+        }
+
+        public void setCommunityTitle(String title) {
+            WebElement communityTitle = getCommunityTitle();
+            communityTitle.clear();
+            communityTitle.sendKeys(title);
+        }
+
+        public void clickCreate() {
+            getCreateBtn().click();
+        }
+
+        public void clickUpdate() {
+            getUpdateBtn().click();
+        }
+
+        public void clickDelete() {
+            getDeleteBtn().click();
+        }
+
+        /**
+         * Create a new community and return the uuid if successful and
+         * otherwise return null
+         */
+        public String createCommunity() {
+            String title = "Test Automation Community - " + System.currentTimeMillis();
+            String contents = "The community was created using the CreateUpdateDeleteCommunity unit test";
+            String tags = "tagA,tagB,tagC";
+            return createCommunity(title, contents, tags);
+        }
+
+        /**
+         * Create a new community and return the uuid if successful and
+         * otherwise return null
+         */
+        public String createCommunity(String title, String content, String tags) {
+            setCommunityTitle(title);
+            setCommunityContent(content);
+            setCommunityTags(tags);
+
+            clickCreate();
+
+            return getCreatedCommunityId();
+        }
+
+        /**
+         * Update the current community and return the true if successful and
+         * otherwise return false
+         */
+        public boolean updateCommunity() {
+            String title = "Updated Test Automation Community - " + System.currentTimeMillis();
+            String contents = "The community was updated using the CreateUpdateDeleteCommunity unit test";
+            String tags = "tagA,tagB,tagC,tagD";
+            return updateCommunity(title, contents, tags);
+        }
+
+        /**
+         * Update the current community and return the true if successful and
+         * otherwise return false
+         */
+        public boolean updateCommunity(String title, String content, String tags) {
+            setCommunityTitle(title);
+            setCommunityContent(content);
+            setCommunityTags(tags);
+
+            clickUpdate();
+
+            WebElement webElement = waitForText("success", "Successfully updated community:", 20);
+
+            String text = webElement.getText();
+
+            return text.startsWith("Successfully updated community:");
+        }
+
+        /**
+         * Delete the current community and return the true if successful and
+         * otherwise return false
+         */
+        public boolean deleteCommunity() {
+            clickDelete();
+
+            WebElement webElement = waitForText("success", "Successfully deleted community:", 20);
+
+            String text = webElement.getText();
+
+            return text.startsWith("Successfully deleted community:");
+        }
+
+        /**
+         * Return the community id of the community that was last created
+         */
+        public String getCreatedCommunityId() {
+            WebElement webElement = waitForText("success", "Successfully created community:", 20);
+
+            String text = webElement.getText();
+
+            if (text.startsWith("Successfully created community:")) {
+                return text.substring("Successfully created community: ".length());
+            } else {
+                return null;
+            }
+        }
+
+        /**
+         * Return the community id of the community that was last loaded
+         */
+        public String getLoadedCommunityId() {
+            WebElement webElement = waitForText("success", "Successfully loaded community:", 20);
+
+            String text = webElement.getText();
+
+            if (text.startsWith("Successfully loaded community:")) {
+                return text.substring("Successfully loaded community: ".length());
+            } else {
+                return null;
+            }
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/GetMyCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/GetMyCommunities.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class GetMyCommunities extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Communities_Get_My_Communities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/GetPublicCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/GetPublicCommunities.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class GetPublicCommunities extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Communities_Get_Public_Communities");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/AddCommunityMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/AddCommunityMember.java
@@ -1,0 +1,101 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class AddCommunityMember extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_AddCommunityMember";
+
+    @Test
+    public void testAddMember() {
+    	String id2 = getProperty("sample.id2");
+    	if (environment.isSmartCloud()) {
+    		id2 = getProperty("smartcloud.id2");
+    	}
+    	
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.id2", id2);
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(id2, json.getString("id"));
+        Assert.assertEquals("member", json.getString("getRole"));
+        if (!environment.isSmartCloud()) {
+        	Assert.assertTrue(getProperty("sample.email2").equalsIgnoreCase(json.getString("getEmail")));
+        }
+        Assert.assertEquals(id2, json.getString("getUserid"));
+    }
+
+    @Test
+    public void testAddMemberError1() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.id2", "12345");
+            
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Unknown user.", json.getString("message"));
+    }
+
+    @Test
+    public void testAddMemberError2() {
+    	if (environment.isSmartCloud()) {
+    		// status 403 causes login
+    		return;
+    	}
+
+    	String id1 = getProperty("sample.id1");
+    	if (environment.isSmartCloud()) {
+    		id1 = getProperty("smartcloud.id1");
+    	}
+    	
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.id2", id1);
+            
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        int code = json.getInt("code");
+        Assert.assertTrue(403 == code || 400 == code);
+        Assert.assertEquals("You are not authorized to perform the requested action.", json.getString("message"));
+    }
+
+    @Test
+    public void testAddMemberErrorInvalid() {
+        setAuthType(AuthType.NONE);
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.id2", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNotNull("No response from test snippet", json);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, member with userid or email must be specified.", json.getString("message"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/Community.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/Community.java
@@ -1,0 +1,61 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class Community extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_Community";
+    
+    public Community() {
+
+    }
+
+    @Test
+    public void testCommunity() {
+        AuthType authType = environment.isSmartCloud() ? AuthType.AUTO_DETECT : AuthType.NONE;
+        setAuthType(authType);
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+            assertCommunityValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#waitForResult(int)
+     */
+    @Override
+    public WebElement waitForResult(int timeout) {
+        return waitForJsonList(2, timeout);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityCreateBody.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityCreateBody.java
@@ -1,0 +1,51 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CommunityCreateBody extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityCreateBody";
+    
+    static final String RequestBody = "\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<entry xmlns=\"http://www.w3.org/2005/Atom\" xmlns:app=\"http://www.w3.org/2007/app\" xmlns:snx=\"http://www.ibm.com/xmlns/prod/sn\">\n<title type=\"text\">Community Title</title>\n<content type=\"html\">Community Content</content>\n<category term=\"community\" scheme=\"http://www.ibm.com/xmlns/prod/sn/type\"></category>\n\n<category term=\"tag1\"></category>\n\n<category term=\"tag2\"></category>\n\n<category term=\"tag3\"></category>\n\n<snx:communityType>public</snx:communityType>\n\n\n</entry>\n";
+
+    public CommunityCreateBody() {
+        setAuthType(AuthType.NONE);
+    }
+
+    @Test
+    public void testCreateBody() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse(jsonList.isEmpty());
+        Assert.assertEquals(RequestBody, ((JsonJavaObject)jsonList.get(0)).getString("requestBody"));
+        Assert.assertEquals(RequestBody, ((JsonJavaObject)jsonList.get(1)).getString("requestBody"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityEntryDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityEntryDataHandler.java
@@ -1,0 +1,60 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CommunityEntryDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityEntryDataHandler";
+
+    @Test
+    public void testCommunityEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        
+        Assert.assertEquals("http://communities.ibm.com:2006/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("getEntityId"));
+        Assert.assertEquals("http://communities.ibm.com:2006/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityUuid")); 
+        Assert.assertEquals("Public Community 2", json.getString("title"));
+        Assert.assertEquals("This is a test public community", json.getString("summary"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/html/communityview?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityUrl"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityAtomUrl"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/html/image?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f&lastMod=1364454917628", json.getString("logoUrl"));
+        //TODO: fix after domino 90 switch Assert.assertEquals(new String[] { "community","tag1","tag2","tag3" }, json.getAsArray("tags").toArray());
+        Assert.assertEquals("<p dir=\"ltr\">\r\n\t\tThis is a test public community</p>", json.getString("content"));
+        Assert.assertEquals(7, json.getInt("memberCount"));
+        Assert.assertEquals("public", json.getString("communityType"));
+        Assert.assertEquals("2013-03-28T07:15:17.628Z", json.getString("published"));
+        Assert.assertEquals("2013-03-28T07:15:20.291Z", json.getString("updated"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("authorUid"));
+        Assert.assertEquals("Frank Adams", json.getString("authorName"));
+        Assert.assertEquals("frankadams@renovations.com", json.getString("authorEmail"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("contributorUserid"));
+        Assert.assertEquals("Frank Adams", json.getString("contributorName"));
+        Assert.assertEquals("frankadams@renovations.com", json.getString("contributorEmail"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityFeedDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityFeedDataHandler.java
@@ -1,0 +1,69 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CommunityFeedDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityFeedDataHandler";
+
+    @Test
+    public void testCommunityFeedDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(5, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(4);
+        Assert.assertEquals("http://communities.ibm.com:2006/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("getEntityId"));
+        Assert.assertEquals("http://communities.ibm.com:2006/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityUuid")); 
+        Assert.assertEquals("Public Community 2", json.getString("title"));
+        Assert.assertEquals("This is a test public community", json.getString("summary"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/html/communityview?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityUrl"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/atom/community/instance?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f", json.getString("communityAtomUrl"));
+        Assert.assertEquals("https://qs.renovations.com:444/communities/service/html/image?communityUuid=07c9947b-bdf3-4106-95d5-949bd5e0fd9f&lastMod=1364454917628", json.getString("logoUrl"));
+        //TODO: fix after switch to domino 90 Assert.assertEquals(new String[] { "community","tag1","tag2","tag3" }, json.getAsArray("tags").toArray());
+        // TODO validate the content is not returned as part of the feed
+        //Assert.assertEquals("<p dir=\"ltr\">\r\n\t\tThis is a test public community</p>", json.getString("content"));
+        Assert.assertEquals(7, json.getInt("memberCount"));
+        Assert.assertEquals("public", json.getString("communityType"));
+        Assert.assertEquals("2013-03-28T07:15:17.628Z", json.getString("published"));
+        Assert.assertEquals("2013-03-28T07:15:20.291Z", json.getString("updated"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("authorUid"));
+        Assert.assertEquals("Frank Adams", json.getString("authorName"));
+        Assert.assertEquals("frankadams@renovations.com", json.getString("authorEmail"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("contributorUserid"));
+        Assert.assertEquals("Frank Adams", json.getString("contributorName"));
+        Assert.assertEquals("frankadams@renovations.com", json.getString("contributorEmail"));
+    }
+
+}
+
+
+
+
+

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityInvitesFeedDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityInvitesFeedDataHandler.java
@@ -1,0 +1,51 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CommunityInvitesFeedDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityInvitesFeedDataHandler";
+
+    @Test
+    public void testCommunityFeedDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(3, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals("urn:lsid:ibm.com:communities:invite-bf9a49e2-e961-45ad-8b8a-edacce62b3c9-21d28e8a-4af8-47c7-913c-d4194e0a7664", json.getString("getEntityId"));
+        Assert.assertEquals("Invitation for Frank Adams to Lucilles Restricted Community 3", json.getString("title"));
+        Assert.assertEquals("2013-03-31T14:19:13.671Z", json.getString("updated"));
+        Assert.assertEquals("662B6E42-3313-8316-4825-7A7000268F34", json.getString("authorUserid"));
+        Assert.assertEquals("Lucille Suarez", json.getString("authorName"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("contributorUserid"));
+        Assert.assertEquals("Frank Adams", json.getString("contributorName"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityMembersFeedDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CommunityMembersFeedDataHandler.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CommunityMembersFeedDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityMembersFeedDataHandler";
+
+    @Test
+    public void testCommunityFeedDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(5, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("getEntityId"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("userid")); 
+        Assert.assertEquals("frankadams@renovations.com", json.getString("email"));
+        Assert.assertEquals("Frank Adams", json.getString("name"));
+        Assert.assertEquals("owner", json.getString("role"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunity.java
@@ -1,0 +1,62 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class CreateCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateCommunity";
+
+    public CreateCommunity() {
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCreateCommunity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+
+        String communityUuid = json.getString("getCommunityUuid");
+        community = getCommunity(communityUuid);
+        
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(community.getTitle(), json.getString("getTitle"));
+        Assert.assertEquals(community.getSummary(), json.getString("getSummary"));
+        Assert.assertEquals(community.getCommunityUrl(), json.getString("getCommunityUrl"));
+        Assert.assertEquals(community.getLogoUrl(), json.getString("getLogoUrl"));
+        Assert.assertEquals(community.getMemberCount(), json.getInt("getMemberCount"));
+        Assert.assertEquals(community.getCommunityType(), json.getString("getCommunityType"));
+        Assert.assertEquals(community.getAuthor().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+        Assert.assertEquals(community.getAuthor().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+        Assert.assertEquals(community.getAuthor().getUserid(), json.getJsonObject("getAuthor").getString("authorUserid"));
+        Assert.assertEquals(community.getContributor().getName(), json.getJsonObject("getContributor").getString("contributorName"));
+        Assert.assertEquals(community.getContributor().getEmail(), json.getJsonObject("getContributor").getString("contributorEmail"));
+        Assert.assertEquals(community.getContributor().getUserid(), json.getJsonObject("getContributor").getString("contributorUserid"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityInvalidTitle.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityInvalidTitle.java
@@ -1,0 +1,64 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CreateCommunityInvalidTitle extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateCommunityInvalidTitle";
+
+    public CreateCommunityInvalidTitle() {
+        setAuthType(AuthType.AUTO_DETECT);
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCreateCommunityInvalidTitle() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID, 10000);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        String communityUuid = json.getString("getCommunityUuid");
+        Assert.assertNotNull(communityUuid);
+        json = (JsonJavaObject)jsonList.get(1);
+        String message = json.getString("message");
+        Assert.assertEquals("A community with the requested name already exists, choose a different name and resubmit.", message);
+        deleteCommunity(communityUuid);
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#waitForResult(int)
+     */
+    @Override
+    public WebElement waitForResult(int timeout) {
+        return waitForJsonList(2, timeout);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityJson.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityJson.java
@@ -1,0 +1,55 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CreateCommunityJson extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateCommunityNew";
+
+    public CreateCommunityJson() {
+        setAuthType(AuthType.AUTO_DETECT);
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCreateCommunityJson() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID, 10000);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+
+        String communityUuid = json.getString("getCommunityUuid");
+        Assert.assertNotNull(communityUuid);
+    
+        deleteCommunity(communityUuid);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityLoadIt.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityLoadIt.java
@@ -1,0 +1,66 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CreateCommunityLoadIt extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateCommunityLoadIt";
+
+    public CreateCommunityLoadIt() {
+        setAuthType(AuthType.AUTO_DETECT);
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCreateCommunityLoadIt() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID, 10000);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        String communityUuid = null;
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            communityUuid = json.getString("getCommunityUuid");
+            Assert.assertNotNull(communityUuid);
+        }
+        
+        deleteCommunity(communityUuid);
+    }
+
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#waitForResult(int)
+     */
+    @Override
+    public WebElement waitForResult(int timeout) {
+        return waitForJsonList(2, timeout);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityNew.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CreateCommunityNew.java
@@ -1,0 +1,55 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class CreateCommunityNew extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateCommunityJson";
+
+    public CreateCommunityNew() {
+        setAuthType(AuthType.AUTO_DETECT);
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCreateCommunityJson() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID, 10000);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+
+        String communityUuid = json.getString("getCommunityUuid");
+        Assert.assertNotNull(communityUuid);
+        
+        deleteCommunity(communityUuid);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CrudCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/CrudCommunity.java
@@ -1,0 +1,70 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class CrudCommunity extends BaseCommunitiesTest {
+    
+    static final String CREATE_SNIPPET_ID = "Social_Communities_API_CreateCommunity";
+    static final String GET_SNIPPET_ID = "Social_Communities_API_GetCommunity";
+    static final String DELETE_SNIPPET_ID = "Social_Communities_API_DeleteCommunity";
+
+    public CrudCommunity() {
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCrudCommunity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(CREATE_SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        String communityUuid = json.getString("getCommunityUuid");
+        community = getCommunity(communityUuid);
+        assertCommunityValid(json);
+        
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        previewPage = executeSnippet(GET_SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        assertCommunityValid((JsonJavaObject)jsonList.get(0));
+        Assert.assertEquals(community.getCommunityUuid(), ((JsonJavaObject)jsonList.get(1)).getString("entityId"));
+        
+        addSnippetParam("sample.communityId2", community.getCommunityUuid());
+        previewPage = executeSnippet(DELETE_SNIPPET_ID);
+        json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("communityUuid"));
+        
+        community = getCommunity(community.getCommunityUuid(), false);
+        Assert.assertNull("Delete community is still available", community);
+        
+        // community has already been deleted
+        community = null;
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/DeleteCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/DeleteCommunity.java
@@ -1,0 +1,84 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class DeleteCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_DeleteCommunity";
+
+    @Test
+    public void testDeleteCommunity() {
+        addSnippetParam("sample.communityId2", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("communityUuid"));
+        
+        // community has already been deleted
+        community = null;
+    }
+    
+    @Test
+    public void testConfirmDeleteCommunity() {
+        addSnippetParam("sample.communityId2", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("communityUuid"));
+        
+        community = getCommunity(community.getCommunityUuid(), false);
+        Assert.assertNull("Delete community is still available", community);
+        
+        // community has already been deleted
+        community = null;
+    }
+    
+    @Test
+    public void testDeleteCommunityError() {
+        addSnippetParam("sample.communityId2", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The referenced community does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testDeleteCommunityInvalidArg() {
+        setAuthType(AuthType.NONE);
+        addSnippetParam("sample.communityId2", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected communityUuid.", json.getString("message"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetCommunity.java
@@ -1,0 +1,72 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetCommunity";
+
+    public GetCommunity() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetCommunity() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        assertCommunityValid((JsonJavaObject)jsonList.get(0));
+        Assert.assertEquals(community.getCommunityUuid(), ((JsonJavaObject)jsonList.get(1)).getString("entityId"));
+    }
+    
+    @Test
+    public void testGetCommunityError() {
+        addSnippetParam("sample.communityId", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The community which this resource or page is associated with does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testGetCommunityInvalidArg() {
+        addSnippetParam("sample.communityId", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected communityUuid.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetCommunityMembers.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetCommunityMembers.java
@@ -1,0 +1,76 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Member;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetCommunityMembers extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetCommunityMembers";
+
+    public GetCommunityMembers() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetCommunityMembers() {
+    	String name1 = getProperty("sample.displayName1");
+    	String userid1 = getProperty("sample.userId1");
+    	String email1 = getProperty("sample.email1");
+    	String name2 = getProperty("sample.displayName2");
+    	String userid2 = getProperty("sample.userId2");
+    	String email2 = getProperty("sample.email2");
+    	if (environment.isSmartCloud()) {
+        	name1 = getProperty("smartcloud.displayName1");
+        	userid1 = getProperty("smartcloud.userId1");
+        	email1 = getProperty("smartcloud.email1");
+        	name2 = getProperty("smartcloud.displayName2");
+        	userid2 = getProperty("smartcloud.userId2");
+        	email2 = getProperty("smartcloud.email2");
+    	}
+    	
+    	String id = getProperty("sample.email2");
+    	if (environment.isSmartCloud()) {
+    		id = getProperty("smartcloud.id2");
+    	}
+        addMember(community, id, "member");
+            	
+    	addSnippetParam("sample.communityId", community.getCommunityUuid());
+    	
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("Get community members returned no members", jsonList.isEmpty());
+        Assert.assertEquals(2, jsonList.size());
+        assertMemberValid((JsonJavaObject)jsonList.get(0), community.getCommunityUuid(), 
+        		name1, userid1, email1, "owner");
+        assertMemberValid((JsonJavaObject)jsonList.get(1), community.getCommunityUuid(), 
+        		name2, userid2, email2, "member");        
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMember.java
@@ -1,0 +1,90 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMember extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetMember";
+
+    public GetMember() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetMember() {
+    	String name1 = getProperty("sample.displayName1");
+    	String userid1 = getProperty("sample.userId1");
+    	String email1 = getProperty("sample.email1");
+    	if (environment.isSmartCloud()) {
+        	name1 = getProperty("smartcloud.displayName1");
+        	userid1 = getProperty("smartcloud.userId1");
+        	email1 = getProperty("smartcloud.email1");
+    	}
+    	
+    	String id = getProperty("sample.email1");
+    	if (environment.isSmartCloud()) {
+    		id = getProperty("smartcloud.id1");
+    	}
+    	
+    	addSnippetParam("sample.communityId", community.getCommunityUuid());
+    	addSnippetParam("sample.id1", id);  
+    	
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        assertMemberValid((JsonJavaObject)jsonList.get(0), community.getCommunityUuid(), 
+        		name1, userid1, email1, "owner");
+        Assert.assertEquals(id, ((JsonJavaObject)jsonList.get(1)).getString("entityId"));  
+    }
+    
+    @Test
+    public void testGetMemberError() {
+    	addSnippetParam("sample.communityId", community.getCommunityUuid());
+    	addSnippetParam("sample.id1", "foo");  
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The community which this resource or page is associated with does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testGetMemberInvalidArg() {
+    	addSnippetParam("sample.communityId", community.getCommunityUuid());
+    	addSnippetParam("sample.id1", "");  
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected communityUuid.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMyCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMyCommunities.java
@@ -1,0 +1,65 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyCommunities extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetMyCommunities";
+    
+    public GetMyCommunities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetMyCommunities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("Get my communities returned no communities", jsonList.isEmpty());
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Assert.assertNotNull(json.getString("getCommunityUuid"));
+            Assert.assertNotNull(json.getString("getTitle"));
+            Assert.assertNotNull(json.getString("getCommunityType"));
+            Assert.assertNotNull(json.getString("getAuthor"));
+            Assert.assertNotNull(json.getString("getContributor"));
+            //Assert.assertNotNull(json.getString("getSummary"));
+            Assert.assertNotNull(json.getString("getCommunityUrl"));
+            Assert.assertNotNull(json.getString("getLogoUrl"));
+            Assert.assertNotNull(json.getString("getMemberCount"));
+            Assert.assertNotNull(json.getString("getPublished"));
+            Assert.assertNotNull(json.getString("getUpdated"));
+            Assert.assertNotNull(json.getString("getSubCommunities"));
+            Assert.assertNotNull(json.getString("getMembers"));
+            Assert.assertNotNull(json.getString("getMember"));
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMyInvites.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetMyInvites.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyInvites extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetMyInvites";
+    
+    public GetMyInvites() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetMyInvites() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        // TODO send some invites
+        //Assert.assertFalse("Get my invites returned no invites", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetPublicCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetPublicCommunities.java
@@ -1,0 +1,63 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetPublicCommunities extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetPublicCommunities";
+
+    public GetPublicCommunities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetPublicCommunities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertFalse("Get public communities returned no communities", jsonList.isEmpty());
+        for (int i=0; i<jsonList.size(); i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Assert.assertNotNull(json.getString("getCommunityUuid"));
+            Assert.assertNotNull(json.getString("getTitle"));
+            Assert.assertNotNull(json.getString("getCommunityType"));
+            Assert.assertNotNull(json.getString("getAuthor"));
+            Assert.assertNotNull(json.getString("getContributor"));
+            Assert.assertNotNull(json.getString("getCommunityUrl"));
+            Assert.assertNotNull(json.getString("getLogoUrl"));
+            Assert.assertNotNull(json.getString("getMemberCount"));
+            Assert.assertNotNull(json.getString("getPublished"));
+            Assert.assertNotNull(json.getString("getUpdated"));
+            Assert.assertNotNull(json.getString("getSubCommunities"));
+            Assert.assertNotNull(json.getString("getMembers"));
+            Assert.assertNotNull(json.getString("getMember"));
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetSaveCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetSaveCommunity.java
@@ -1,0 +1,72 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class GetSaveCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityGetSave";
+
+    @Test
+    public void testGetSaveCommunity() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(3, jsonList.size());
+
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(2);
+        
+        community = getCommunity(json.getString("getCommunityUuid"));
+        
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(community.getTitle(), json.getString("getTitle"));
+        Assert.assertEquals(community.getSummary(), json.getString("getSummary"));
+        Assert.assertEquals(community.getCommunityUrl(), json.getString("getCommunityUrl"));
+        Assert.assertEquals(community.getLogoUrl(), json.getString("getLogoUrl"));
+        Assert.assertEquals(community.getMemberCount(), json.getInt("getMemberCount"));
+        Assert.assertEquals(community.getCommunityType(), json.getString("getCommunityType"));
+        Assert.assertEquals(community.getAuthor().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+        Assert.assertEquals(community.getAuthor().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+        Assert.assertEquals(community.getAuthor().getUserid(), json.getJsonObject("getAuthor").getString("authorUserid"));
+        Assert.assertEquals(community.getContributor().getName(), json.getJsonObject("getContributor").getString("contributorName"));
+        Assert.assertEquals(community.getContributor().getEmail(), json.getJsonObject("getContributor").getString("contributorEmail"));
+        Assert.assertEquals(community.getContributor().getUserid(), json.getJsonObject("getContributor").getString("contributorUserid"));
+    }
+  
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#waitForResult(int)
+     */
+    @Override
+    public WebElement waitForResult(int timeout) {
+        return waitForJsonList(3, timeout);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetSubCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/GetSubCommunities.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetSubCommunities extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetSubCommunities";
+
+    public GetSubCommunities() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    @Ignore
+    public void testGetSubCommunities() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        //TODO create sub communities
+        //List jsonList = previewPage.getJsonList();
+        //Assert.assertFalse("Get sub communities returned no communities", jsonList.isEmpty());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/NewSaveCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/NewSaveCommunity.java
@@ -1,0 +1,61 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class NewSaveCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CommunityNewSave";
+
+    public NewSaveCommunity() {
+        createCommunity = false;
+    }
+
+    @Test
+    public void testCommunityNewSave() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+
+        community = getCommunity(json.getString("getCommunityUuid"));
+        
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(community.getTitle(), json.getString("getTitle"));
+        Assert.assertEquals(community.getSummary(), json.getString("getSummary"));
+        Assert.assertEquals(community.getCommunityUrl(), json.getString("getCommunityUrl"));
+        Assert.assertEquals(community.getLogoUrl(), json.getString("getLogoUrl"));
+        Assert.assertEquals(community.getMemberCount(), json.getInt("getMemberCount"));
+        Assert.assertEquals(community.getCommunityType(), json.getString("getCommunityType"));
+        Assert.assertEquals(community.getAuthor().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+        Assert.assertEquals(community.getAuthor().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+        Assert.assertEquals(community.getAuthor().getUserid(), json.getJsonObject("getAuthor").getString("authorUserid"));
+        Assert.assertEquals(community.getContributor().getName(), json.getJsonObject("getContributor").getString("contributorName"));
+        Assert.assertEquals(community.getContributor().getEmail(), json.getJsonObject("getContributor").getString("contributorEmail"));
+        Assert.assertEquals(community.getContributor().getUserid(), json.getJsonObject("getContributor").getString("contributorUserid"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/RemoveCommunityMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/RemoveCommunityMember.java
@@ -1,0 +1,51 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Member;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class RemoveCommunityMember extends BaseCommunitiesTest {
+
+    static final String SNIPPET_ID = "Social_Communities_API_RemoveCommunityMember";
+
+    @Test
+    public void testRemoveMember() {
+    	String id = getProperty("sample.email2");
+    	if (environment.isSmartCloud()) {
+    		id = getProperty("smartcloud.id2");
+    	}
+        addMember(community, id, "member");
+            	
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.id2", id);
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertFalse("Remove member failed", hasMember(community, getProperty("sample.email2")));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/TestAddMember.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/TestAddMember.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Member;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class TestAddMember extends BaseCommunitiesTest {
+
+    @Test
+    public void testAddMember() {
+    	String id = getProperty("sample.email2");
+    	if (environment.isSmartCloud()) {
+    		id = getProperty("smartcloud.id2");
+    	}
+        
+        boolean added = addMember(community, id, "member");
+        
+        Assert.assertTrue("Add member failed", added);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunity.java
@@ -1,0 +1,92 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class UpdateCommunity extends BaseCommunitiesTest {
+
+    static final String SNIPPET_ID = "Social_Communities_API_UpdateCommunity";
+
+    @Test
+    public void testUpdateCommunity() {
+        String updatedTitle = "Updated Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.communityTitle", updatedTitle);
+        addSnippetParam("sample.communityContent", updatedContent);
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(updatedTitle, json.getString("getTitle"));
+        Assert.assertEquals(updatedContent, json.getString("getContent"));
+    }
+    
+    @Test
+    public void testUpdateCommunityDuplicate(){
+    	if (environment.isSmartCloud()) {
+    		return;
+    	}
+    	
+        String duplicateTitle = "Duplicate Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        Community community2 = createCommunity(duplicateTitle, "public", "Content for duplicate test", "duplicate");
+        
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.communityTitle", duplicateTitle);
+        addSnippetParam("sample.communityContent", updatedContent);
+
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(409, json.getInt("code"));
+        Assert.assertEquals("A community with the requested name already exists, choose a different name and resubmit.", json.getString("message"));
+        
+		deleteCommunity(community2);
+    }
+    
+    @Test
+    public void testUpdateCommunityError() {
+        addSnippetParam("sample.communityId", "Foo");
+        addSnippetParam("sample.communityTitle", "Foo");
+        addSnippetParam("sample.communityContent", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The referenced community does not exist.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunityJson.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunityJson.java
@@ -1,0 +1,92 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class UpdateCommunityJson extends BaseCommunitiesTest {
+
+    static final String SNIPPET_ID = "Social_Communities_API_UpdateCommunityJson";
+
+    @Test
+    public void testUpdateCommunity() {
+        String updatedTitle = "Updated Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.communityTitle", updatedTitle);
+        addSnippetParam("sample.communityContent", updatedContent);
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        
+        Assert.assertEquals(community.getCommunityUuid(), json.getString("getCommunityUuid"));
+        Assert.assertEquals(updatedTitle, json.getString("getTitle"));
+        Assert.assertEquals(updatedContent, json.getString("getContent"));
+    }
+    
+    @Test
+    public void testUpdateCommunityDuplicate() {
+    	if (environment.isSmartCloud()) {
+    		return;
+    	}
+    	
+        String duplicateTitle = "Duplicate Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        Community community2 = createCommunity(duplicateTitle, "public", "Content for duplicate test", "duplicate");
+        
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        addSnippetParam("sample.communityTitle", duplicateTitle);
+        addSnippetParam("sample.communityContent", updatedContent);
+
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(409, json.getInt("code"));
+        Assert.assertEquals("A community with the requested name already exists, choose a different name and resubmit.", json.getString("message"));
+        
+		deleteCommunity(community2);
+    }
+    
+    @Test
+    public void testUpdateCommunityError() {
+        addSnippetParam("sample.communityId", "Foo");
+        addSnippetParam("sample.communityTitle", "Foo");
+        addSnippetParam("sample.communityContent", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The referenced community does not exist.", json.getString("message"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunityTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/UpdateCommunityTags.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class UpdateCommunityTags extends BaseCommunitiesTest {
+
+    static final String SNIPPET_ID = "Social_Communities_API_UpdateCommunityTags";
+    
+    @Test
+    public void testUpdateTags() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        List tags = (List)json.get("getTags");
+        Assert.assertNotNull("getTags returned nothing", tags);
+        Assert.assertEquals(3, tags.size());
+        Assert.assertEquals("newtag1", tags.get(0));
+        Assert.assertEquals("newtag2", tags.get(1));
+        Assert.assertEquals("newtag3", tags.get(2));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/ValidateBaseCommunitiesTest.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/api/ValidateBaseCommunitiesTest.java
@@ -1,0 +1,91 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Community;
+
+/**
+ * @author mwallace
+ *  
+ * @date 29 Jul 2013
+ */
+public class ValidateBaseCommunitiesTest extends BaseCommunitiesTest {
+	
+	private int index = 0;
+    
+    @Test
+    public void testCreateCommunity1() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity2() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity3() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity4() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity5() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity6() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity7() {
+    	testCreateCommunity();
+    }
+    
+    @Test
+    public void testCreateCommunity8() {
+    	testCreateCommunity();
+    }
+    
+    public void testCreateCommunity() {
+    	Community comm = getCommunity(community.getCommunityUuid(), false);
+    	Assert.assertNotNull("Create community failed", comm);
+    	deleteCommunity(comm);
+    	comm = getCommunity(comm.getCommunityUuid(), false);
+    	Assert.assertNull("Delete community failed", comm);
+    	community = null;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest#createCommunityName()
+     */
+    @Override
+    protected String createCommunityName() {
+    	return super.createCommunityName() + " - " + (++index);
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/rest/GetMyCommunitiesXml.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/communities/rest/GetMyCommunitiesXml.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.communities.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class GetMyCommunitiesXml extends BaseAuthServiceTest {
+
+    @Test
+    @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Communities_Rest_Get_My_Communities_XML");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/AddCommentToFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/AddCommentToFile.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author Vineet Kanwal
+ *
+ */
+public class AddCommentToFile extends BaseFilesTest {
+	
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Add_Comment_To_File");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetFilesSharedByMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetFilesSharedByMe.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * 
+ * @author VineetKanwal
+ *
+ */
+public class GetFilesSharedByMe extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_Files_Shared_By_Me");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetFilesSharedWithMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetFilesSharedWithMe.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author Vineet Kanwal
+ *
+ */
+public class GetFilesSharedWithMe extends BaseFilesTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_Files_Shared_With_Me");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFileComments.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFileComments.java
@@ -1,0 +1,54 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author Vineet Kanwal
+ *
+ */
+public class GetMyFileComments extends BaseFilesTest {
+	
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_My_File_Comments");
+        assertTrue(getNoErrorMsg(), result);
+    }
+    @Override
+    public String getAuthenticatedMatch() {
+        return "id0";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFiles.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author VineetKanwal
+ *
+ */
+public class GetMyFiles extends BaseFilesTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_My_Files");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetMyFolders.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author VineetKanwal
+ *
+ */
+public class GetMyFolders extends BaseFilesTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_My_Folders");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetPublicFileComments.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetPublicFileComments.java
@@ -1,0 +1,50 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author Vineet Kanwal
+ *
+ */
+public class GetPublicFileComments extends BaseFilesTest {
+	
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Files_Get_My_File_Comments");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetPublicFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/GetPublicFiles.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+
+/**
+ * 
+ * @author VineetKanwal
+ *
+ */
+public class GetPublicFiles extends BaseFilesTest {
+
+    @Test
+    public void testNoError() {
+    	if(environment.isSmartCloud()){
+    		return;
+    	}
+        boolean result = checkNoError("Social_Files_Get_Public_Files");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/LoadUpdateLockPinDeleteFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/LoadUpdateLockPinDeleteFile.java
@@ -1,0 +1,309 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * 
+ * @author VineetKanwal
+ *
+ */
+public class LoadUpdateLockPinDeleteFile extends BaseFilesTest {
+	
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@Test
+	public void testLoadUpdateLockPinDeleteFile() {
+		LoadUpdateLockPinDeleteFilePage crudPage = launchSnippet();
+		String uuid = crudPage.getLoadedFileId();
+		Assert.assertNotNull("Unable to load file", uuid);
+		boolean updated = crudPage.updateFile();
+		Assert.assertTrue("Unable to update a file", updated);
+		boolean lockedOrUnLocked = crudPage.lockUnlockFile();
+		Assert.assertTrue("Unable to lock/unlock a file", lockedOrUnLocked);
+		boolean pinOrUnpin = crudPage.pinUnpinFile();
+		Assert.assertTrue("Unable to pin/unpin a file", pinOrUnpin);
+		boolean deleted = crudPage.deleteFile();
+		Assert.assertTrue("Unable to delete a file", deleted);
+		fileEntry = null;
+	}
+
+	/* (non-Javadoc)
+	 * 
+	 * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition() */
+	@Override
+	public String getAuthenticatedCondition() {
+		return "idWithText";
+	}
+
+	/* (non-Javadoc)
+	 * 
+	 * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch() */
+	@Override
+	public String getAuthenticatedMatch() {
+		return "fileId";
+	}
+
+	// Internals
+
+	private LoadUpdateLockPinDeleteFilePage launchSnippet() {
+		ResultPage resultPage = launchSnippet("Social_Files_Load_Update_Lock_Pin_Delete_File");
+
+		waitForText("success", "Successfully loaded file:", 20);
+
+		return new LoadUpdateLockPinDeleteFilePage(resultPage);
+	}
+
+	/* Page object for the Social_Communities_Create_Update_Delete_File snippet */
+	class LoadUpdateLockPinDeleteFilePage extends BaseResultPage {
+
+		private ResultPage delegate;
+
+		public LoadUpdateLockPinDeleteFilePage(ResultPage delegate) {
+			this.delegate = delegate;
+
+			setWebDriver(delegate.getWebDriver());
+		}
+
+		/* (non-Javadoc)
+		 * 
+		 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText() */
+		@Override
+		public String getText() {
+			return delegate.getText();
+		}
+
+		/* (non-Javadoc)
+		 * 
+		 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement () */
+		@Override
+		public WebElement getWebElement() {
+			return delegate.getWebElement();
+		}
+
+		public WebElement getSuccess() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("success"));
+		}
+
+		public WebElement getError() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("error"));
+		}
+
+		public WebElement getFileId() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("fileId"));
+		}
+
+		public WebElement getFileLabel() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("label"));
+		}
+
+		public WebElement getFileSummary() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("summary"));
+		}
+
+		public WebElement getFileVisibility() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("visibility"));
+		}
+
+		public WebElement getLoadBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("loadBtn"));
+		}
+
+		public WebElement getUpdateBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("updateBtn"));
+		}
+
+		public WebElement getDeleteBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("delete"));
+		}
+
+		public WebElement getLockUnlockBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("lockUnlock"));
+		}
+
+		public WebElement getPinUnpinBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("pinUnPin"));
+		}
+
+		public void setFileLabel(String label) {
+			WebElement fileLabel = getFileLabel();
+			fileLabel.clear();
+			fileLabel.sendKeys(label);
+		}
+
+		public void setFileSummary(String summary) {
+			WebElement fileSummary = getFileSummary();
+			fileSummary.clear();
+			fileSummary.sendKeys(summary);
+		}
+
+		public void setFileVisibility(String visibility) {
+			WebElement fileVisibility = getFileVisibility();
+			fileVisibility.clear();
+			fileVisibility.sendKeys(visibility);
+		}
+
+		public void clickLockUnlock() {
+			getLockUnlockBtn().click();
+		}
+
+		public void clickPinUnpin() {
+			getPinUnpinBtn().click();
+		}
+
+		public void clickUpdate() {
+			getUpdateBtn().click();
+		}
+
+		public void clickDelete() {
+			getDeleteBtn().click();
+		}
+
+		/** Update the current file and return the true if successful and otherwise return false */
+		public boolean updateFile() {
+			String label = "Updated Test Automation File " + System.currentTimeMillis();
+			String summary = "The file was updated using the LoadUpdateLockPinDeleteFile unit test";
+			String visibility = "public";
+			return updateFile(label, summary, visibility);
+		}
+
+		/** Update the current file and return the true if successful and otherwise return false */
+		public boolean updateFile(String label, String summary, String visibility) {
+			setFileLabel(label);
+			setFileSummary(summary);
+			setFileVisibility(visibility);
+
+			clickUpdate();
+
+			WebElement webElement = waitForText("success", "Successfully updated file:", 20);
+			if(webElement == null){
+				webElement = getError();
+				String error = webElement.getText();
+				Trace.log("Error updating File with ID " + fileEntry.getFileId() + " : " + error);
+				return false;
+			}
+
+			String text = webElement.getText();
+
+			return text.startsWith("Successfully updated file:");
+		}
+		
+		/** Lock/Unlock the current file and return the true if successful and otherwise return false */
+		public boolean lockUnlockFile() {
+			clickLockUnlock();
+
+			WebElement webElement = waitForText("success", "Successfully", 20);
+
+			if(webElement == null){
+				webElement = getError();
+				String error = webElement.getText();
+				Trace.log("Error Locking/Unlocking File with ID " + fileEntry.getFileId() + " : " + error);
+				return false;
+			}
+			
+			String text = webElement.getText();
+
+			return text.startsWith("Successfully");
+		}
+		
+		/** Pin/Unpin the current file and return the true if successful and otherwise return false */
+		public boolean pinUnpinFile() {
+			clickPinUnpin();
+
+			WebElement webElement = waitForText("success", "Successfully", 20);
+			if(webElement == null){
+				webElement = getError();
+				String error = webElement.getText();
+				Trace.log("Error pinning/unpinning File with ID " + fileEntry.getFileId() + " : " + error);
+				return false;
+			}
+
+			String text = webElement.getText();
+
+			return text.startsWith("Successfully");
+		}
+
+
+		/** Delete the current file and return the true if successful and otherwise return false */
+		public boolean deleteFile() {			
+			clickDelete();
+			WebElement webElement = waitForText("success", "Deleted file:", 20);
+			if(webElement == null){				
+				webElement = getError();
+				String error = webElement.getText();
+				if(error.contains("ItemNotFound")) {
+					Trace.log("File with ID " + fileEntry.getFileId() + " not found, seems already deleted!");
+					return true;
+				}
+				else {
+					Trace.log("Error deleting File with ID " + fileEntry.getFileId() + " : " + error);
+					return false;
+				}
+			}
+
+			String text = webElement.getText();
+
+			return text.startsWith("Deleted file:");
+		}
+
+		/** Return the file id of the file that was last loaded */
+		public String getLoadedFileId() {
+			WebElement webElement = waitForText("success", "Successfully loaded file:", 20);
+			
+			if(webElement == null){
+				webElement = getError();
+				String error = webElement.getText();
+				Trace.log("Error loading File with ID " + fileEntry.getFileId() + " : " + error);
+				return null;
+			}
+
+			String text = webElement.getText();
+
+			if (text.startsWith("Successfully loaded file:")) {
+				return text.substring("Successfully loaded file: ".length());
+			} else {
+				return null;
+			}
+		}
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/UploadFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/UploadFile.java
@@ -1,0 +1,207 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.files;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/** 
+ * 
+ * @author VineetKanwal 
+ * 
+ **/
+public class UploadFile extends BaseFilesTest {
+	File file;
+	String fileId;
+
+	@Before
+	public void init() {
+		try {
+			file = new File("JSUploadFileTest" + System.currentTimeMillis() + ".txt");
+			file.createNewFile();
+			Trace.log("Created test file: " + file.getAbsolutePath());
+			BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+			writer.write("JS Upload File Test File");
+			writer.flush();
+			writer.close();
+		} catch (FileNotFoundException e) {
+			Assert.fail("Error creating test file: " + e.getMessage());
+			e.printStackTrace();
+		} catch (IOException e) {
+			Assert.fail("Error creating test file: " + e.getMessage());
+			e.printStackTrace();
+		}
+
+	}
+
+	@After
+	public void destroy() {
+		try {
+			if (file != null) {
+				file.delete();
+			}
+		} catch (Exception e) {
+			Assert.fail("Error deleting test file: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void testUploadFile() {
+		// Disabling for Dojo 1.4.3 which does not support FormData
+        String jsLib = System.getProperty(TestEnvironment.PROP_JAVASCRIPT_LIB);
+        if (StringUtil.isEmpty(jsLib)) {
+            jsLib = environment.getProperty(TestEnvironment.PROP_JAVASCRIPT_LIB);
+        }
+        if("dojo143".equalsIgnoreCase(jsLib)){
+        	return;
+        }
+		UploadFilePage crudPage = launchSnippet();
+		boolean uploaded = crudPage.uploadFile();
+		Assert.assertTrue("Unable to upload the file", uploaded);
+		addSnippetParam("sample.fileId", fileId);
+		JavaScriptPreviewPage previewPage = executeSnippet("Social_Files_API_DeleteFile");
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+	}
+
+	/* (non-Javadoc)
+	 * 
+	 * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition() */
+	@Override
+	public String getAuthenticatedCondition() {
+		return "idWithText";
+	}
+
+	/* (non-Javadoc)
+	 * 
+	 * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch() */
+	@Override
+	public String getAuthenticatedMatch() {
+		return "uploadBtn";
+	}
+
+	// Internals
+
+	private UploadFilePage launchSnippet() {
+		ResultPage resultPage = launchSnippet("Social_Files_Upload_File");
+
+		return new UploadFilePage(resultPage);
+	}
+
+	/* Page object for the Social_Communities_Create_Update_Delete_File snippet */
+	class UploadFilePage extends BaseResultPage {
+
+		private ResultPage delegate;
+
+		public UploadFilePage(ResultPage delegate) {
+			this.delegate = delegate;
+
+			setWebDriver(delegate.getWebDriver());
+		}
+
+		/* (non-Javadoc)
+		 * 
+		 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText() */
+		@Override
+		public String getText() {
+			return delegate.getText();
+		}
+
+		/* (non-Javadoc)
+		 * 
+		 * @see com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement () */
+		@Override
+		public WebElement getWebElement() {
+			return delegate.getWebElement();
+		}
+
+		public WebElement getSuccess() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("success"));
+		}
+
+		public WebElement getError() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("error"));
+		}
+
+		public WebElement getFileId() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("fileId"));
+		}
+
+		public WebElement getFileControl() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("your-files"));
+		}
+
+		public WebElement getUploadBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("uploadBtn"));
+		}
+
+		public void setFile() {
+			WebElement fileCotrol = getFileControl();
+			fileCotrol.sendKeys(file.getAbsolutePath());
+		}
+
+		public void clickUpload() {
+			getUploadBtn().click();
+		}
+
+		/** Update the current file and return the true if successful and otherwise return false */
+		public boolean uploadFile() {
+			setFile();
+			clickUpload();
+			WebElement webElement = waitForText("success", "File with ID", 50);
+
+			String text = webElement.getText();
+
+			boolean result = text.startsWith("File with ID");
+
+			if (result) {
+				fileId = text.split(" ")[3];
+			}
+
+			return result;
+		}
+
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/AddCommentToFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/AddCommentToFile.java
@@ -1,0 +1,49 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class AddCommentToFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID_FILE = "Social_Files_API_FileAddComment";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testFileAddComment() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertTrue(json.getString("getContent").startsWith("Comment Added from JS Sample"));
+		assertEquals(fileEntry.getAuthorEntry().getUserUuid(), json.getJsonObject("getAuthor").getString("authorUserId"));
+		assertEquals(fileEntry.getAuthorEntry().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+		if (!StringUtil.isEmpty(fileEntry.getAuthorEntry().getEmail())) {
+			assertEquals(fileEntry.getAuthorEntry().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+		}
+		assertEquals(fileEntry.getAuthorEntry().getUserState(), json.getJsonObject("getAuthor").getString("authorUserState"));
+		assertEquals("Re: " + fileEntry.getTitle(), json.getString("getTitle"));
+		assertEquals("1", json.getString("getVersionLabel"));
+		assertEquals(fileEntry.getAuthorEntry().getUserUuid(), json.getJsonObject("getModifier").getString("modifierUserId"));
+		assertEquals(fileEntry.getAuthorEntry().getUserState(), json.getJsonObject("getModifier").getString("modifierUserState"));
+		assertEquals("en", json.getString("getLanguage"));
+		assertEquals("true", json.getString("getDeleteWithRecord"));
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/AddFilesToFolder.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/AddFilesToFolder.java
@@ -1,0 +1,38 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class AddFilesToFolder extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_AddFilesToFolder";
+
+	@Before
+	public void init() {
+		createFile();
+		createFolder();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+		addSnippetParam("sample.folderId", folder.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+	
+	@Test
+	public void testAddFilesToFolder() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/DeleteFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/DeleteFile.java
@@ -1,0 +1,45 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class DeleteFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_DeleteFile";
+
+	static final String SNIPPET_ID_FILE = "Social_Files_API_FileRemove";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void deleteFile() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+		fileEntry = null;
+	}
+
+	@Test
+	public void fileRemove() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+		fileEntry = null;
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/FileAddComment.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/FileAddComment.java
@@ -1,0 +1,49 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class FileAddComment extends BaseFilesTest {
+
+	static final String SNIPPET_ID_FILE = "Social_Files_API_FileAddComment";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testFileAddComment() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertTrue(json.getString("getContent").startsWith("Comment Added from JS Sample"));
+		assertEquals(fileEntry.getAuthorEntry().getUserUuid(), json.getJsonObject("getAuthor").getString("authorUserId"));
+		assertEquals(fileEntry.getAuthorEntry().getName(), json.getJsonObject("getAuthor").getString("authorName"));
+		if (!StringUtil.isEmpty(fileEntry.getAuthorEntry().getEmail())) {
+			assertEquals(fileEntry.getAuthorEntry().getEmail(), json.getJsonObject("getAuthor").getString("authorEmail"));
+		}
+		assertEquals(fileEntry.getAuthorEntry().getUserState(), json.getJsonObject("getAuthor").getString("authorUserState"));
+		assertEquals("Re: " + fileEntry.getTitle(), json.getString("getTitle"));
+		assertEquals("1", json.getString("getVersionLabel"));
+		assertEquals(fileEntry.getAuthorEntry().getUserUuid(), json.getJsonObject("getModifier").getString("modifierUserId"));
+		assertEquals(fileEntry.getAuthorEntry().getUserState(), json.getJsonObject("getModifier").getString("modifierUserState"));
+		assertEquals("en", json.getString("getLanguage"));
+		assertEquals("true", json.getString("getDeleteWithRecord"));
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFile.java
@@ -1,0 +1,51 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetFile";
+
+	FileEntry file;
+
+	@Before
+	public void init() {
+		try {
+			createFile();
+			addSnippetParam("sample.fileId", fileEntry.getFileId());
+			fileService = getFileService();
+			file = fileService.getFile(fileEntry.getFileId(), true);
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testGetFile() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			JsonJavaObject fileJson = previewPage.getJson();
+			Assert.assertEquals(fileJson.getString("getLabel"), file.getLabel());
+			Assert.assertEquals(fileJson.getString("getTitle"), file.getTitle());
+			Assert.assertEquals(fileJson.getString("getVisibility"), file.getVisibility());
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFilesSharedByMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFilesSharedByMe.java
@@ -1,0 +1,76 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetFilesSharedByMe extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetFilesSharedByMe";
+
+	private List<FileEntry> files;
+
+	@Before
+	public void init() {
+		try {
+			fileService = getFileService();
+			files = fileService.getFilesSharedByMe(new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	// TODO make sure there are files shared by test user
+
+	@Test
+	public void testGetFilesSharedByMe() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), files.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded file not found in shared list", existsSharedFileWithLabel(fileJsonObj.getString("getLabel")));
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsSharedFileWithLabel(String label) {
+		for (FileEntry entry : files) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if (files == null) {
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(files.size(), timeout);
+	}
+
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFilesSharedWithMe.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetFilesSharedWithMe.java
@@ -1,0 +1,76 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetFilesSharedWithMe extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetFilesSharedWithMe";
+
+	private List<FileEntry> files;
+
+	@Before
+	public void init() {
+		try {
+			fileService = getFileService();
+			files = fileService.getFilesSharedWithMe(new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	// TODO make sure there are files shared with test user
+
+	@Test
+	public void testGetFilesSharedWithMe() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), files.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded file not found in shared list", existsSharedFileWithLabel(fileJsonObj.getString("getLabel")));
+				// Assert.assertEquals(fileJsonObj.getString("getLabel"), files.get(i).getLabel());
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsSharedFileWithLabel(String label) {
+		for (FileEntry entry : files) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if(files == null){
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(files.size(), timeout);
+	}	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyFiles.java
@@ -1,0 +1,72 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetMyFiles extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetMyFiles";
+
+	private List<FileEntry> files;
+
+	@Before
+	public void init() {
+		try {
+			fileService = getFileService();
+			files = fileService.getMyFiles(new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void testGetMyFiles() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), files.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded file not found in list", existsFileWithLabel(fileJsonObj.getString("getLabel")));
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsFileWithLabel(String label) {
+		for (FileEntry entry : files) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if(files == null){
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(files.size(), timeout);
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyFolders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyFolders.java
@@ -1,0 +1,73 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetMyFolders extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetMyFolders";
+
+	private List<FileEntry> folders;
+
+	@Before
+	public void init() {
+		try {
+			fileService = getFileService();
+			folders = fileService.getMyFolders(new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void testGetMyFolders() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), folders.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded fodler not found in list", existsFolderWithLabel(fileJsonObj.getString("getLabel")));
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsFolderWithLabel(String label) {
+		for (FileEntry entry : folders) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if(folders == null){
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(folders.size(), timeout);
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyPinnedFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetMyPinnedFiles.java
@@ -1,0 +1,79 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetMyPinnedFiles extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetMyPinnedFiles";
+
+	static final String SNIPPET_ID_PIN = "Social_Files_API_PinFile";
+
+	private List<FileEntry> files;
+
+	@Before
+	public void init() {
+		try {
+			fileService = getFileService();
+			files = fileService.getPinnedFiles(new HashMap<String, String>());
+			assertNotNull(files);
+		} catch (FileServiceException e) {
+			e.printStackTrace();
+			Assert.fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testGetMyPinnedFiles() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), files.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded file not found in list", existsFileWithLabel(fileJsonObj.getString("getLabel")));
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsFileWithLabel(String label) {
+		for (FileEntry entry : files) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if (files == null) {
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(files.size(), timeout);
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetPublicFileComments.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetPublicFileComments.java
@@ -1,0 +1,89 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.CommentEntry;
+
+public class GetPublicFileComments extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetPublicFileComments";
+
+	private List<CommentEntry> comments;
+
+	@Before
+	public void init() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+		try {
+			comments = fileService.getAllFileComments(fileEntry.getFileId(), new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@After
+	public void destroy() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testGetPublicFileComments() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), comments.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("comment was not found in comment list", existComments(fileJsonObj.getString("getContent")));				
+			}
+		} catch (Exception ex) {
+			Assert.fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existComments(String content) {
+		for (CommentEntry comment : comments) {
+			if (content == null) {
+				if (comment.getComment() == null)
+					return true;
+				else
+					continue;
+			}
+			if (comment.getComment().equals(content)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if(comments == null){
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(comments.size(), timeout);
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetPublicFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/GetPublicFiles.java
@@ -1,0 +1,98 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.files.FileServiceException;
+import com.ibm.sbt.services.client.connections.files.model.FileEntry;
+
+public class GetPublicFiles extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_GetPublicFiles";
+
+	private List<FileEntry> files;
+
+	@Before
+	public void init() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		// to make sure there is at least one public file
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+		try {
+			files = fileService.getPublicFiles(new HashMap<String, String>());
+		} catch (FileServiceException e) {
+			Assert.fail(e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@After
+	public void destroy() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		deleteFileAndQuit();
+	}
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		// TODO disabled as there may be an OAuth problem
+		return !environment.isSmartCloud();
+	}
+
+	@Test
+	public void testGetPublicFiles() {
+		if (environment.isSmartCloud()) {
+			return;
+		}
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		try {
+			@SuppressWarnings({ "rawtypes" })
+			List jsonList = previewPage.getJsonList();
+			Assert.assertEquals(jsonList.size(), files.size());
+			for (int i = 0; i < jsonList.size(); i++) {
+				JsonJavaObject fileJsonObj = (JsonJavaObject) jsonList.get(i);
+				Assert.assertTrue("snippet loaded file not found in list", existsFileWithLabel(fileJsonObj.getString("getLabel")));
+			}
+		} catch (Exception ex) {
+			fail(previewPage.getJson().getJsonObject("cause").getString("message"));
+		}
+	}
+
+	private boolean existsFileWithLabel(String label) {
+		for (FileEntry entry : files) {
+			if (label == null) {
+				if (entry.getLabel() == null)
+					return true;
+				else
+					continue;
+			}
+			if (entry.getLabel().equals(label)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public WebElement waitForResult(int timeout) {
+		if(files == null){
+			return super.waitForResult(timeout);
+		}
+		return waitForJsonList(files.size(), timeout);
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/LockAndUnlockFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/LockAndUnlockFile.java
@@ -1,0 +1,53 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class LockAndUnlockFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID_LOCK = "Social_Files_API_LockFile";
+	static final String SNIPPET_ID_UNLOCK = "Social_Files_API_UnLockFile";
+
+	static final String SNIPPET_ID_LOCK_FILE = "Social_Files_API_FileLock";
+	static final String SNIPPET_ID_UNLOCK_FILE = "Social_Files_API_FileUnLock";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testLockUnlockFile() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_LOCK);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+
+		previewPage = executeSnippet(SNIPPET_ID_UNLOCK);
+		json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+	}
+
+	@Test
+	public void testFileLockUnlock() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_LOCK_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+
+		previewPage = executeSnippet(SNIPPET_ID_UNLOCK_FILE);
+		json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/PinFileAndRemovePinFromFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/PinFileAndRemovePinFromFile.java
@@ -1,0 +1,53 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class PinFileAndRemovePinFromFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID_PIN = "Social_Files_API_PinFile";
+	static final String SNIPPET_ID_REMOVE_PIN = "Social_Files_API_RemovePinFromFile";
+
+	static final String SNIPPET_ID_PIN_FILE = "Social_Files_API_FilePin";
+	static final String SNIPPET_ID_REMOVE_PIN_FILE = "Social_Files_API_FileUnpin";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testPinFileAndRemovePinFromFile() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_PIN);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+
+		previewPage = executeSnippet(SNIPPET_ID_REMOVE_PIN);
+		json = previewPage.getJson();
+		assertEquals(fileEntry.getFileId(), json.getString("fileId"));
+	}
+
+	@Test
+	public void testFilePinFileAndRemovePin() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_PIN_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertEquals("Success", json.getString("status"));
+
+		previewPage = executeSnippet(SNIPPET_ID_REMOVE_PIN_FILE);
+		json = previewPage.getJson();
+		assertEquals(fileEntry.getFileId(), json.getString("fileId"));
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/UpdateFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/UpdateFile.java
@@ -1,0 +1,48 @@
+package com.ibm.sbt.test.js.connections.files.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+public class UpdateFile extends BaseFilesTest {
+
+	static final String SNIPPET_ID = "Social_Files_API_UpdateFile";
+
+	static final String SNIPPET_ID_FILE = "Social_Files_API_FileUpdate";
+
+	@Before
+	public void init() {
+		createFile();
+		addSnippetParam("sample.fileId", fileEntry.getFileId());
+	}
+
+	@After
+	public void destroy() {
+		deleteFileAndQuit();
+	}
+
+	@Test
+	public void testUpdateFile() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		JsonJavaObject json = previewPage.getJson();
+		assertTrue(json.getString("getLabel").contains("New Label"));
+		assertEquals("New Summary", json.getString("getSummary"));
+		assertEquals("public", json.getString("getVisibility"));
+	}
+
+	@Test
+	public void testFileUpdate() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID_FILE);
+		JsonJavaObject json = previewPage.getJson();
+		assertTrue(json.getString("getLabel").contains("New Label"));
+		assertEquals("New Summary", json.getString("getSummary"));
+		assertEquals("public", json.getString("getVisibility"));
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/CreateForum.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/CreateForum.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class CreateForum extends BaseForumsTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_CreateForum";
+
+    public CreateForum() {
+        createForum = false;
+    }
+
+    @Test
+    public void testCreateForum() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+
+        String forumUuid = json.getString("getForumUuid");
+        Assert.assertNotNull(forumUuid);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/DeleteForum.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/DeleteForum.java
@@ -1,0 +1,84 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 19 Mar 2013
+ */
+public class DeleteForum extends BaseForumsTest {
+    
+    static final String SNIPPET_ID = "Social_Forums_API_DeleteForum";
+
+    @Test
+    public void testDeleteCommunity() {
+        addSnippetParam("ForumService.forumUuid", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        //Assert.assertEquals(forum.getForumUuid(), json.getString("forumUuid"));
+        
+        // forum has already been deleted
+        //forum = null;
+    }
+    
+    @Test
+    public void testConfirmDeleteCommunity() {
+    	addSnippetParam("ForumService.forumUuid", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        //Assert.assertEquals(forum.getForumUuid(), json.getString("forumUuid"));
+        
+        //forum = getForum(forum.getForumUuid(), false);
+        //Assert.assertNull("Deleted forum is still available", forum);
+
+        // forum has already been deleted
+        //forum = null;
+    }
+    
+    @Test
+    public void testDeleteCommunityError() {
+    	addSnippetParam("ForumService.forumUuid", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The referenced forum does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testDeleteCommunityInvalidArg() {
+        setAuthType(AuthType.NONE);
+    	addSnippetParam("ForumService.forumUuid", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected forumUuid.", json.getString("message"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetCommunity.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetCommunity.java
@@ -1,0 +1,72 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetCommunity extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Social_Communities_API_GetCommunity";
+
+    public GetCommunity() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetCommunity() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        assertCommunityValid((JsonJavaObject)jsonList.get(0));
+        Assert.assertEquals(community.getCommunityUuid(), ((JsonJavaObject)jsonList.get(1)).getString("entityId"));
+    }
+    
+    @Test
+    public void testGetCommunityError() {
+        addSnippetParam("sample.communityId", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The community which this resource or page is associated with does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testGetCommunityInvalidArg() {
+        addSnippetParam("sample.communityId", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected communityUuid.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetForum.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetForum.java
@@ -1,0 +1,72 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetForum extends BaseForumsTest {
+    
+    static final String SNIPPET_ID = "Social_Forums_API_GetForum";
+
+    public GetForum() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetForum() {
+        //addSnippetParam("ForumService.forumUuid", forum.getForumUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        //assertForumValid((JsonJavaObject)jsonList.get(0));
+        //Assert.assertEquals(forum.getForumUuid(), ((JsonJavaObject)jsonList.get(1)).getString("entityId"));
+    }
+    
+    @Test
+    public void testGetForumError() {
+        addSnippetParam("ForumService.forumUuid", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The forum which this resource or page is associated with does not exist.", json.getString("message"));
+    }
+    
+    @Test
+    public void testGetForumInvalidArg() {
+        addSnippetParam("ForumService.forumUuid", "");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals(400, json.getInt("code"));
+        Assert.assertEquals("Invalid argument, expected forumUuid.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetForums.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetForums extends BaseForumsTest {
+
+    static final String SNIPPET_ID = "Social_Forums_API_GetForums";
+    
+    public GetForums() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetForums() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        //List jsonList = previewPage.getJsonList();
+        // TODO create some forums
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetMyForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetMyForums.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyForums extends BaseApiTest {
+
+    static final String SNIPPET_ID = "Social_Forums_API_GetMyForums";
+    
+    public GetMyForums() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetMyForums() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        //List jsonList = previewPage.getJsonList();
+        // TODO create some forums
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetPublicForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/GetPublicForums.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetPublicForums extends BaseForumsTest {
+
+    static final String SNIPPET_ID = "Social_Forums_API_GetPublicForums";
+    
+    public GetPublicForums() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test
+    public void testGetCompletedForums() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        //List jsonList = previewPage.getJsonList();
+        // TODO create some forums
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/UpdateForum.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/api/UpdateForum.java
@@ -1,0 +1,86 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseForumsTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class UpdateForum extends BaseForumsTest {
+
+    static final String SNIPPET_ID = "Social_Forums_API_UpdateForum";
+
+    @Test
+    public void testUpdateForum() {
+        String updatedTitle = "Updated Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        
+        //addSnippetParam("ForumService.forumUuid", forum.getForumUuid());
+        addSnippetParam("ForumService.forumTitle", updatedTitle);
+        addSnippetParam("ForumService.forumContent", updatedContent);
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertNull("Unexpected error detected on page", json.getString("code"));
+        
+        //Assert.assertEquals(forum.getForumUuid(), json.getString("getForumUuid"));
+        Assert.assertEquals(updatedTitle, json.getString("getTitle"));
+        Assert.assertEquals(updatedContent, json.getString("getContent"));
+    }
+    
+    @Test
+    public void testUpdateForumDuplicate(){
+    	if (environment.isSmartCloud()) {
+    		return;
+    	}
+    	
+        String duplicateTitle = "Duplicate Title - " + System.currentTimeMillis();
+        String updatedContent = "Updated Content - " + System.currentTimeMillis();
+        //Forum forum2 = createForum(duplicateTitle, "public", "Content for duplicate test", "duplicate");
+        
+        //addSnippetParam("ForumService.forumUuid", forum.getForumUuid());
+        addSnippetParam("ForumService.forumTitle", duplicateTitle);
+        addSnippetParam("ForumService.forumContent", updatedContent);
+
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(409, json.getInt("code"));
+        Assert.assertEquals("A forum with the requested name already exists, choose a different name and resubmit.", json.getString("message"));
+        
+		//deleteForum(forum2);
+    }
+    
+    @Test
+    public void testUpdateForumError() {
+        addSnippetParam("ForumService.forumUuid", "Foo");
+        addSnippetParam("ForumService.forumTitle", "Foo");
+        addSnippetParam("ForumService.forumContent", "Foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("The referenced forum does not exist.", json.getString("message"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/rest/GetMyForums.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/rest/GetMyForums.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyForums extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Forums_REST_Get_My_Forums");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/rest/GetMyForumsXml.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/forums/rest/GetMyForumsXml.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.forums.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+public class GetMyForumsXml extends BaseAuthServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Forums_REST_Get_My_Forums_XML");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/BaseProfileEntryTest.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/BaseProfileEntryTest.java
@@ -1,0 +1,62 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Assert;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseProfileEntryTest extends BaseApiTest {
+    
+    public void validate(JavaScriptPreviewPage previewPage) {
+        JsonJavaObject json = previewPage.getJson();
+        validate(json);
+    }
+        
+    public void validate(JsonJavaObject json) {
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("getEntityId"));
+        Assert.assertEquals("tag:profiles.ibm.com,2006:entrye0b62b52-6a67-4489-b03b-4eb1f62c73e7", json.getString("id"));
+        Assert.assertEquals("0EE5A7FA-3434-9A59-4825-7A7000278DAA", json.getString("userid"));
+        Assert.assertEquals("Frank Adams", json.getString("name"));
+        Assert.assertEquals("FrankAdams@renovations.com", json.getString("email"));
+        Assert.assertEquals("Frank Adams", json.getString("title"));
+        Assert.assertEquals("fadams@gmail.com", json.getString("altEmail"));
+        Assert.assertEquals("https://qs.renovations.com:444/profiles/photo.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427", json.getString("photoUrl"));
+        Assert.assertEquals("Chief Operating Officer", json.getString("jobTitle"));
+        Assert.assertEquals("<empty>", json.getString("organizationUnit"));
+        Assert.assertEquals("https://qs.renovations.com:444/profiles/atom/profile.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7", json.getString("fnUrl"));
+        Assert.assertEquals("55555555", json.getString("telephoneNumber"));
+        Assert.assertEquals("Building1", json.getString("building"));
+        Assert.assertEquals("Floor1", json.getString("floor"));
+        Assert.assertEquals("<empty>", json.getString("streetAddress"));
+        Assert.assertEquals("<empty>", json.getString("extendedAddress"));
+        Assert.assertEquals("<empty>", json.getString("locality"));
+        Assert.assertEquals("<empty>", json.getString("postalCode"));
+        Assert.assertEquals("<empty>", json.getString("region"));
+        Assert.assertEquals("<empty>", json.getString("countryName"));
+        Assert.assertEquals("https://qs.renovations.com:444/profiles/audio.do?key=e0b62b52-6a67-4489-b03b-4eb1f62c73e7&lastMod=1365182136427", json.getString("soundUrl"));
+        Assert.assertEquals("Profile information for Frank Adams", json.getString("summary"));
+        Assert.assertEquals("fadams@gmail.com", json.getString("groupwareMail"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CheckProfileCache.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CheckProfileCache.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+
+/**
+ * @author projsaha
+ *  
+ * @date 3 May 2013
+ */
+public class CheckProfileCache extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_CheckProfileCache";     
+	
+    @Test
+    public void testProfileCache() {     	
+    	
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+    	 List jsonList = previewPage.getJsonList();
+    	 JsonJavaObject json = (JsonJavaObject)jsonList.get(0);         
+        Assert.assertEquals(1, json.getInt("Cache count after first get operation"));   
+        
+    }       
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CreateAndDeleteProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CreateAndDeleteProfile.java
@@ -1,0 +1,74 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.communities.Community;
+import com.ibm.sbt.services.client.connections.communities.CommunityServiceException;
+
+
+/**
+ * @author projsaha
+ *  
+ * @date 3 May 2013
+ */
+public class CreateAndDeleteProfile extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID1 = "Social_Profiles_API_CreateProfile";
+    static final String SNIPPET_ID2 = "Social_Profiles_API_DeleteProfile";
+	
+    /**
+	 * Test method which runs the createProfile sample followed by deleteProfile sample
+	 */
+    
+    @Test
+    public void testCreateAndDeleteProfile() {        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID1);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("QWERAB04-F2E1-1222-4825-7A700026E92C", json.getString("getUserid"));
+        Assert.assertEquals("MikeAdams@renovations.com", json.getString("getEmail"));
+        Assert.assertEquals("Mike Adams", json.getString("getName"));
+        previewPage = executeSnippet(SNIPPET_ID2);
+        json = previewPage.getJson();
+        Assert.assertEquals("QWERAB04-F2E1-1222-4825-7A700026E92C", json.getString("id"));
+        previewPage = executeSnippet(SNIPPET_ID2);
+        json = previewPage.getJson();
+        Assert.assertEquals(404, json.getInt("code"));
+        Assert.assertEquals("CLFRN1172E: The request is invalid.", json.getString("message"));
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getProperty(java.lang.String)
+     */
+    @Override
+    public String getProperty(String name) {
+        if (TestEnvironment.PROP_BASIC_USERNAME.equals(name)) {
+            return "admin";
+        }
+        if (TestEnvironment.PROP_BASIC_PASSWORD.equals(name)) {
+            return "passw0rd";
+        }
+        return super.getProperty(name);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CreateProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/CreateProfile.java
@@ -1,0 +1,61 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+
+/**
+ * @author projsaha
+ *  
+ * @date 3 May 2013
+ */
+public class CreateProfile extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_CreateProfile"; 
+        
+    @Test
+    public void testCreateProfileWithMissingInputs() {    	
+        addSnippetParam("sample.createProfileDistinguishedName", ""); // missing input here
+        
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();        
+        Assert.assertEquals(500, json.getInt("code"));
+        Assert.assertEquals("CLFRN1120E: An error occurred.", json.getString("message"));
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getProperty(java.lang.String)
+     */
+    @Override
+    public String getProperty(String name) {
+        if (TestEnvironment.PROP_BASIC_USERNAME.equals(name)) {
+            return "admin";
+        }
+        if (TestEnvironment.PROP_BASIC_PASSWORD.equals(name)) {
+            return "passw0rd";
+        }
+        return super.getProperty(name);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/DeleteProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/DeleteProfile.java
@@ -1,0 +1,60 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+
+/**
+ * @author projsaha
+ *  
+ * @date 3 May 2013
+ */
+public class DeleteProfile extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_DeleteProfile";    
+	
+    @Test
+    public void DeleteProfileWithMissingArguments() {        
+    	addSnippetParam("sample.createProfileId", "");          	
+    	
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();        
+        Assert.assertEquals(400, json.getInt("code"));       
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getProperty(java.lang.String)
+     */
+    @Override
+    public String getProperty(String name) {
+        if (TestEnvironment.PROP_BASIC_USERNAME.equals(name)) {
+            return "admin";
+        }
+        if (TestEnvironment.PROP_BASIC_PASSWORD.equals(name)) {
+            return "passw0rd";
+        }
+        return super.getProperty(name);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetCachedProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetCachedProfile.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetCachedProfile extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_GetCachedProfile";
+
+    @Test
+    public void testCachedProfile() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(20, jsonList.size());
+        for (int i=0; i<20; i++) {
+            JsonJavaObject json = (JsonJavaObject)jsonList.get(i);
+            Assert.assertTrue(json.getInt("profileLoaded") > 0);
+        }
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetColleagues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetColleagues.java
@@ -1,0 +1,42 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetColleagues extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_GetColleagues";
+
+    @Test
+    public void testGetColleagues() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertTrue(jsonList.size() > 0);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetPeopleManaged.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetPeopleManaged.java
@@ -1,0 +1,42 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetPeopleManaged extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_GetPeopleManaged";
+
+    @Test
+    public void testGetPeopleManaged() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertTrue(jsonList.size() > 0);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetProfile.java
@@ -1,0 +1,43 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.services.client.connections.profiles.Profile;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetProfile extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_GetProfile";
+
+    @Test
+    public void testGetProfile() {
+        Profile profile = getProfile(getProperty("sample.id1"));
+        addSnippetParam("sample.email1", getProperty("sample.email1"));
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        validate(profile, json);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetProfileDemonstrationSnippet.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetProfileDemonstrationSnippet.java
@@ -1,0 +1,107 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.services.client.connections.profiles.Profile;
+
+public class GetProfileDemonstrationSnippet extends BaseProfilesTest {
+
+	public GetProfileDemonstrationSnippet() {
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+
+	@Test
+	public void testGetProfile() {
+
+		Profile profile = getProfile(getProperty("sample.id1"));
+		GetProfilePage getProfilePage = launchSnippet();
+		String profileName = getProfilePage.getProfileName();
+		Assert.assertNotNull("Unable to load profile", profileName);
+		Assert.assertEquals("Frank Adams", profileName);
+		Assert.assertEquals(profile.getUserid(), getProfilePage.getProfileId());
+		Assert.assertEquals(profile.getTitle(), getProfilePage.getProfileJobTitle());
+	}
+
+	private GetProfilePage launchSnippet() {
+		ResultPage resultPage = launchSnippet("Social_Profiles_Get_Profile");
+		waitForText("name", "Frank Adams", 20);
+		return new GetProfilePage(resultPage);
+	}
+
+	/*
+	 * Page object for the Social_Profiles_Get_Profile
+	 */
+	class GetProfilePage extends BaseResultPage {
+
+		private ResultPage delegate;
+
+		public GetProfilePage(ResultPage delegate) {
+			this.delegate = delegate;
+			setWebDriver(delegate.getWebDriver());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+		 */
+		@Override
+		public String getText() {
+			return delegate.getText();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+		 * ()
+		 */
+		@Override
+		public WebElement getWebElement() {
+			return delegate.getWebElement();
+		}
+
+		public String getProfileId() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("userId")).getText();
+		}
+		
+		public String getProfileJobTitle() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("jobTitle")).getText();
+		}
+
+		/**
+		 * Return the profile name of the profile that was loaded
+		 */
+		public String getProfileName() {
+			WebElement webElement = waitForText("name", "Frank Adams", 20);
+			return (webElement == null) ? null : webElement.getText();
+		}
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetReportingChain.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/GetReportingChain.java
@@ -1,0 +1,42 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetReportingChain extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_GetReportingChain";
+
+    @Test
+    public void testGetReportingChain() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertTrue(jsonList.size() > 0);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryDataHandler.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileEntryDataHandler extends BaseProfileEntryTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileEntryDataHandler";
+
+    @Test
+    public void testProfileEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        validate(previewPage);
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryHCardFull.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryHCardFull.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileEntryHCardFull extends BaseProfileEntryTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileEntryHCardFull";
+
+    @Test
+    public void testProfileEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        validate(previewPage);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryHCardLite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryHCardLite.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileEntryHCardLite extends BaseProfileEntryTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileEntryHCardLite";
+
+    @Test
+    public void testProfileEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        validate(previewPage);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryVCardFull.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryVCardFull.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileEntryVCardFull extends BaseProfileEntryTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileEntryVCardFull";
+
+    @Test
+    public void testProfileEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        validate(previewPage);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryVCardLite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileEntryVCardLite.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileEntryVCardLite extends BaseProfileEntryTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileEntryVCardLite";
+
+    @Test
+    public void testProfileEntryDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        validate(previewPage);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileFeedDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/ProfileFeedDataHandler.java
@@ -1,0 +1,45 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ProfileFeedDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_ProfileFeedDataHandler";
+
+    @Test
+    public void testProfileFeedDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(4, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        // TODO validate values
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/Search.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/Search.java
@@ -1,0 +1,42 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class Search extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_Search";
+
+    @Test
+    public void testSearch() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertTrue(jsonList.size() > 0);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfile.java
@@ -1,0 +1,68 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+
+/**
+ * @author projsaha
+ *  
+ * @date 3 May 2013
+ */
+public class UpdateProfile extends BaseProfilesTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_API_UpdateProfile"; 
+    static final String SNIPPET_ID2 = "Social_Profiles_API_UpdateProfilePattern2"; 
+	
+    @Test
+    public void testUpdateProfile() { 	    	
+    	addSnippetParam("sample.updateProfileJobTitle", "Software Engineer");
+        addSnippetParam("sample.updateProfileBuilding", "1");
+        addSnippetParam("sample.updateProfileFloor", "2nd");
+        addSnippetParam("sample.updateProfileTelephoneNumber", "343343"); // missing input here
+        
+    	
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();        
+        Assert.assertEquals("Software Engineer", json.getString("jobTitle"));   
+        Assert.assertEquals("1", json.getString("building"));  
+        Assert.assertEquals("2nd", json.getString("floor"));  
+        Assert.assertEquals("343343", json.getString("telephoneNumber"));  
+    }   
+    
+    @Test
+    public void testUpdateProfilePattern2() {    
+    	addSnippetParam("sample.updateProfileJobTitle", "Software Associate Engineer");
+        addSnippetParam("sample.updateProfileBuilding", "2");
+        addSnippetParam("sample.updateProfileFloor", "3rd");
+        addSnippetParam("sample.updateProfileTelephoneNumber", "343344"); // missing input here
+        
+    	JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID2);
+        JsonJavaObject json = previewPage.getJson();        
+        Assert.assertEquals("Software Associate Engineer-1", json.getString("jobTitle"));   
+        Assert.assertEquals("2-1", json.getString("building"));  
+        Assert.assertEquals("3rd-1", json.getString("floor"));  
+        Assert.assertEquals("343344", json.getString("telephoneNumber"));  
+    }   
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfileDemonstrationSnippet.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfileDemonstrationSnippet.java
@@ -1,0 +1,181 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.connections.BaseProfilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+
+public class UpdateProfileDemonstrationSnippet extends BaseProfilesTest {
+
+	public UpdateProfileDemonstrationSnippet() {
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+
+	@Test
+	public void testUpdateProfile() {
+		// Profile profile = getProfile(getProperty("sample.id1"));
+		GetProfilePage getProfilePage = launchSnippet();
+		String profileLoadMessage = getProfilePage.getProfileMessage();
+		Assert.assertNotNull("Unable to load profile", profileLoadMessage);
+		Assert.assertEquals(
+				"Successfully loaded profile entry for Frank Adams",
+				profileLoadMessage);
+		String profileUpdateMessage = getProfilePage.updateProfile();
+		Assert.assertNotNull("Unable to load profile", profileLoadMessage);
+		Assert.assertEquals(
+				"Successfully updated profile entry for Frank Adams",
+				profileUpdateMessage);
+
+	}
+	
+	
+	private GetProfilePage launchSnippet() {
+		ResultPage resultPage = launchSnippet("Social_Profiles_Update_Profile");
+		waitForText("success", "Successfully loaded profile entry for ", 20);
+		return new GetProfilePage(resultPage);
+	}
+
+	/*
+	 * Page object for the Social_Profiles_Get_Profile
+	 */
+	class GetProfilePage extends BaseResultPage {
+
+		private ResultPage delegate;
+
+		public GetProfilePage(ResultPage delegate) {
+			this.delegate = delegate;
+			setWebDriver(delegate.getWebDriver());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+		 */
+		@Override
+		public String getText() {
+			return delegate.getText();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+		 * ()
+		 */
+		@Override
+		public WebElement getWebElement() {
+			return delegate.getWebElement();
+		}
+
+		/**
+		 * Return the text of the success element
+		 */
+		public String getProfileMessage() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("success")).getText();
+		}
+
+		public WebElement getProfileFloor() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("floor"));
+		}
+
+		public WebElement getProfileBuilding() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("building"));
+		}
+
+		public WebElement getProfileJobTitle() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("jobTitle"));
+		}
+
+		public WebElement getLoadBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("loadBtn"));
+		}
+
+		public WebElement getUpdateBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("updateBtn"));
+		}
+
+		public void setProfileBuilding(String building) {
+			WebElement profileBuilding = getProfileBuilding();
+			profileBuilding.clear();
+			profileBuilding.sendKeys(building);
+		}
+
+		public void setProfileFloor(String floor) {
+			WebElement profileFloor = getProfileFloor();
+			profileFloor.clear();
+			profileFloor.sendKeys(floor);
+		}
+
+		public void setProfileJobTitle(String jobTitle) {
+			WebElement profileJobTitle = getProfileJobTitle();
+			profileJobTitle.clear();
+			profileJobTitle.sendKeys(jobTitle);
+		}
+		
+		public void clickUpdate() {
+			getUpdateBtn().click();
+		}
+
+		
+		/**
+		 * Create a new community and return the uuid if successful and
+		 * otherwise return null
+		 */
+		public String updateProfile() {
+			String building = "Profile Building" ;					
+			String floor = "Profile floor";
+			String jobtTitle = "Test job title";
+			return updateProfile(building, floor, jobtTitle);
+		}
+
+		/**
+		 * Create a new community and return the uuid if successful and
+		 * otherwise return null
+		 */
+		public String updateProfile(String building, String floor, String jobTitle) {
+			setProfileBuilding(building);
+			setProfileFloor(floor);
+			setProfileJobTitle(jobTitle);
+
+			clickUpdate();
+
+			return getUpdateProfileMessage();
+		}
+		
+		public String getUpdateProfileMessage(){
+			waitForText("success", "Successfully updated profile entry for ", 20);
+			return getProfileMessage();
+		}
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfilePhoto.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/api/UpdateProfilePhoto.java
@@ -1,0 +1,209 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.api;
+
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import junit.framework.Assert;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.test.connections.BaseFilesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * 
+ * @author VineetKanwal
+ * 
+ **/
+public class UpdateProfilePhoto extends BaseFilesTest {
+	File file;	
+
+	@Before
+	public void init() {
+		try {
+			file = new File("JSProfilePicUpdate" + System.currentTimeMillis()
+					+ ".jpg");
+			BufferedImage image = new BufferedImage(100, 100,
+					BufferedImage.TYPE_INT_RGB);
+			Graphics g = image.getGraphics();
+			g.drawString("Hello World!!!", 10, 20);
+			ImageIO.write(image, "jpg", file);			
+		} catch (FileNotFoundException e) {
+			Assert.fail("Error creating test file: " + e.getMessage());
+			e.printStackTrace();
+		} catch (IOException e) {
+			Assert.fail("Error creating test file: " + e.getMessage());
+			e.printStackTrace();
+		}
+
+	}
+
+	@After
+	public void destroy() {
+		try {
+			if (file != null) {
+				file.delete();
+			}
+		} catch (Exception e) {
+			Assert.fail("Error deleting test file: " + e.getMessage());
+			e.printStackTrace();
+		}
+	}
+
+	@Test
+	public void testUpdateProfilePhoto() {
+		// Disabling for Dojo 1.4.3 which does not support FormData
+		String jsLib = System.getProperty(TestEnvironment.PROP_JAVASCRIPT_LIB);
+		if (StringUtil.isEmpty(jsLib)) {
+			jsLib = environment
+					.getProperty(TestEnvironment.PROP_JAVASCRIPT_LIB);
+		}
+		if ("dojo143".equalsIgnoreCase(jsLib)) {
+			return;
+		}
+		UpdateProfilePhotoPage crudPage = launchSnippet();
+		boolean uploaded = crudPage.updateProfilePhoto();
+		Assert.assertTrue("Unable toupdate profile photo", uploaded);				
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+	 */
+	@Override
+	public String getAuthenticatedCondition() {
+		return "idWithText";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+	 */
+	@Override
+	public String getAuthenticatedMatch() {
+		return "uploadBtn";
+	}
+
+	// Internals
+
+	private UpdateProfilePhotoPage launchSnippet() {
+		ResultPage resultPage = launchSnippet("Social_Profiles_Update_Profile_Photo");
+
+		return new UpdateProfilePhotoPage(resultPage);
+	}
+
+	/*
+	 * Page object for the Connections_Communities_Create_Update_Delete_File
+	 * snippet
+	 */
+	class UpdateProfilePhotoPage extends BaseResultPage {
+
+		private ResultPage delegate;
+
+		public UpdateProfilePhotoPage(ResultPage delegate) {
+			this.delegate = delegate;
+
+			setWebDriver(delegate.getWebDriver());
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+		 */
+		@Override
+		public String getText() {
+			return delegate.getText();
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * 
+		 * @see
+		 * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+		 * ()
+		 */
+		@Override
+		public WebElement getWebElement() {
+			return delegate.getWebElement();
+		}
+
+		public WebElement getSuccess() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("success"));
+		}
+
+		public WebElement getError() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("error"));
+		}
+		
+		public WebElement getFileControl() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("your-files"));
+		}
+
+		public WebElement getUpdateBtn() {
+			WebElement resultEl = getWebElement();
+			return resultEl.findElement(By.id("updateBtn"));
+		}
+
+		public void setFile() {
+			WebElement fileCotrol = getFileControl();
+			fileCotrol.sendKeys(file.getAbsolutePath());
+		}
+
+		public void clickUpdate() {
+			getUpdateBtn().click();
+		}
+
+		/**
+		 * Update the current file and return the true if successful and
+		 * otherwise return false
+		 */
+		public boolean updateProfilePhoto() {
+			setFile();
+			clickUpdate();
+			WebElement webElement = waitForText("success", "Profile Photo updated successfuly", 50);
+
+			String text = webElement.getText();
+
+			boolean result = text.startsWith("Profile Photo updated successfuly");			
+
+			return result;
+		}
+
+	}
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadName.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadName.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ReadName extends BaseServiceTest {
+
+    @Test
+    public void testExpected() {
+        String expected = getProperty("sample.displayName1");
+        boolean result = checkExpected("Social_Profiles_REST_Read_Name", expected);
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadNameAndEmail.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadNameAndEmail.java
@@ -1,0 +1,38 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ReadNameAndEmail extends BaseServiceTest {
+
+    @Test
+    public void testExpected() {
+        String expected = getProperty("sample.displayName1");
+        boolean result = checkExpected("Social_Profiles_REST_Read_Name_and_Email", expected);
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadProfilePhoto.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadProfilePhoto.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.rest;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ReadProfilePhoto extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        ResultPage resultPage = launchSnippet("Social_Profiles_REST_Read_Profile_Photo", AuthType.NONE);
+        WebElement contentEl = resultPage.getWebElement().findElement(By.id("content"));
+        WebElement imgEl = contentEl.findElement(By.tagName("img"));
+        assertNotNull("Unable to find image tag", imgEl);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+        return "idWithChild";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadProfileXml.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadProfileXml.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ReadProfileXml extends BaseServiceTest {
+
+    @Test
+    public void testNoError() {
+        boolean result = checkNoError("Social_Profiles_REST_Read_Profile_XML");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadResponseHeaders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/profiles/rest/ReadResponseHeaders.java
@@ -1,0 +1,37 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.profiles.rest;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ReadResponseHeaders extends BaseServiceTest {
+
+    @Test
+    public void testExpected() {
+        boolean result = checkExpected("Social_Profiles_REST_Read_Response_Headers", "Content-Type: application/atom+xml;charset=UTF-8");
+        assertTrue(getExpectedErrorMsg(), result);
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/PeopleSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/PeopleSearch.java
@@ -1,0 +1,161 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search;
+
+import junit.framework.Assert;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+import com.ibm.sbt.automation.core.test.pageobjects.BaseResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class PeopleSearch extends BaseAuthServiceTest {
+	
+    @Test @Ignore
+    public void testPeopleSearch() {
+    	PeopleSearchPage searchPage = launchSnippet();
+        boolean success = searchPage.peopleSearch("Test");
+        Assert.assertTrue("No results when search for people", success);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+        return "idWithText";
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+        return "searchBtn";
+    }
+
+    // Internals
+
+    private PeopleSearchPage launchSnippet() {
+        ResultPage resultPage = launchSnippet("Social_Search_People_Search");
+        return new PeopleSearchPage(resultPage);
+    }
+
+    /*
+     * Page object for the
+     * Social_Communities_Search_People_Search snippet
+     */
+    class PeopleSearchPage extends BaseResultPage {
+
+        private ResultPage delegate;
+
+        public PeopleSearchPage(ResultPage delegate) {
+            this.delegate = delegate;
+
+            setWebDriver(delegate.getWebDriver());
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getText()
+         */
+        @Override
+        public String getText() {
+            return delegate.getText();
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see
+         * com.ibm.sbt.automation.core.test.pageobjects.ResultPage#getWebElement
+         * ()
+         */
+        @Override
+        public WebElement getWebElement() {
+            return delegate.getWebElement();
+        }
+
+        public WebElement getError() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("error"));
+        }
+
+        public WebElement getTopicInput() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("topicInput"));
+        }
+
+        public WebElement getSearchBtn() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("searchBtn"));
+        }
+
+        public WebElement getPeopleTable() {
+            WebElement resultEl = getWebElement();
+            return resultEl.findElement(By.id("peopleTable"));
+        }
+        
+        public void setTopic(String topic) {
+            WebElement topicInput = getTopicInput();
+            topicInput.clear();
+            topicInput.sendKeys(topic);
+        }
+
+        public void clickSearch() {
+        	getSearchBtn().click();
+        }
+        
+        /**
+         * Execute people search for specified topic and return the true if successful and
+         * otherwise return false
+         */
+        public boolean peopleSearch(String topic) {
+            setTopic(topic);
+            clickSearch();
+
+            WebElement webElement = waitForChildren("table", "tr[2]", 10);
+            if (webElement != null) {
+                String text = webElement.getText();
+                return text != null && text.length() > 0;
+            } else {
+                webElement = getError();
+                String text = webElement.getText();
+                return text.startsWith("No people associated with topic:");
+            }
+        }
+
+
+
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetApplications.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetApplications.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetApplications extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetApplications";
+
+    public GetApplications() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetApplications() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetDates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetDates.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetDates extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetDates";
+
+    public GetDates() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetDates() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyApplications.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyApplications.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyApplications extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetMyApplications";
+
+    public GetMyApplications() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetMyApplications() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyDates.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyDates.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyDates extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetMyDates";
+
+    public GetMyDates() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetMyDates() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyPeople.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyPeople.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyPeople extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetMyPeople";
+
+    public GetMyPeople() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetMyPeople() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyResults.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyResults.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyResults extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetMyResults";
+
+    public GetMyResults() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetMyResults() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i), true);
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetMyTags.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetMyTags extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetMyTags";
+
+    public GetMyTags() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetMyTags() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetPeople.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetPeople.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetPeople extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetPeople";
+
+    public GetPeople() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetPeople() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetResults.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetResults.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetResults extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetResults";
+
+    public GetResults() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetResults() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i), true, false);
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetTags.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/api/GetTags.java
@@ -1,0 +1,49 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.api;
+
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseSearchTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class GetTags extends BaseSearchTest {
+    
+    static final String SNIPPET_ID = "Social_Search_API_GetTags";
+
+    public GetTags() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+
+    @Test @Ignore
+    public void testGetTags() {
+        addSnippetParam("sample.searchQuery", "Test");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        for (int i=0; i<jsonList.size(); i++) {
+        	assertResultValid((JsonJavaObject)jsonList.get(i));
+        }
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/ApplicationSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/ApplicationSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class ApplicationSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_Application_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/DateSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/DateSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class DateSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_Date_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyApplicationSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyApplicationSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MyApplicationSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_My_Application_Search", true);
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyDateSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyDateSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MyDateSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_My_Date_Search", true);
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyPeopleSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyPeopleSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MyPeopleSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_My_People_Search", true);
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MySearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MySearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MySearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_My_Search", true);
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyTagSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/MyTagSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class MyTagSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_Search", true);
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/PeopleSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/PeopleSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class PeopleSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_People_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/Search.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/Search.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class Search extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/TagSearch.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/search/rest/TagSearch.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.connections.search.rest;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+
+/**
+ * @author mwallace
+ * 
+ * @date 5 Mar 2013
+ */
+public class TagSearch extends BaseAuthServiceTest {
+
+    @Test @Ignore
+    public void testNoError() {
+        boolean result = checkNoError("Social_Search_REST_Tag_Search");
+        assertTrue(getNoErrorMsg(), result);
+    }
+
+    @Override
+    public String getAuthenticatedMatch() {
+    	return "xml";
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/DemoSnippet.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/DemoSnippet.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class DemoSnippet extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_DemoSnippet";
+    
+    public DemoSnippet() {
+        setAuthType(AuthType.AUTO_DETECT);
+    }
+    
+    @Test
+    public void testDemoSnippet() {
+        addSnippetParam("sample.communityId", "foo");
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("DemoSnippet", json.getString("name"));
+        Assert.assertEquals("foo", json.getString("communityUuid"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointDelete.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointDelete.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class EndpointDelete extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_EndpointDelete";
+    
+    @Test
+    public void testEndpointDelete() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        Assert.assertEquals("<empty>", ((JsonJavaObject)jsonList.get(0)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("url"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("options"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("xhr"));
+        Assert.assertEquals(200, ((JsonJavaObject)jsonList.get(1)).getInt("status"));
+        
+        // community has already been deleted
+        community = null;
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointGet.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointGet.java
@@ -1,0 +1,56 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class EndpointGet extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_EndpointGet";
+    
+    public EndpointGet() {
+        setAuthType(AuthType.NONE);
+    }
+    
+    @Test
+    public void testEndpointGet() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(0)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("url"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("options"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("text"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("xhr"));
+        Assert.assertEquals(200, ((JsonJavaObject)jsonList.get(1)).getInt("status"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointLockFile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointLockFile.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class EndpointLockFile extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_EndpointLockFile";
+    
+    public EndpointLockFile() {
+        setAuthType(AuthType.BASIC);
+    }
+    
+    @Test
+    public void testEndpointGet() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(3, jsonList.size());
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointPost.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointPost.java
@@ -1,0 +1,51 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class EndpointPost extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_EndpointPost";
+    
+    @Test
+    public void testEndpointPost() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(0)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("Location"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("url"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("options"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("xhr"));
+        Assert.assertEquals(201, ((JsonJavaObject)jsonList.get(1)).getInt("status"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointPut.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/EndpointPut.java
@@ -1,0 +1,52 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class EndpointPut extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_EndpointPut";
+    
+    @Test
+    public void testEndpointPut() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(0)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("url"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("options"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("text"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("xhr"));
+        Assert.assertEquals(200, ((JsonJavaObject)jsonList.get(1)).getInt("status"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/LangMixin.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/LangMixin.java
@@ -1,0 +1,58 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class LangMixin extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_LangMixin";
+    
+    @Test
+    public void testLangMixin() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(6, jsonList.size());
+        JsonJavaObject json = null;
+        Assert.assertEquals("object1_one", ((JsonJavaObject)jsonList.get(0)).getString("one"));
+        Assert.assertEquals("object2_one", ((JsonJavaObject)jsonList.get(1)).getString("one"));
+        Assert.assertEquals("object2_two", ((JsonJavaObject)jsonList.get(1)).getString("two"));
+        Assert.assertEquals("object3_one", ((JsonJavaObject)jsonList.get(2)).getString("one"));
+        Assert.assertEquals("object3_two", ((JsonJavaObject)jsonList.get(2)).getString("two"));
+        Assert.assertEquals("object3_three", ((JsonJavaObject)jsonList.get(2)).getString("three"));
+        Assert.assertEquals("object1_one", ((JsonJavaObject)jsonList.get(3)).getString("one"));
+        Assert.assertEquals("object2_two", ((JsonJavaObject)jsonList.get(3)).getString("two"));
+        Assert.assertEquals("object3_three", ((JsonJavaObject)jsonList.get(3)).getString("three"));
+        Assert.assertEquals("object1_one", ((JsonJavaObject)jsonList.get(4)).getString("one"));
+        Assert.assertEquals("object3_two", ((JsonJavaObject)jsonList.get(4)).getString("two"));
+        Assert.assertEquals("object3_three", ((JsonJavaObject)jsonList.get(4)).getString("three"));
+        Assert.assertEquals("object1_one", ((JsonJavaObject)jsonList.get(5)).getString("one"));
+        Assert.assertEquals("object2_two", ((JsonJavaObject)jsonList.get(5)).getString("two"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/ResponseHeaders.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/ResponseHeaders.java
@@ -1,0 +1,46 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class ResponseHeaders extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_ResponseHeaders";
+    
+    @Test
+    public void testResponseHeaders() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("IBM_HTTP_Server", json.getString("Server"));
+        Assert.assertNotNull(json.getString("Location"));
+        Assert.assertNotNull(json.getString("url"));
+        Assert.assertNotNull(json.getString("options"));
+        Assert.assertNotNull(json.getString("xhr"));
+        Assert.assertEquals(201, json.getInt("status"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/TransportGet.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/sbt/TransportGet.java
@@ -1,0 +1,56 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.sbt;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.connections.BaseCommunitiesTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class TransportGet extends BaseCommunitiesTest {
+    
+    static final String SNIPPET_ID = "Toolkit_TransportGet";
+    
+    public TransportGet() {
+        setAuthType(AuthType.NONE);
+    }
+    
+    @Test
+    public void testTransportGet() {
+        addSnippetParam("sample.communityId", community.getCommunityUuid());
+        
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(0)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("url"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("options"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("data"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("text"));
+        Assert.assertNotNull(((JsonJavaObject)jsonList.get(1)).getString("xhr"));
+        Assert.assertEquals(200, ((JsonJavaObject)jsonList.get(1)).getInt("status"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/CommunitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/CommunitiesTestSuite.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ com.ibm.sbt.test.js.connections.CommunitiesTestSuite.class })
+public class CommunitiesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+    	TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/FilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/FilesTestSuite.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ com.ibm.sbt.test.js.connections.FilesTestSuite.class })
+public class FilesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+    	TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/ProfilesGridTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/ProfilesGridTestSuite.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetConnections;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContactByGUID;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContacts;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContactsByIndex;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetProfileByGUID;
+import com.ibm.sbt.test.js.smartcloud.profiles.controls.Colleagues;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ Colleagues.class })
+public class ProfilesGridTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+    	TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/ProfilesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/ProfilesTestSuite.java
@@ -1,0 +1,53 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetConnections;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContactByGUID;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContacts;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetContactsByIndex;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetMyProfile;
+import com.ibm.sbt.test.js.smartcloud.profiles.GetProfileByGUID;
+
+/**
+ * @author mwallace
+ * 
+ * @date 12 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ GetConnections.class, GetContactByGUID.class, GetContacts.class, GetContactsByIndex.class, GetProfileByGUID.class, GetMyProfile.class })
+public class ProfilesTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+    	TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/SearchRestTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/SearchRestTestSuite.java
@@ -1,0 +1,60 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.connections.search.rest.ApplicationSearch;
+import com.ibm.sbt.test.js.connections.search.rest.DateSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyApplicationSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyDateSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyPeopleSearch;
+import com.ibm.sbt.test.js.connections.search.rest.MySearch;
+import com.ibm.sbt.test.js.connections.search.rest.MyTagSearch;
+import com.ibm.sbt.test.js.connections.search.rest.PeopleSearch;
+import com.ibm.sbt.test.js.connections.search.rest.Search;
+import com.ibm.sbt.test.js.connections.search.rest.TagSearch;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ Search.class, MySearch.class, PeopleSearch.class,
+		MyPeopleSearch.class, TagSearch.class, MyTagSearch.class,
+		ApplicationSearch.class, MyApplicationSearch.class, DateSearch.class,
+		MyDateSearch.class })
+public class SearchRestTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/SearchTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/SearchTestSuite.java
@@ -1,0 +1,61 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import com.ibm.sbt.automation.core.environment.TestEnvironment;
+import com.ibm.sbt.automation.core.environment.TestEnvironmentFactory;
+import com.ibm.sbt.test.js.connections.search.PeopleSearch;
+import com.ibm.sbt.test.js.connections.search.api.GetApplications;
+import com.ibm.sbt.test.js.connections.search.api.GetDates;
+import com.ibm.sbt.test.js.connections.search.api.GetMyApplications;
+import com.ibm.sbt.test.js.connections.search.api.GetMyDates;
+import com.ibm.sbt.test.js.connections.search.api.GetMyPeople;
+import com.ibm.sbt.test.js.connections.search.api.GetMyResults;
+import com.ibm.sbt.test.js.connections.search.api.GetMyTags;
+import com.ibm.sbt.test.js.connections.search.api.GetPeople;
+import com.ibm.sbt.test.js.connections.search.api.GetResults;
+import com.ibm.sbt.test.js.connections.search.api.GetTags;
+
+/**
+ * @author mwallace
+ * 
+ * @date 6 Mar 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ PeopleSearch.class, GetApplications.class, GetDates.class,
+		GetMyApplications.class, GetMyDates.class, GetMyPeople.class,
+		GetMyResults.class, GetMyTags.class, GetPeople.class, GetResults.class,
+		GetTags.class })
+public class SearchTestSuite {
+    @BeforeClass
+    public static void init() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.enableSmartCloud();
+    }
+    
+    @AfterClass
+    public static void cleanup() {
+        TestEnvironment environment = TestEnvironmentFactory.getEnvironment();
+        environment.disableSmartCloud();
+        TestEnvironment.cleanup();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetConnections.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetConnections.java
@@ -1,0 +1,41 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+
+/**
+ * @author Vimal Dhupar
+ * @date 22 May 2013
+ */
+public class GetConnections extends BaseProfilesTest {
+
+	static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetConnections";
+
+	@Test
+	public void testGetConnections() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		List jsonList = previewPage.getJsonList();
+		Assert.assertFalse("Get Profile  returned no results", jsonList.isEmpty());
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContactByGUID.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContactByGUID.java
@@ -1,0 +1,39 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+
+/**
+ * @author Vimal Dhupar
+ * @date 22 May 2013
+ */
+public class GetContactByGUID extends BaseProfilesTest {
+
+	static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetContactByGUID";
+
+	@Test
+	public void testGetContactByGUID() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		JsonJavaObject json = previewPage.getJson();
+		Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContacts.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContacts.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+
+/**
+ * @author Vimal Dhupar
+ * @date 22 May 2013
+ */
+public class GetContacts extends BaseProfilesTest {
+
+	static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetContacts";
+
+	@Test
+	public void testGetContacts() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		List json = previewPage.getJsonList();
+		Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContactsByIndex.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetContactsByIndex.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+
+/**
+ * @author Vimal Dhupar
+ * @date 22 May 2013
+ */
+public class GetContactsByIndex extends BaseProfilesTest {
+
+	static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetContactsByIndex";
+
+	@Test
+	public void testGetContactsByIndex() {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		List json = previewPage.getJsonList();
+		Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetMyProfile.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetMyProfile.java
@@ -1,0 +1,48 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import org.junit.Assert;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+import com.ibm.sbt.services.client.SBTServiceException;
+
+/**
+ * @author Lorenzo Boccaccia
+ * @date 22 May 2013
+ */
+public class GetMyProfile extends BaseProfilesTest {
+
+    static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetMyProfile";
+
+    @Test
+    public void testGetMyProfile() throws SBTServiceException {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+    }
+
+    @Test
+    public void testOrgIdRegression() throws SBTServiceException {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+        String orgId = json.getString("getOrgId");
+        Assert.assertFalse(Integer.valueOf(orgId) == 0);
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetProfileByGUID.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/GetProfileByGUID.java
@@ -1,0 +1,40 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+import com.ibm.sbt.automation.core.test.smartcloud.BaseProfilesTest;
+import com.ibm.sbt.services.client.SBTServiceException;
+
+/**
+ * @author Vimal Dhupar
+ * @date 22 May 2013
+ */
+public class GetProfileByGUID extends BaseProfilesTest {
+
+	static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_GetProfileByGUID";
+
+	@Test
+	public void testGetProfileByGUID() throws SBTServiceException {
+		JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+		JsonJavaObject json = previewPage.getJson();
+		Assert.assertFalse("Get Profile  returned no results", json.isEmpty());
+	}
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/ProfileEntryJsonDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/ProfileEntryJsonDataHandler.java
@@ -1,0 +1,65 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author Vimal Dhupar
+ *  
+ * @date 10th June, 2013
+ */
+public class ProfileEntryJsonDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_ProfileEntryJsonDataHandler";
+
+    @Test
+    public void testProfileEntryJsonDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        
+        Assert.assertEquals("na.collabserv.com:user:20547574", json.getString("entityId"));
+        
+        Assert.assertEquals("Sales Executive", json.getString("title")); 
+        Assert.assertEquals("https://apps.na.collabserv.com/contacts/profiles/view/20547574", json.getString("profileUrl"));
+        Assert.assertEquals("Frank Adams", json.getString("name"));
+        
+        
+        Assert.assertEquals(true, json.getBoolean("thumbnailUrlB"));
+        Assert.assertEquals(true, json.getBoolean("emailB"));
+        Assert.assertEquals(true, json.getBoolean("addressB"));
+        
+        Assert.assertEquals(45609, json.getInt("phoneNumber"));
+        Assert.assertEquals(20542369, json.getInt("organisationIdN"));
+        
+        ArrayList jArray = new ArrayList();
+        jArray.add("IBM Test - SDK Renovations");
+        Assert.assertEquals(jArray, (List)json.get("departmentA"));
+        jArray.clear();
+        jArray.add("US");
+        Assert.assertEquals(jArray, (List)json.get("countryA"));
+        jArray.clear();
+        jArray.add("Sales Executive IBM Collaboration Software");
+        Assert.assertEquals(jArray, (List)json.get("aboutA"));
+    }
+    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/ProfileFeedJsonDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/ProfileFeedJsonDataHandler.java
@@ -1,0 +1,68 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author Vimal Dhupar
+ *  
+ * @date 10th June, 2013
+ */
+public class ProfileFeedJsonDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_ProfileFeedJsonDataHandler";
+
+    @Test
+    public void testProfileFeedJsonDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+    	JsonJavaObject json0 = (JsonJavaObject)jsonList.get(0);
+    	JsonJavaObject json1 = (JsonJavaObject)jsonList.get(1);
+    	
+    	Assert.assertEquals("na.collabserv.com:contact:966797", json0.getString("entityId"));
+    	Assert.assertEquals("na.collabserv.com:contact:966800", json1.getString("entityId"));
+    	
+        Assert.assertEquals("Technical Sales Manager, WorldWide Team.", json0.getString("title")); 
+        Assert.assertEquals("https://apps.na.collabserv.com/contacts/contacts/view/966797", json0.getString("profileUrl"));
+        Assert.assertEquals("https://apps.na.collabserv.com/contacts/contacts/view/966800", json1.getString("profileUrl"));
+        
+        Assert.assertEquals("Alan Goodwin", json0.getString("name"));
+        Assert.assertEquals("Philippe Riand", json1.getString("name"));
+        
+        Assert.assertEquals(false, json0.getBoolean("thumbnailUrlB"));
+        Assert.assertEquals(true, json0.getBoolean("emailB"));
+        Assert.assertEquals(true, json0.getBoolean("addressB"));
+        Assert.assertEquals(false, json1.getBoolean("thumbnailUrlB"));
+        Assert.assertEquals(true, json1.getBoolean("emailB"));
+        Assert.assertEquals(false, json1.getBoolean("addressB"));
+        
+        List jArray = new ArrayList();
+        jArray.add("IBM Test - SDK Renovations");
+        Assert.assertEquals(jArray, (List)json0.get("departmentA"));
+        Assert.assertEquals(jArray, (List)json1.get("departmentA"));
+        jArray.clear();
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/TestNumberJsonDataHandler.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/TestNumberJsonDataHandler.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author Vimal Dhupar
+ *  
+ * @date 11th June, 2013
+ */
+public class TestNumberJsonDataHandler extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Social_Profiles_SmartCloud_API_TestNumberJsonDataHandler";
+
+    @Test
+    public void testProfileEntryJsonDataHandler() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        
+        Assert.assertEquals(123, json.getInt("number"));
+        Assert.assertEquals(12.12, json.getDouble("decimalNumber"),0.01);
+        Assert.assertEquals(234, json.getInt("stringNumber"));
+        Assert.assertEquals(4, json.getInt("array"));
+        //commenting out the below tests, because the jsonBeanStringify is currently not adding the NaN values in the json response.
+//        Assert.assertEquals(Double.NaN, json.getAsInt("notANumber"),0.01);
+//        Assert.assertEquals(Double.NaN, json.getAsInt("notANumber1"),0.01);
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/controls/Colleagues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/controls/Colleagues.java
@@ -1,0 +1,41 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles.controls;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author sberrybyrne
+ * @date 6 Mar 2013
+ */
+public class Colleagues extends BaseGridTest {
+	
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && environment.isSmartCloud();
+	}
+
+    @Test @Ignore
+    public void colleaguesGridTest() {
+        setAuthType(AuthType.OAUTH10);
+        assertTrue("Expected the test to generate a grid", checkGrid("Social_Profiles_SmartCloud_Controls_Colleagues"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/controls/MyProfilePanel.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/smartcloud/profiles/controls/MyProfilePanel.java
@@ -1,0 +1,98 @@
+/**
+ * 
+ */
+package com.ibm.sbt.test.js.smartcloud.profiles.controls;
+
+import static org.junit.Assert.assertTrue;
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.BaseTest.AuthType;
+import com.ibm.sbt.automation.core.test.pageobjects.PanelResultPage;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+import com.ibm.sbt.automation.core.utils.Trace;
+
+/**
+ * @author mwallace
+ *
+ */
+public class MyProfilePanel extends BaseTest {
+
+	/**
+	 * Constructor
+	 */
+	public MyProfilePanel() {
+		setAuthType(AuthType.AUTO_DETECT);
+	}
+	
+	@Override
+	protected boolean isEnvironmentValid() {
+		return super.isEnvironmentValid() && environment.isSmartCloud();
+	}
+
+    @Test
+    public void testProfilePanel() {
+        assertTrue("Expected the test to generate a grid", checkPanel("Social_Profiles_SmartCloud_Controls_MyProfilePanel"));
+    }																
+
+    /**
+     * Check the panel
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected boolean checkPanel(String snippetId) {
+    	PanelResultPage resultPage = launchPanel(snippetId);
+        
+        return checkPanel(resultPage, snippetId);
+    }
+    
+    /**
+     * Launch the list snippet and return a PanelResultPage
+     * 
+     * @param snippetId
+     * @return
+     */
+    protected PanelResultPage launchPanel(String snippetId) {
+        ResultPage resultPage = super.launchSnippet(snippetId, authType);
+        return new PanelResultPage(resultPage);
+    }
+    
+    /**
+     * Return true if a Panel was created on the page i.e. could find ul, multiple li's
+     * @return
+     */
+    protected boolean checkPanel(PanelResultPage resultPage, String snippetId) {
+       Trace.log("Panel result page: " + resultPage.getText());
+       
+       String photoUrl = resultPage.getPhotoUrl();
+       Assert.assertFalse("Invalid photo url", StringUtil.isEmpty(photoUrl));
+       
+       String[] details = resultPage.getDetails();
+       Assert.assertFalse("Invalid details", details == null || details.length == 0);
+       Assert.assertEquals("Invalid details", 2, details.length);
+       
+       return true;
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedMatch()
+     */
+    @Override
+    public String getAuthenticatedMatch() {
+    	return getProperty("smartcloud.displayName1");
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.automation.core.test.BaseTest#getAuthenticatedCondition()
+     */
+    @Override
+    public String getAuthenticatedCondition() {
+    	return "linkText";
+    }
+    	
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/utilities/CheckJavaScriptLibrary.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/utilities/CheckJavaScriptLibrary.java
@@ -1,0 +1,56 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.utilities;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.automation.core.test.BaseAuthServiceTest;
+import com.ibm.sbt.automation.core.test.BaseTest;
+import com.ibm.sbt.automation.core.test.pageobjects.ResultPage;
+
+/**
+ * @author priand
+ */
+public class CheckJavaScriptLibrary extends BaseTest {
+
+	public static final String SNIPPET_ID = "Utilities_Check_JavaScript_Library";
+	
+    @Test
+    public void testNoError() {
+        String text = executeSnippet(SNIPPET_ID);
+        assertTrue(StringUtil.indexOfIgnoreCase(text, "dojo")>=0);
+        assertTrue(StringUtil.indexOfIgnoreCase(text, "1.8.0")>=0);
+    }
+    
+    /**
+     * @param snippetId
+     * @return
+     */
+    protected String executeSnippet(String snippetId) {
+        ResultPage resultPage = launchSnippet(snippetId, authType);
+        String text =  resultPage.getText();
+        
+        //dumpResultPage(resultPage);
+                
+        if (text != null && text.startsWith("Show Snippet Code")) {
+            text = text.substring("Show Snippet Code".length());
+        }
+        return (text == null) ? null : text.trim();
+    }    
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/utilities/UtilitiesTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/utilities/UtilitiesTestSuite.java
@@ -1,0 +1,32 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.utilities;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * @author priand
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ CheckJavaScriptLibrary.class })
+public class UtilitiesTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/SampleFrameworkTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/SampleFrameworkTestSuite.java
@@ -1,0 +1,35 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample;
+
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+import com.ibm.sbt.test.sample.framework.SampleFrameworkJava;
+import com.ibm.sbt.test.sample.framework.SampleFrameworkJavaScript;
+
+/**
+ * @author Francis
+ * @date 24 May 2013
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ SampleFrameworkJava.class, SampleFrameworkJavaScript.class })
+public class SampleFrameworkTestSuite {
+    @AfterClass
+    public static void cleanup() {
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyColleagues.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyColleagues.java
@@ -1,0 +1,38 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample.app.mySocial;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 19 June 2013
+ */
+public class MyColleagues extends BaseGridTest {
+
+	@Override
+	protected boolean isEnvironmentValid() {
+		return  super.isEnvironmentValid() && !environment.isSmartCloud();
+	}
+
+    @Test
+    public void myColleaguesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("SampleApps_MySocial_My_Colleagues"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyCommunities.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyCommunities.java
@@ -1,0 +1,33 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample.app.mySocial;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 19 June 2013
+ */
+public class MyCommunities extends BaseGridTest {
+
+    @Test
+    public void myCommunitiesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("SampleApps_MySocial_My_Communities"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyFiles.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/app/mySocial/MyFiles.java
@@ -1,0 +1,32 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample.app.mySocial;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseGridTest;
+
+/**
+ * @author David Ryan
+ * @date 19 June 2013
+ */
+public class MyFiles extends BaseGridTest {
+    @Test
+    public void myFilesTest() {
+        assertTrue("Expected the test to generate a grid", checkGrid("SampleApps_MySocial_My_Files"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/framework/SampleFrameworkJava.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/framework/SampleFrameworkJava.java
@@ -1,0 +1,86 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample.framework;
+
+import static org.junit.Assert.assertTrue;
+import java.util.List;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import com.ibm.sbt.automation.core.test.BaseSampleFrameworkTest;
+import com.ibm.sbt.automation.core.test.pageobjects.SampleFrameworkResultPage;
+
+/**
+ * @author Francis
+ * @date 24 May 2013
+ */
+public class SampleFrameworkJava extends BaseSampleFrameworkTest{
+	
+	public SampleFrameworkJava(){
+		snippetType = SnippetType.JAVAFRAMEWORK;
+	}
+	
+	
+	@Test
+	public void testFramework() {
+	    SampleFrameworkResultPage resultPage = launchSampleFramework();
+        assertTrue("Expected the main container to be displayed", checkMainContent(resultPage));
+        assertTrue("Expected tree to be displayed", checkTree(resultPage));
+        if(getTestEnvironment().isSmartCloud())
+            assertTrue("Expected the smartcloud navigation bar to be present", checkSmartcloudNavBar(resultPage));
+        
+        clickLeafNode(resultPage);
+
+        assertTrue("Expected the code divs to contain code after clicking leaf node", checkCodeDivs(resultPage));
+        
+        
+        toIframeContext(resultPage);
+        assertTrue("Expected iframe to contain html after clicking leaf node", checkIframe(resultPage));
+	}
+	
+	
+	
+	/*
+     * Check if the Sample Framework's main content is displayed on the page
+     * 
+     * @param snippetId
+     * @return true if displayed
+     */
+    protected boolean checkSampleFramework() {
+        SampleFrameworkResultPage resultPage = launchSampleFramework();
+        return resultPage.getMainContent().isDisplayed();
+    }
+    
+    /*
+     * Check if the js snippet has some content, and test that the nav bar works.
+     * 
+     * @param snippetId - the sample framework page
+     * @return true if displayed
+     */
+    private boolean checkCodeDivs(SampleFrameworkResultPage resultPage) {
+        WebElement jspDiv = resultPage.getJspSnippetDiv();
+        String jspContent = jspDiv.getAttribute("innerHTML");
+        WebElement ulNav = resultPage.getCodeNav();
+        List<WebElement> tabList = ulNav.findElements(By.xpath(".//a"));
+        WebDriverWait wait = new WebDriverWait(resultPage.getWebDriver(), 2);
+        tabList.get(1).click();
+        boolean docDivDisplayed = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(SampleFrameworkResultPage.DOCSNIPPETDIV))).isDisplayed();
+
+        return jspContent != null && docDivDisplayed;
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/framework/SampleFrameworkJavaScript.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/sample/framework/SampleFrameworkJavaScript.java
@@ -1,0 +1,79 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.sample.framework;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import com.ibm.sbt.automation.core.test.BaseSampleFrameworkTest;
+import com.ibm.sbt.automation.core.test.pageobjects.SampleFrameworkResultPage;
+
+/**
+ * @author Francis
+ * @date 24 May 2013
+ */
+public class SampleFrameworkJavaScript extends BaseSampleFrameworkTest {
+
+    public SampleFrameworkJavaScript() {
+        snippetType = SnippetType.JAVASCRIPTFRAMEWORK;
+    }
+
+    @Test
+    @Ignore
+    public void testFramework() {
+        SampleFrameworkResultPage resultPage = launchSampleFramework();
+        assertTrue("Expected the main container to be displayed", checkMainContent(resultPage));
+        assertTrue("Expected tree to be displayed", checkTree(resultPage));
+        if(getTestEnvironment().isSmartCloud())
+            assertTrue("Expected the smartcloud navigation bar to be present", checkSmartcloudNavBar(resultPage));
+        
+        clickLeafNode(resultPage);
+
+        assertTrue("Expected the code divs to contain code after clicking leaf node", checkCodeDivs(resultPage));
+        toIframeContext(resultPage);
+        assertTrue("Expected iframe to contain html after clicking leaf node", checkIframe(resultPage));
+    }
+
+    /*
+     * Check if the js snippet has some content, and test that the nav bar works.
+     * 
+     * @param snippetId - the sample framework page
+     * @return true if displayed
+     */
+    private boolean checkCodeDivs(SampleFrameworkResultPage resultPage) {
+        WebElement jsDiv = resultPage.getJsSnippetDiv();
+        String jsContent = jsDiv.getAttribute("innerHTML");
+        WebElement ulNav = resultPage.getCodeNav();
+        List<WebElement> tabList = ulNav.findElements(By.xpath(".//a"));
+        WebDriverWait wait = new WebDriverWait(resultPage.getWebDriver(), 5l);
+        tabList.get(1).click();
+        boolean htmlDivDisplayed = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(SampleFrameworkResultPage.HTMLSNIPPETDIV))).isDisplayed();
+        tabList.get(2).click();
+        boolean cssDivDisplayed = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(SampleFrameworkResultPage.CSSSNIPPETDIV))).isDisplayed();
+        tabList.get(3).click();
+        boolean docDivDisplayed = wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(SampleFrameworkResultPage.DOCSNIPPETDIV))).isDisplayed();
+
+        return jsContent != null && htmlDivDisplayed && cssDivDisplayed && docDivDisplayed;
+    }
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/samples/acme/TestAcmeSampleApp.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/samples/acme/TestAcmeSampleApp.java
@@ -1,0 +1,32 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.samples.acme;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import com.ibm.sbt.automation.core.test.BaseAcmeTest;
+
+public class TestAcmeSampleApp extends BaseAcmeTest{
+	
+	@Test
+	public void checkSample(){
+		
+		assertTrue("Expected to be able to book a flight and have it display in the my flights page", testAcmeAirlinesSample());
+	}
+	
+}


### PR DESCRIPTION
added two selenium projects
those are to be opened as maven project as we cannot distribute dependencies ourselves

this patch removes completely the use of an absolute target folder as a staging area, 
reverting to maven default, because:
- test project use the java API so to have the latest must be part of the same reactor build
- eclipse doesn't understand projects with non standard target folder
- the absolute target folder from the parent was inherited by the test project, being in the same pom tree.
