### PR TITLE
UPDATE: The SearchBlogsPublic control was missing a doc file

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Search/Controls/SearchBlogsPublic.doc.html
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Social/Search/Controls/SearchBlogsPublic.doc.html
@@ -1,0 +1,1 @@
+Demonstrates searching connections publicly visible blogs using the connections API. All blogs visible to you may also be searched as in other samples, which requires authentication.


### PR DESCRIPTION
@markewallace @daviryan - Hi. Was browsing the search samples and noticed that SearchBlogsPublic was missing a doc.html file - added!
