### PR TITLE
Extend File Grid To display files from a community

### DIFF
--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.doc.html
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.doc.html
@@ -1,0 +1,2 @@
+Sample To display files from a community in a grid. To display
+community files set the type parameter to "communityFiles"

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.html
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.html
@@ -1,0 +1,1 @@
+<div id="gridDiv"></div>

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.js
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.js
@@ -1,0 +1,10 @@
+require(["sbt/dom", "sbt/connections/controls/files/FileGrid"], function(dom, FileGrid) {
+        var grid = new FileGrid({
+	         type : "communityFiles",
+	         communityId:"%{name=sample.communityId1|helpSnippetId=Social_Communities_Get_My_Communities}",
+	    });
+        
+        dom.byId("gridDiv").appendChild(grid.domNode);
+        
+        grid.update();
+});

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.properties
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/samples/js/Social/Files/Controls/Community Files.properties
@@ -1,0 +1,3 @@
+description=Displays files from a community in a grid.
+tags=controls,FileGrid, FileAction, community
+theme=oneui

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileConstants.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileConstants.js
@@ -459,9 +459,15 @@ define([ "../lang", "./ConnectionsConstants" ], function(lang,conn) {
         AtomAddCommentToCommunityFile : "/${files}/basic/api/communitylibrary/{communityId}/document/{documentId}/feed",
         
         /**
-         * Get All Files in a Community
+         * Get All Community Files, Shows only files with with a libraryType of communityFiles
+         * TODO This should be renamed
          */
         AtomGetAllFilesInCommunity : "/${files}/basic/api/communitylibrary/{communityId}/feed",
+        
+        /**
+         * Get all files in a community, Shows public, private, communityFiles etc.
+         */
+        AtomGetAllCommunityFiles : "/${files}/basic/api/communitycollection/{communityId}/feed",
         
         /**
          * Get Community File

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/FileGrid.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/FileGrid.js
@@ -163,6 +163,16 @@ function(declare, lang, dom, stringUtil, sbt, parameter, Grid,
 						rendererArgs : {
 							type : "file"
 						}
+					},
+					"communityFiles" : {
+						storeArgs : {
+							url : FileConstants.AtomGetAllCommunityFiles,
+							attributes : FileConstants.FileXPath,
+							paramSchema : ParamSchema
+						},
+						rendererArgs : {
+							type : "file"
+						}
 					}
 
 				},
@@ -292,7 +302,7 @@ function(declare, lang, dom, stringUtil, sbt, parameter, Grid,
 						params = lang.mixin(params, {
 							direction : this.direction
 						});
-					}
+					}					
 
 					return this.constructUrl(url, params, this
 							.getUrlParams(), endpoint);
@@ -316,6 +326,12 @@ function(declare, lang, dom, stringUtil, sbt, parameter, Grid,
 					if (this.documentId) {
 						params = lang.mixin(params, {
 							documentId : this.documentId
+						});
+					}
+					
+					if(this.communityId){
+						params = lang.mixin(params, {
+							communityId : this.communityId
 						});
 					}
 


### PR DESCRIPTION
Extend File Grid To display files from a community. Also added new sample to demonstrate this. Added new ATOM URL to the file constants to display ALL files from a community and not just "community files". Tested and working on smartcloud and connections and on dojo 143 and dojo 180.  
