### PR TITLE
Grid xss prevention

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/store/AtomStore.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/store/AtomStore.js
@@ -303,8 +303,7 @@ define(["../declare","../config","../lang", "../base/core", "../xml", "../xpath"
                         item[attrib] = null;
                     }
                 }
-                
-                //item[attrib] =  entities.decode(item[attrib]) ;
+
             }
            
             return item;


### PR DESCRIPTION
Encoding Data before is displayed in Grids, or other components that are using the Atom Store. This will prevent XSS Attacks. 
