### PR TITLE
Fix control support for Dojo 1.7.x and lower

### DIFF
--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/.settings/org.eclipse.wst.common.component
@@ -9,10 +9,10 @@
         <dependent-module archiveName="com.ibm.sbt.samples.commons-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.samples.commons/com.ibm.sbt.samples.commons">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
+        <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.xml-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
+        <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons.runtime-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
@@ -540,7 +540,7 @@ abstract public class AbstractLibrary {
 			if (enableDefineCheck(request.getJsVersion())) {
 				indent(sb).append("if(typeof define=='undefined'){").append(newLine());
 	
-				String[][] registerModules = getRegisterModules();
+				String[][] registerModules = getRegisterModules(request);
 				String[][] registerExtModules = StringUtil.isNotEmpty(request.getToolkitExtUrl()) ? getRegisterExtModules(request)
 						: null;
 				String[] requireModules = getRequireModules();
@@ -555,7 +555,7 @@ abstract public class AbstractLibrary {
 			}
 
 			// register the module paths and required modules
-			String[][] registerModulesAmd = getRegisterModulesAmd();
+			String[][] registerModulesAmd = getRegisterModulesAmd(request);
 			String toolkitExtUrl = request.getToolkitExtUrl();
 			String[][] registerExtModulesAmd = StringUtil.isNotEmpty(toolkitExtUrl) ? getRegisterExtModulesAmd(request) : null;
 			String[] requireModulesAmd = getRequireModulesAmd();
@@ -1049,12 +1049,12 @@ abstract public class AbstractLibrary {
 	/**
 	 * @return
 	 */
-	abstract protected String[][] getRegisterModules();
+	abstract protected String[][] getRegisterModules(LibraryRequest request);
 
 	/**
 	 * @return
 	 */
-	abstract protected String[][] getRegisterModulesAmd();
+	abstract protected String[][] getRegisterModulesAmd(LibraryRequest request);
 
 	/**
 	 * @return

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/DojoLibrary.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/DojoLibrary.java
@@ -115,19 +115,24 @@ public class DojoLibrary extends AbstractLibrary {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules()
+	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModules() {
+	protected String[][] getRegisterModules(LibraryRequest request) {
 		return REGISTER_MODULES;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd()
+	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModulesAmd() {
+	protected String[][] getRegisterModulesAmd(LibraryRequest request) {
+	    if (isExceedsVersion(request.getJsVersion(), minimumDojo2Version)) {
+	        REGISTER_MODULES_AMD[2][1] = PATH_SBTX_DOJO2;
+	    } else {
+            REGISTER_MODULES_AMD[2][1] = PATH_SBTX_DOJO;
+	    }
 		return REGISTER_MODULES_AMD;
 	}
 	
@@ -148,8 +153,7 @@ public class DojoLibrary extends AbstractLibrary {
 	        REGISTER_EXT_MODULES_AMD[1][1] = PATH_SBTX_DOJO2;
 	    } else {
             REGISTER_EXT_MODULES_AMD[1][1] = PATH_SBTX_DOJO;
-	    }
-	    
+	    }	    
 	    return REGISTER_EXT_MODULES_AMD;
 	}
 

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/JQueryLibrary.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/JQueryLibrary.java
@@ -52,19 +52,19 @@ public class JQueryLibrary extends RequireJSLibrary {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules()
+	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModules() {
+	protected String[][] getRegisterModules(LibraryRequest request) {
 		return REGISTER_MODULES;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd()
+	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModulesAmd() {
+	protected String[][] getRegisterModulesAmd(LibraryRequest request) {
 		return REGISTER_MODULES;
 	}
 	

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/LibraryServlet.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/LibraryServlet.java
@@ -196,8 +196,7 @@ public class LibraryServlet extends BaseToolkitServlet {
             }
         } catch (Throwable thrown) {
             // send 500 response and display causing exception
-            serviceException(req, resp, thrown, null, false); // (no lang, no
-                                                              // RTL for now)
+            serviceException(req, resp, thrown, null, false); 
 
             if (logger.isLoggable(Level.WARNING)) {
                 logger.log(Level.WARNING, "Error servicing library GET request", thrown);

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/RequireJSLibrary.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/RequireJSLibrary.java
@@ -73,19 +73,19 @@ public abstract class RequireJSLibrary extends AbstractLibrary {
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules()
+	 * @see com.ibm.sbt.jslibrary.servlet.BaseLibrary#getRegisterModules(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModules() {
+	protected String[][] getRegisterModules(LibraryRequest request) {
 		return REGISTER_MODULES;
 	}
 
 	/*
 	 * (non-Javadoc)
-	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd()
+	 * @see com.ibm.sbt.jslibrary.servlet.AbstractLibrary#getRegisterModulesAmd(LibraryRequest)
 	 */
 	@Override
-	protected String[][] getRegisterModulesAmd() {
+	protected String[][] getRegisterModulesAmd(LibraryRequest request) {
 		return REGISTER_MODULES;
 	}
 

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileService.js
@@ -1454,16 +1454,19 @@ define(
 					if (promise) {
 						return promise;
 					}
+					
 					var files = null;
 					if (typeof fileControlOrId == "string") {
 						var fileControl = document.getElementById(fileControlOrId);
-						filePath = fileControl.value;
 						files = fileControl.files;
 					} else if (typeof fileControlOrId == "object") {
-						filePath = fileControlOrId.value;
 						files = fileControlOrId.files;
 					} else {
 						return this.createBadRequestPromise("File Control or ID is required");
+					}
+					
+					if (files.length == 0) {
+						return this.createBadRequestPromise("No files selected for upload");
 					}
 
 					var file = files[0];

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/dialog/Dialog.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/dialog/Dialog.js
@@ -30,14 +30,12 @@ define([ "../../declare", "../../lang",
      */
     var Dialog = declare([ _TemplatedDialog ], {
     	
-    	dialogStyle : "",
+    	dialogStyle : "width: 525px;",
     	
     	templateString : DialogTemplate,
     	
     	buttonClass : "lotusFormButton",
     	
-    	style : "",
-
         /**
          * Constructor method for the grid.
          * Creates a default store and renderer, if none have been already created
@@ -69,17 +67,18 @@ define([ "../../declare", "../../lang",
 						templateString : widget
 					});
 				}
+				widget.dialog = this;
 				
 				this.widget = widget;
 				this.contentNode.appendChild(widget.domNode);
 			}
 			
-			// optionally hide the OK and Cancel buttons
-			if (this.hideOK && this.buttonOK) {
-				this.buttonOK.style.display = "none";
+			// optionally hide the execute and Cancel buttons
+			if (this.hideExecute && this.executeButton) {
+				this.executeButton.style.display = "none";
 			}
-			if (this.hideCancel && this.buttonCancel) {
-				this.buttonCancel.style.display = "none";
+			if (this.hideCancel && this.cancelButton) {
+				this.cancelButton.style.display = "none";
 			}
 		},
 		

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/dialog/templates/Dialog.html
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/dialog/templates/Dialog.html
@@ -20,8 +20,8 @@
 					</div>
 				</div>
 				<div class="lotusDialogFooter" dojoattachpoint="buttonsNode">
-					<input type="button" class="lotusFormButton" role="button" value="${nls.OK}" dojoattachevent="onclick: onExecute"  dojoattachpoint="buttonOK">
-					<input type="button" class="lotusFormButton" role="button" value="${nls.Cancel}" dojoattachevent="onclick: onCancel" dojoattachpoint="buttonCancel">
+					<input type="button" class="lotusFormButton" role="button" value="${nls.OK}" dojoattachevent="onclick: onExecute"  dojoattachpoint="executeButton">
+					<input type="button" class="lotusFormButton" role="button" value="${nls.Cancel}" dojoattachevent="onclick: onCancel" dojoattachpoint="cancelButton">
 				</div>
 			</form>
 		</div>


### PR DESCRIPTION
Fix to use the correct path for Dojo1 base widgets when using versions of Dojo less then version 1.8.0
