### PR TITLE
fix for Download community file. instead of communityId , the method now

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/java/Social/Files/Download Upload Community File.jsp
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/java/Social/Files/Download Upload Community File.jsp
@@ -14,6 +14,7 @@
  * permissions and limitations under the License.
  */-->
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<%@page import="com.ibm.sbt.services.client.connections.files.FileService"%>
 <%@page import="com.ibm.sbt.services.client.connections.files.File"%>
 <%@page import="com.ibm.commons.util.io.StreamUtil"%>
 <%@page import="java.io.ByteArrayInputStream"%>
@@ -36,21 +37,22 @@
 </head>
 
 <body>
-  <h4>Download File</h4>
+  <h4>Download Upload Community File</h4>
   <div id="content">
     <%
     try {
 	    CommunityService service = new CommunityService();
+	    FileService serviceFS = new FileService();
 	    CommunityList communities = service.getMyCommunities();
 	    String communityId = "";
 	    if(communities != null && ! communities.isEmpty())  {
 	    	communityId = communities.get(0).getCommunityUuid();
-		    FileList list = service.getCommunityFiles(communityId, null);
+		    FileList list = serviceFS.getCommunityFiles(communityId, null);
 		    String fileId = "";
 		    if(list != null && ! list.isEmpty()) {
 		    	fileId = list.get(0).getFileId();
 			    OutputStream ostream = new ByteArrayOutputStream();
-		    	long noOfBytes = service.downloadCommunityFile(ostream, fileId, communityId, null);
+		    	long noOfBytes = serviceFS.downloadCommunityFile(ostream, fileId, list.get(0).getLibraryId());
 			    out.println("File Downloaded in ostream = " + noOfBytes + "\nFile Name = " + list.get(0).getTitle());
 				InputStream istream = new ByteArrayInputStream(((ByteArrayOutputStream)ostream).toByteArray());
 				String newFileName = "TestCommUpload"+System.currentTimeMillis();

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/communities/CommunityService.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/communities/CommunityService.java
@@ -980,15 +980,15 @@ public class CommunityService extends BaseService {
 	 * Method to download a community file
 	 * @param ostream
 	 * @param fileId
-	 * @param communityId
+	 * @param libraryId - Library Id of which the file is a part. This value can be obtained by using File's getLibraryId method.
 	 * @param params
 	 * @return long
 	 * @throws CommunityServiceException
 	 */
-	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String communityId, Map<String, String> params) throws CommunityServiceException {
+	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String libraryId, Map<String, String> params) throws CommunityServiceException {
 		FileService svc = new FileService(this.endpoint);
 		try {
-			return svc.downloadCommunityFile(ostream, fileId, communityId, params);
+			return svc.downloadCommunityFile(ostream, fileId, libraryId, params);
 		} catch (FileServiceException e) {
 			throw new CommunityServiceException(e, Messages.DownloadCommunitiesException);
 		} 

--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -466,57 +466,27 @@ public class FileService extends BaseService {
 	}
 	
 	/**
-	 * Method to download a community file
+	 * Method to download a community file. A community file is a public file.
 	 * @param ostream - output stream which contains the binary content of the file
 	 * @param fileId
-	 * @param communityId
+	 * @param libraryId - Library Id of which the file is a part. This value can be obtained by using File's getLibraryId method.
 	 * @return
 	 * @throws FileServiceException
 	 */
-	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String communityId) throws FileServiceException {
-		return downloadCommunityFile(ostream, fileId, communityId, null);
+	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String libraryId) throws FileServiceException {
+		return downloadCommunityFile(ostream, fileId, libraryId, null);
 	}
 	/**
-	 * Method to download a community file
+	 * Method to download a community file. A community file is a public file. 
 	 * @param ostream - output stream which contains the binary content of the file
 	 * @param fileId
-	 * @param communityId
+	 * @param libraryId - Library Id of which the file is a part. This value can be obtained by using File's getLibraryId method.
 	 * @param params
 	 * @return long 
 	 * @throws FileServiceException
 	 */
-	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String communityId, Map<String, String> params) throws FileServiceException {
-		File file = getCommunityFile(communityId, fileId);
-		// now we have the file.. we need to download it.. 
-		String accessType = AccessType.AUTHENTICATED.getAccessType();
-		SubFilters downloadFilters = new SubFilters();
-		downloadFilters.setLibraryId(file.getLibraryId());
-		downloadFilters.setFileId(file.getFileId());
-		String resultType = ResultType.MEDIA.getResultType();
-		String requestUrl = FileServiceURIBuilder.constructUrl(FileServiceURIBuilder.FILES.getBaseUrl(), accessType, null, null,
-                null, downloadFilters, resultType); 
-		
-		Map<String, String> headers = new HashMap<String, String>();
-		headers.put(Headers.ContentType, Headers.BINARY);
-		Response response = null;
-		try {
-			response = this.getClientService().get(requestUrl, params, headers, ClientService.FORMAT_INPUTSTREAM);
-		} catch (ClientServicesException e) {
-			throw new FileServiceException(e, Messages.MessageExceptionInDownloadingFile);
-		} 
-		InputStream istream = (InputStream) response.getData();
-		long noOfBytes = 0;
-		try {
-			if (istream != null) {
-				noOfBytes = StreamUtil.copyStream(istream, ostream);
-				ostream.flush();
-			}
-		} catch (IllegalStateException e) {
-			throw new FileServiceException(e, Messages.MessageExceptionInDownloadingFile);
-		} catch (IOException e) {
-			throw new FileServiceException(e, Messages.MessageExceptionInDownloadingFile);
-		}
-		return noOfBytes;
+	public long downloadCommunityFile(OutputStream ostream, final String fileId, final String libraryId, Map<String, String> params) throws FileServiceException {
+		return downloadFile(ostream, fileId, libraryId, params, true);
 	}
 	
 	/**


### PR DESCRIPTION
requires a libraryId.
