### PR TITLE
change in name of method for getColleguesConnectionEntries to make it

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Profiles/API/GetColleaguesConnectionEntries.js
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Profiles/API/GetColleaguesConnectionEntries.js
@@ -1,7 +1,7 @@
 require([ "sbt/connections/ProfileService", "sbt/dom", "sbt/json" ], function(ProfileService,dom,json) {
     try {
         var profileService = new ProfileService();
-        var promise = profileService.getColleaguesConnectionEntry("%{name=sample.id1}");
+        var promise = profileService.getColleaguesConnectionEntries("%{name=sample.id1}");
         promise.then(
             function(connectionEntries) {
             	var result = [];

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/ProfileService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/ProfileService.js
@@ -787,13 +787,13 @@ define([ "../declare", "../lang", "../config", "../stringUtil", "./ProfileConsta
         /**
          * Get the colleagues for the specified profile as ConnectionEntries
          * 
-         * @method getColleaguesConnectionEntry
+         * @method getColleaguesConnectionEntries
          * @param {String} id userId/email of the profile
          * @param {Object} args Object representing various query parameters
          *            that can be passed. The parameters must be exactly as they are
          *            supported by IBM Connections.
          */
-        getColleaguesConnectionEntry : function(id, args) {
+        getColleaguesConnectionEntries : function(id, args) {
             // detect a bad request by validating required arguments
             var idObject = this._toIdObject(id);
             var promise = this._validateIdObject(idObject);


### PR DESCRIPTION
consistent with Java

Change of name of the getColleguesConnectionEntries in profileService JS Connections API to make it consistent with Java.
Executed the corresponding test case in profileTestSuite and they run fine.
