### PR TITLE
Minor API consistency work on CommunityService JS

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Communities/Add Remove Community Members.js
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Communities/Add Remove Community Members.js
@@ -46,11 +46,11 @@ function loadMembers(community, dom) {
 
 function removeMembers(community, members, dom) {
     for (var i=0; i<members.length-1; i++) {
-        community.removeMember(members[i]);
+        community.removeMember(members[i].getUserid());
     }
 
     // wait for the last remove before reloading
-    community.removeMember(members[members.length-1]).then(
+    community.removeMember(members[members.length-1].getUserid()).then(
         function(memberId) {
             loadMembers(community, dom);
         },

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/CommunityService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/CommunityService.js
@@ -342,11 +342,11 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
          * Remove member of a community
          * 
          * @method removeMember
-         * @param {String/Object} Member id of the member or member object (of the member to be removed)
+         * @param {String} Member id of the member 
          * @param {Object} [args] Argument object
          */
-        removeMember : function(member,args) {
-            return this.service.removeMember(this.getCommunityUuid(), member, args);
+        removeMember : function(memberId,args) {
+            return this.service.removeMember(this.getCommunityUuid(), memberId, args);
         },
         
         /**
@@ -663,6 +663,17 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
         getCommunityUuid : function() {
             return this.communityUuid;
         },
+        
+        /**
+         * Return the id of the invite.
+         * 
+         * @method getId
+         * @return {String} id
+         */
+        
+        getId: function() {
+    		return this.getAsString("uid");
+    	},
 
         /**
          * Return the community invite title.
@@ -1318,15 +1329,15 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
          * 
          * @method
          * @param {String/Object} community id of the community or the community object.
-         * @param {String/Object} member id of the member or member object (of the member to be removed)
+         * @param {String} memberId id of the member
          * @param {Object} [args] Argument object
          */
-        removeMember : function(communityUuid,memberOrId,args) {
+        removeMember : function(communityUuid,memberId,args) {
             var promise = this._validateCommunityUuid(communityUuid);
             if (promise) {
                 return promise;
             }
-            var member = this._toMember(memberOrId);
+            var member = this._toMember(memberId);
             promise = this._validateMember(member);
             if (promise) {
                 return promise;


### PR DESCRIPTION
This is regarding API consistency work on CommunityService. I have just passed memberId instead of member object for removeMember operation. also add a wrapper method getId for invite class. I have modified the showcase sample to accomodate this change and verified that its working.

Unit test cases executed : CommunityTestSuite. No regressions found.
