### PR TITLE
To prevent breakage for existing consumers.

### DIFF
--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/forums/model/Author.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/forums/model/Author.java
@@ -43,9 +43,14 @@ public class Author extends Person {
 //		this.dataHandler = dataHandler;
 //	}
 //	
-//	public String getUserid() {
-//		return dataHandler.getAsString(ForumsXPath.actorUserid);
-//	}
+	/*
+	 *  Keeping this method for now to prevent breakage for existing users.
+	 *  New users should use getId() instead of getUserId()
+	 */
+	@Deprecated
+	public String getUserid() {
+		return super.getId();
+	}
 //
 //	
 //	public String getName() {


### PR DESCRIPTION
Added a deprecated method getUserId() back to prevent breakage for existing consumers
