### PR TITLE
GridRender Fix

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/grid/GridRenderer.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/controls/grid/GridRenderer.js
@@ -101,7 +101,7 @@ define([ "../../declare", "../../dom", "../../lang"],
                 el.appendChild(node);
                 
                 grid._doAttachEvents(el, data);
-                grid._doAttachPoints(grid,el);
+                grid._doAttachPoints(el,grid);
             }
         },
         
@@ -126,7 +126,7 @@ define([ "../../declare", "../../dom", "../../lang"],
                 el.appendChild(node);
                 
                 grid._doAttachEvents(el, data);
-                grid._doAttachPoints(grid,el);
+                grid._doAttachPoints(el,grid);
             }
         },
         
@@ -151,7 +151,7 @@ define([ "../../declare", "../../dom", "../../lang"],
                     el.appendChild(node);
                     
                     grid._doAttachEvents(el, data);
-                    grid._doAttachPoints(grid,el);
+                    grid._doAttachPoints(el,grid);
                 }
             }
         },
@@ -376,7 +376,7 @@ define([ "../../declare", "../../dom", "../../lang"],
                 el.appendChild(node);
                 
                 grid._doAttachEvents(el, item);
-                grid._doAttachPoints(grid,el);
+                grid._doAttachPoints(el,grid);
             }
         },
 


### PR DESCRIPTION
_doAttachEvents() signature was changed recently, but the calls to this function in the gridRenderer were not updated, this is causing an error in the grids, this commit will fix.
