### PR TITLE
FileAddComment.java : fix for deleteWithRecord after bug fix in getBoolean(). Now its returning the correct value "false"

### DIFF
--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/FileAddComment.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/connections/files/api/FileAddComment.java
@@ -43,7 +43,7 @@ public class FileAddComment extends BaseFilesTest {
 		assertEquals(fileEntry.getAuthor().getUserUuid(), json.getJsonObject("getModifier").getString("modifierUserId"));
 		assertEquals(fileEntry.getAuthor().getUserState(), json.getJsonObject("getModifier").getString("modifierUserState"));
 		assertEquals("en", json.getString("getLanguage"));
-		assertEquals("true", json.getString("getDeleteWithRecord"));
+		assertEquals("false", json.getString("getDeleteWithRecord"));
 	}
 
 }


### PR DESCRIPTION
The earlier one was in AddCommentToFile.java. 
