### PR TITLE
Parameterize libraryUrl

### DIFF
--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/LibraryRequest.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/LibraryRequest.java
@@ -1,5 +1,5 @@
 /*
- * © Copyright IBM Corp. 2012
+ * ï¿½ Copyright IBM Corp. 2012
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License. 
@@ -163,7 +163,7 @@ public class LibraryRequest {
         this.toolkitExtUrl = StringUtil.replace(params.getToolkitExtUrl(), "%local_server%", UrlUtil.getServerUrl(httpRequest));
         this.toolkitExtJsUrl = StringUtil.replace(params.getToolkitExtJsUrl(), "%local_server%", UrlUtil.getServerUrl(httpRequest));
         this.serviceUrl = StringUtil.replace(params.getServiceUrl(), "%local_application%", UrlUtil.getContextUrl(httpRequest));
-        this.libraryUrl = UrlUtil.getRequestUrl(httpRequest);
+        this.libraryUrl = params.getLibraryUrl().indexOf("%")>-1?UrlUtil.getRequestUrl(httpRequest):params.getLibraryUrl();
         this.jsLibraryUrl = StringUtil.replace(params.getJsLibraryUrl(), "%local_server%", UrlUtil.getServerUrl(httpRequest));
         this.iframeUrl = StringUtil.replace(params.getIframeUrl(), "%local_server%", UrlUtil.getServerUrl(httpRequest));
 


### PR DESCRIPTION
Added support to configure the libraryUrl. Now you can specify on sbt.properties the properties: libraryUrl, serviceUrl and toolkitUrl to override urls automatically generated on the LibraryServlet.
