### PR TITLE
fixed for endpoint cookie handling

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SSOEndpoint.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/endpoints/SSOEndpoint.java
@@ -17,6 +17,12 @@
 package com.ibm.sbt.services.endpoints;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.StringTokenizer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Cookie;
 
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -29,7 +35,12 @@ import org.apache.http.impl.cookie.BasicClientCookie2;
 import org.apache.http.protocol.HttpContext;
 
 import com.ibm.commons.runtime.Context;
+import com.ibm.commons.runtime.util.UrlUtil;
+import com.ibm.commons.util.PathUtil;
+import com.ibm.commons.util.StringUtil;
 import com.ibm.sbt.security.authentication.AuthenticationException;
+import com.ibm.sbt.service.core.handlers.BasicAuthCredsHandler;
+import com.ibm.sbt.service.core.servlet.ServiceServlet;
 import com.ibm.sbt.services.client.ClientServicesException;
 import com.ibm.sbt.services.endpoints.js.JSReference;
 
@@ -42,6 +53,9 @@ import com.ibm.sbt.services.endpoints.js.JSReference;
 public class SSOEndpoint extends AbstractEndpoint {
 
     private static final long serialVersionUID = 1L;
+    
+    private String authenticationPage = null;
+    
 
     public SSOEndpoint() {
     }
@@ -53,6 +67,48 @@ public class SSOEndpoint extends AbstractEndpoint {
 
     @Override
 	public void authenticate(boolean force) throws ClientServicesException {
+    	  if(force || !isAuthenticated()) {
+              String authPage = getAuthenticationPage();
+           	Context context = Context.get();
+              if(StringUtil.isNotEmpty(authPage)) {
+              	try{
+              		if(!UrlUtil.isAbsoluteUrl(authPage)){
+              			authPage = UrlUtil.makeUrlAbsolute((HttpServletRequest)context.getHttpRequest(), authPage);
+                  	}
+
+              		String redirectUrl = UrlUtil.getRequestUrl((HttpServletRequest)context.getHttpRequest());// change needed to handle portlethttprequest
+              		
+              	   	String endPointName = authPage.substring(authPage.indexOf("=")+1, authPage.length());
+                  	String baseUrl = UrlUtil.getBaseUrl(((HttpServletRequest)context.getHttpRequest()));
+                  	String servletPath = ServiceServlet.getServletPath();
+                  	String basicProxyUrl = BasicAuthCredsHandler.URL_PATH;
+                      
+                  	//constructing proxy action url
+                  	String postToProxy = PathUtil.concat(baseUrl, servletPath, '/');
+                  	postToProxy = PathUtil.concat(postToProxy,basicProxyUrl, '/');
+                  	postToProxy = PathUtil.concat(postToProxy,endPointName, '/');
+                  	postToProxy = PathUtil.concat(postToProxy,"JavaApp", '/');
+                  	
+                  	// encode URL's
+  		           	postToProxy = URLEncoder.encode(postToProxy,"UTF-8");
+  		         	redirectUrl = URLEncoder.encode(redirectUrl,"UTF-8");
+                  	
+                  	// passing proxy action url as a parameter to the authentication page
+                  	authPage = PathUtil.concat(authPage,"proxyPath",'&');
+                  	authPage = PathUtil.concat(authPage,postToProxy,'=');
+                  	// passing redirectURL as a parameter to the authentication page
+                  	authPage = PathUtil.concat(authPage,"redirectURL",'&');
+                  	authPage = PathUtil.concat(authPage,redirectUrl,'=');
+                  	context.sendRedirect(authPage);
+                         
+                      
+              	} catch (IOException e) {
+              		throw new ClientServicesException(null,"LTPA token expired or invalid. Cannot refresh: authentication page is not set");
+              	}
+              } else {
+              	throw new ClientServicesException(null,"LTPA token expired or invalid. Cannot refresh: authentication page is not set");
+              }
+          }
     }
 
     @Override
@@ -76,10 +132,35 @@ public class SSOEndpoint extends AbstractEndpoint {
         String _domain;
 
         public LtpaInterceptor(String url) {
-            _domain = url.substring(url.indexOf("//")+2);
-            if(_domain.indexOf(":")!=-1) {
-                _domain = _domain.substring(0, _domain.indexOf(":"));
-            }
+        	try {
+        		URL u = new URL(url);
+        		_domain = u.getHost();
+        		//handles ipv6 hosts
+        		if (_domain.startsWith("[") && _domain.endsWith("]")) {
+        			_domain = _domain.substring(0, _domain.length()-1);
+        		}
+        		
+        	} catch (Exception e ) {
+	        	//fall back for incomplete urls
+	            _domain = url.substring(url.indexOf("//")+2);
+	            if(_domain.indexOf(":")!=-1) {
+	                _domain = _domain.substring(0, _domain.indexOf(":"));
+	            }
+        	}
+        }
+        
+        
+        public String getRawCookieValue(javax.servlet.http.Cookie cookie, HttpServletRequest request) {
+        	String co = request.getHeader("cookie");
+        	StringTokenizer st = new StringTokenizer(co, "; ");
+        	while (st.hasMoreTokens()) {
+        		String cs = st.nextToken();
+        		if (cs.substring(0, cs.indexOf('=')).equals(cookie.getName())) {
+        			String value =  cs.substring(cs.indexOf('=')+1);
+        		return value;
+        		}
+    		}
+        	return cookie.getValue();
         }
 
         @Override
@@ -94,7 +175,7 @@ public class SSOEndpoint extends AbstractEndpoint {
             java.util.Map<java.lang.String, java.lang.Object> cookieMap = ctx.getRequestCookieMap();
             if(cookieMap.containsKey("LtpaToken")) {
                 javax.servlet.http.Cookie cookie = (javax.servlet.http.Cookie) cookieMap.get("LtpaToken");
-                BasicClientCookie2 cookie1 = new BasicClientCookie2(cookie.getName(), cookie.getValue());
+                BasicClientCookie2 cookie1 = new BasicClientCookie2(cookie.getName(), getRawCookieValue(cookie, ctx.getHttpRequest()));
                 if(cookie.getDomain()!=null) {
                     cookie1.setDomain(cookie.getDomain());
                 }
@@ -112,7 +193,7 @@ public class SSOEndpoint extends AbstractEndpoint {
 
             if(cookieMap.containsKey("LtpaToken2")) {
                 javax.servlet.http.Cookie cookie = (javax.servlet.http.Cookie) cookieMap.get("LtpaToken2");
-                BasicClientCookie2 cookie2 = new BasicClientCookie2(cookie.getName(), cookie.getValue());
+                BasicClientCookie2 cookie2 = new BasicClientCookie2(cookie.getName(), getRawCookieValue(cookie, ctx.getHttpRequest()));
                 if(cookie.getDomain()!=null) {
                     cookie2.setDomain(cookie.getDomain());
                 }
@@ -137,4 +218,13 @@ public class SSOEndpoint extends AbstractEndpoint {
 		// TODO Auto-generated method stub
 		
 	}
+	
+	public String getAuthenticationPage() {
+		return authenticationPage;
+	}
+	
+	public void setAuthenticationPage(String authenticationPage) {
+		this.authenticationPage = authenticationPage;
+	}
+	
 }


### PR DESCRIPTION
- domain is correctly retrieved for endpoint urls having subpaths

i.e. developerworks connections
- added support to authentication redirects and token failure modes

a redirect can be defined now to handle issuing token to users,
the redirect should then redirect back to the app
if no redirect is defined it throws an exception, Java can handle it
- now retrieves raw cookie value to resolve problem with escaping

servlet container was stripping escaping and breaking auth for some.
