### PR TITLE
hard link to jsdoc page

### DIFF
--- a/samples/j2ee/com.ibm.sbt.landing/WebContent/index.html
+++ b/samples/j2ee/com.ibm.sbt.landing/WebContent/index.html
@@ -20,7 +20,7 @@
  		<p>
  		   <a class="btn btn-primary btn-large" href="/sbt.sample.web">Toolkit Samples</a>
 		   <a class="btn btn-primary btn-large" href="/acme.social.sample.webapp">Acme Airline Sample</a>
-           <a class="btn btn-primary btn-large" href="jsdoc">Javascript API Documentation</a>
+           <a class="btn btn-primary btn-large" href="http://localhost:8080/jsdoc">Javascript API Documentation</a>
            <a class="btn btn-primary btn-large" href="javadoc">Java API Documentation</a>
         </p>
         <p>


### PR DESCRIPTION
the jsdoc was displayed incorrectly as it references
javascript libraries only available from http, not https

this link to jsdoc pages as http, allowing the required js 
file to load without mixed content being blocked by the browser
