### PR TITLE
New sample to demonstrate setting endpoint in the BaseService

### DIFF
--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.doc.html
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.doc.html
@@ -1,0 +1,1 @@
+<p>Shows how to set the endpoint in the BaseService class.</p>

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.html
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.html
@@ -1,0 +1,3 @@
+<pre>
+	<div id="json" class="alert"></div>
+</pre>

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.js
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.js
@@ -1,0 +1,22 @@
+require([ "sbt/config", "sbt/lang", "sbt/dom", "sbt/json", "sbt/base/BaseService" ], 
+    function(config,lang,dom,json,BaseService) {
+        try {
+        	var results = [];
+        	
+            var baseService = new BaseService({
+                endpoint : "connections"
+            });
+            results.push(baseService);
+            
+            var endpoint = config.findEndpoint("connections");
+            baseService = new BaseService({
+                endpoint : endpoint
+            });
+            results.push(baseService);
+            
+            dom.setText("json", json.jsonBeanStringify(results));
+        } catch (error) {
+            dom.setText("json", json.jsonBeanStringify(error));
+        }
+    }
+);

--- a/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.properties
+++ b/samples/j2ee/com.ibm.sbt.sample.web/WebContent/samples/js/Toolkit/Base/BaseServiceEndpoint.properties
@@ -1,0 +1,2 @@
+description=Set endpoint in the BaseService
+tags=BaseService

--- a/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
+++ b/src/j2ee/com.ibm.sbt.web/WebContent/js/sdk/sbt/base/BaseService.js
@@ -67,13 +67,19 @@ define(["../config", "../declare", "../lang", "../log", "../stringUtil", "../Cac
          * @param {Object} args Arguments for this service.
          */
         constructor : function(args) {
-            // create an endpoint if name was specified
-            if (args && args.endpoint) {
-                this.endpoint = config.findEndpoint(args.endpoint);
+        	args = args || {};
+        	
+            // set endpoint if specified in args
+            if (args.endpoint) {
+            	if (lang.isString(args.endpoint)) {
+            		this.endpoint = config.findEndpoint(args.endpoint);
+            	} else {
+            		this.endpoint = args.endpoint;
+            	}
             }
 
             // optionally create a cache
-            if (args && args.cacheSize) {
+            if (args.cacheSize) {
                 this._cache = new Cache(args.cacheSize);
             }
         },

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/BaseTestSuite.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/BaseTestSuite.java
@@ -22,8 +22,10 @@ import org.junit.runners.Suite.SuiteClasses;
 
 import com.ibm.sbt.automation.core.environment.TestEnvironment;
 import com.ibm.sbt.test.js.base.BaseEntity;
+import com.ibm.sbt.test.js.base.BaseService;
 import com.ibm.sbt.test.js.base.BaseServiceConstructUrl;
 import com.ibm.sbt.test.js.base.BaseServiceDeleteEntity;
+import com.ibm.sbt.test.js.base.BaseServiceEndpoint;
 import com.ibm.sbt.test.js.base.BaseServiceGetEntities;
 import com.ibm.sbt.test.js.base.BaseServiceGetEntity;
 import com.ibm.sbt.test.js.base.BaseServiceUpdateEntity;
@@ -42,6 +44,8 @@ import com.ibm.sbt.test.js.base.VCardDataHandler;
 @RunWith(Suite.class)
 @SuiteClasses({ 
     BaseEntity.class, 
+    BaseService.class,
+    BaseServiceEndpoint.class,
     BaseServiceValidation.class,
     BaseServiceConstructUrl.class,
     BaseServiceGetEntity.class, 

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseService.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseService.java
@@ -1,0 +1,42 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseService extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseService";
+    
+    @Test
+    public void testDeleteEntity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        JsonJavaObject json = previewPage.getJson();
+        Assert.assertEquals("connections", json.getJsonObject("endpoint").getString("name"));
+    }
+
+}

--- a/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceEndpoint.java
+++ b/test/selenium/com.ibm.sbt.automation.test/src/com/ibm/sbt/test/js/base/BaseServiceEndpoint.java
@@ -1,0 +1,48 @@
+/*
+ * � Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at,
+ * 
+ * http,//www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+package com.ibm.sbt.test.js.base;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.automation.core.test.BaseApiTest;
+import com.ibm.sbt.automation.core.test.pageobjects.JavaScriptPreviewPage;
+
+/**
+ * @author mwallace
+ *  
+ * @date 25 Mar 2013
+ */
+public class BaseServiceEndpoint extends BaseApiTest {
+    
+    static final String SNIPPET_ID = "Toolkit_Base_BaseServiceEndpoint";
+    
+    @Test
+    public void testDeleteEntity() {
+        JavaScriptPreviewPage previewPage = executeSnippet(SNIPPET_ID);
+        List jsonList = previewPage.getJsonList();
+        Assert.assertEquals(2, jsonList.size());
+        JsonJavaObject json = (JsonJavaObject)jsonList.get(0);
+        Assert.assertEquals("connections", json.getJsonObject("endpoint").getString("name"));
+        json = (JsonJavaObject)jsonList.get(1);
+        Assert.assertEquals("connections", json.getJsonObject("endpoint").getString("name"));
+    }
+
+}


### PR DESCRIPTION
To set the endpoint in the BaseService you must pass the endpoint name or endpoint instance in the arguments passed to the BaseService constructor. Changed the BaseService constructor to handle the case were an Endpoint instance is passed in. Added a new sample to demonstrate setting endpoint in the BaseService. 
