### PR TITLE
BUGFIX: Correct string is now displayed when a bookmark has no tags

### DIFF
--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/bookmarks/BookmarkGridRenderer.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/bookmarks/BookmarkGridRenderer.js
@@ -68,7 +68,7 @@ define(["../../../declare", "../../../i18n",
 	             if (tags == undefined) {
 	                 return "";
 	             } else {
-	                 var tagsStr = "";
+	                 var tagsStr = nls.noTags;
 	                 if (lang.isArray(tags)) {
 	                     for (var i=0; i<tags.length; i++) {
 	                         tagsStr += this._substitute(this.tagAnchorTemplate, { tagName : tags[i] });

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/bookmarks/nls/BookmarkGridRenderer.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/connections/controls/bookmarks/nls/BookmarkGridRenderer.js
@@ -20,6 +20,7 @@ define({
     	tags : "Tags: ",
         date: "Date",
         popularity: "Popularity",
-        feed : "Feed for these Bookmarks"
+        feed : "Feed for these Bookmarks",
+        noTags : "No tags"
     }
 });


### PR DESCRIPTION
@markewallace - Hi Mark. Fixed the issue you addressed in the mail from earlier. ("When a bookmark has no tags then the row should display "Tags: No tags"")
