### PR TITLE
A NullPointerException is being thrown if name == null when calling Http...

### DIFF
--- a/src/eclipse/plugins/com.ibm.commons.runtime/src/com/ibm/commons/runtime/util/ParameterProcessor.java
+++ b/src/eclipse/plugins/com.ibm.commons.runtime/src/com/ibm/commons/runtime/util/ParameterProcessor.java
@@ -1,5 +1,5 @@
 /*
- * © Copyright IBM Corp. 2012
+ * ï¿½ Copyright IBM Corp. 2012
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License. 
@@ -97,8 +97,14 @@ public class ParameterProcessor {
 	          @Override
             public String getParameter(String parameter) {
 	              String name = ParameterProcessor.getParameterPart(parameter, "label"); 
-	              String value = finalRequest.getParameter(name);
-	              if(name == null && value == null){ // for backwards compatibility with non-labelled params...
+	              String value = null;
+	              if(name != null){
+	            	  value = finalRequest.getParameter(name);
+	              } else {
+	            	  name = ParameterProcessor.getParameterPart(parameter, "name");
+	              }
+	              
+	              if(value == null){ // for backwards compatibility with non-labelled params...
 	                  name = ParameterProcessor.getParameterPart(parameter, "name");
 	                  value = finalRequest.getParameter(name);
 	              }


### PR DESCRIPTION
A NullPointerException is being thrown if name == null when calling HttpServletRequest getParameter(). The problem with the original code was that the null check was performed AFTER the null-sensitive section of the code, causing problems when run on Linux (not sure why Windows isn't affected - the input values when run on Windows are identical to those on Linux (i.e. name is null)). Regardless, the null check should be placed before the null-sensitive code. 
