### PR TITLE
corrected logic for getNumber for getting totalResults for IE

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/xpath.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/xpath.js
@@ -63,14 +63,7 @@ define(['./declare'],function(declare) {
         selectNumber : function(xmlDomCtx){
             var doc = xmlDomCtx.ownerDocument || xmlDomCtx;
             if (this.ie) {
-                try {
-                    doc.setProperty("SelectionLanguage", "XPath");
-                    doc.setProperty("SelectionNamespaces", this.nsString);
-                    if (xmlDomCtx === doc) xmlDomCtx = doc.documentElement;
-                    return xmlDomCtx.selectNodes(this.xpath).length;
-                } catch (ex) {
-                    throw "XPath is not supported";
-                }
+            	return this.selectText(xmlDomCtx);
             } else {
                 var _this = this;
                 var result = doc.evaluate(this.xpath, xmlDomCtx,


### PR DESCRIPTION
corrected logic for getNumber for getting totalResults for IE. The earlier logic was trying to select all nodes with given xpath and
returning length of them. This will not work since the xpath passed is
not of entries but of totalResults and moreover it will only return
number of entries for that page and not total results. So, the best
solution is to just return text value in case of IE.
