### PR TITLE
Cs tags

### DIFF
--- a/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/communities/Community.java
+++ b/src/eclipse/plugins/com.ibm.sbt.core/src/com/ibm/sbt/services/client/connections/communities/Community.java
@@ -175,8 +175,8 @@ public class Community extends BaseEntity {
 	 */
 	public void setTags(String tags) {
 		if(StringUtil.isNotEmpty(tags) && tags.contains(" ")){
-			tags = StringUtil.replace(tags, " ", ",");
-			setTags(Arrays.asList(StringUtil.splitString(tags, ',')));
+			tags = tags.trim();
+			setTags(Arrays.asList(StringUtil.splitString(tags, ' ')));
 		}
 		else if(StringUtil.isNotEmpty(tags) && tags.contains(",")){
 			setTags(Arrays.asList(StringUtil.splitString(tags, ',')));


### PR DESCRIPTION
updated setTags method for community, so as to split the tags which contain space or comma.
this is required  to keep in sync with web UI , when any tag is added with space or comma, then it is split
