### PR TITLE
Changes to support untrusted SSL connections for gadgets.

### DIFF
--- a/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/config/OpenSocialContainerConfig.java
+++ b/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/config/OpenSocialContainerConfig.java
@@ -9,6 +9,11 @@ import java.util.Map;
 public interface OpenSocialContainerConfig {
 	
 	/**
+	 * Key to allow untrusted SSL connections.  Set to true or false.
+	 */
+	public static final String ALLOW_UNTRUSTED_SSL_CONNECTIONS = "domino.allowuntrustedsslconnections";
+	
+	/**
 	 * Gets the collection of properties to be overriden by the container.  If a property is not in this list
 	 * than the default value from the OpenSocial implementation will be used.
 	 * @return The collection of properties to be overriden by the container.

--- a/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/internal/DominoHttpFetcher.java
+++ b/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/internal/DominoHttpFetcher.java
@@ -1,0 +1,542 @@
+package com.ibm.sbt.opensocial.domino.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.ProxySelector;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.HttpVersion;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.client.params.HttpClientParams;
+import org.apache.http.client.protocol.RequestAddCookies;
+import org.apache.http.client.protocol.ResponseProcessCookies;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.http.conn.params.ConnRouteParams;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.entity.HttpEntityWrapper;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
+import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.params.HttpProtocolParams;
+import org.apache.http.protocol.HttpContext;
+import org.apache.shindig.common.Nullable;
+import org.apache.shindig.common.logging.i18n.MessageKeys;
+import org.apache.shindig.common.servlet.Authority;
+import org.apache.shindig.common.uri.Uri;
+import org.apache.shindig.gadgets.GadgetException;
+import org.apache.shindig.gadgets.http.BasicHttpFetcher;
+import org.apache.shindig.gadgets.http.HttpRequest;
+import org.apache.shindig.gadgets.http.HttpResponse;
+import org.apache.shindig.gadgets.http.HttpResponseBuilder;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.ibm.sbt.opensocial.domino.config.OpenSocialContainerConfig;
+import com.ibm.sbt.opensocial.domino.container.ContainerExtPoint;
+import com.ibm.sbt.opensocial.domino.container.ContainerExtPointManager;
+
+/**
+ * A simple Http fetcher that will allow connections over SSL to untrusted servers.
+ * This should not be allowed in production but for development use cases it is useful and saves time
+ * and frustration.  For this reason we allow each container to specify whether they want to allow this.
+ * For a container to allow unsecure connections they should add domino.allowuntrustedsslconnections and
+ * set it to true in their container configuration.
+ * There are some cases where we don't have the container id and when we don't we always default back to 
+ * the BasicHttpFetcher, which does not allow unsecure connections.
+ */
+@Singleton
+public class DominoHttpFetcher extends BasicHttpFetcher {
+
+	private static final int DEFAULT_CONNECT_TIMEOUT_MS = 5000;
+	private static final int DEFAULT_READ_TIMEOUT_MS = 5000;
+	private static final int DEFAULT_MAX_OBJECT_SIZE = 0;  // no limit
+	private static final long DEFAULT_SLOW_RESPONSE_WARNING = 10000;
+	private static final String CLASS = DominoHttpFetcher.class.getName();
+
+	private final ContainerExtPointManager manager;
+	private final HttpClient trustAllFetcher;
+	private final Logger LOG;
+	private final Authority authority;
+	// mutable fields must be volatile
+	private volatile int maxObjSize;
+	private volatile long slowResponseWarning;
+
+	private final Set<Class<?>> TIMEOUT_EXCEPTIONS = ImmutableSet.<Class<?>>of(ConnectionPoolTimeoutException.class,
+			SocketTimeoutException.class, SocketException.class, HttpHostConnectException.class, NoHttpResponseException.class,
+			InterruptedException.class, UnknownHostException.class);
+
+	static class GzipDecompressingEntity extends HttpEntityWrapper {
+		public GzipDecompressingEntity(final HttpEntity entity) {
+			super(entity);
+		}
+
+		@Override
+		public InputStream getContent() throws IOException, IllegalStateException {
+			// the wrapped entity's getContent() decides about repeatability
+			InputStream wrappedin = wrappedEntity.getContent();
+
+			return new GZIPInputStream(wrappedin);
+		}
+
+		@Override
+		public long getContentLength() {
+			// length of ungzipped content is not known
+			return -1;
+		}
+	}
+
+	static class DeflateDecompressingEntity extends HttpEntityWrapper {
+		public DeflateDecompressingEntity(final HttpEntity entity) {
+			super(entity);
+		}
+
+		@Override
+		public InputStream getContent()
+				throws IOException, IllegalStateException {
+
+			// the wrapped entity's getContent() decides about repeatability
+			InputStream wrappedin = wrappedEntity.getContent();
+
+			return new InflaterInputStream(wrappedin, new Inflater(true));
+		}
+
+		@Override
+		public long getContentLength() {
+			// length of ungzipped content is not known
+			return -1;
+		}
+	}
+
+
+	private TrustManager[] trustAllCerts = new TrustManager[] { new X509TrustManager() {
+		@Override
+		public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+			return null;
+		}
+
+		@Override
+		public void checkClientTrusted(X509Certificate[] certs, String authType) {
+			// Do nothing
+		}
+
+		@Override
+		public void checkServerTrusted(X509Certificate[] certs, String authType) {
+			// Do nothing
+		}
+	} };
+
+	/**
+	 * Creates a new DominoHttpFetcher.
+	 * @param basicHttpFetcherProxy The http proxy to use.
+	 * @param manager The container config manager to use.
+	 * @param log The logger.
+	 * @param authority The current server authority.
+	 */
+	@Inject
+	public DominoHttpFetcher(@Nullable @Named("org.apache.shindig.gadgets.http.basicHttpFetcherProxy")
+	String basicHttpFetcherProxy, ContainerExtPointManager manager, Logger log, Authority authority) {
+		this(DEFAULT_MAX_OBJECT_SIZE, DEFAULT_CONNECT_TIMEOUT_MS, DEFAULT_READ_TIMEOUT_MS,
+				basicHttpFetcherProxy, manager, log, authority);
+	}
+
+	/**
+	 * Creates a new DominoHttpFetcher.
+	 * @param maxObjSize Maximum size, in bytes, of the object we will fetch, 0 if no limit..
+	 * @param connectionTimeoutMs timeout, in milliseconds, for connecting to hosts.
+	 * @param readTimeoutMs timeout, in millseconds, for unresponsive connections
+	 * @param basicHttpFetcherProxy The http proxy to use.
+	 * @param manager The container extension point manager.
+	 * @param log The logger.
+	 * @param authority The server authority.
+	 */
+	public DominoHttpFetcher(int maxObjSize, int connectionTimeoutMs,
+			int readTimeoutMs, String basicHttpFetcherProxy, ContainerExtPointManager manager, Logger log, Authority authority) {
+		super(maxObjSize, connectionTimeoutMs, readTimeoutMs, basicHttpFetcherProxy);
+		final String method = "constructor";
+		setMaxObjectSizeBytes(maxObjSize);
+	    setSlowResponseWarning(DEFAULT_SLOW_RESPONSE_WARNING);
+		this.manager = manager;
+		this.LOG = log;
+		this.authority = authority;
+		Scheme sch = null;
+		try {
+			SSLContext sc = SSLContext.getInstance("SSL");
+			sc.init(null, trustAllCerts, new java.security.SecureRandom());
+			SSLSocketFactory socketFactory = new SSLSocketFactory(sc, SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+			sch = new Scheme("https", 443, socketFactory);
+		} catch(Exception e) {
+			LOG.logp(Level.WARNING, CLASS, method, "Error creating scheme for HTTPs.  The default fetcher will be used.  " +
+					"The default fetcher will not allow untrusted SSL connections.", e);
+		}
+
+		HttpParams params = new BasicHttpParams();
+
+		HttpConnectionParams.setConnectionTimeout(params, connectionTimeoutMs);
+
+		HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
+		HttpProtocolParams.setUserAgent(params, "Apache Shindig");
+		HttpProtocolParams.setContentCharset(params, "UTF-8");
+
+		HttpConnectionParams.setConnectionTimeout(params, connectionTimeoutMs);
+		HttpConnectionParams.setSoTimeout(params, readTimeoutMs);
+		HttpConnectionParams.setStaleCheckingEnabled(params, true);
+		HttpConnectionParams.setSoReuseaddr(params, true);
+
+		HttpClientParams.setRedirecting(params, true);
+		HttpClientParams.setAuthenticating(params, false);
+
+		// Create and initialize scheme registry
+		SchemeRegistry schemeRegistry = new SchemeRegistry();
+		schemeRegistry.register(new Scheme("http", 80, PlainSocketFactory.getSocketFactory()));
+		if(sch == null) {
+			schemeRegistry.register(new Scheme("https", 443, SSLSocketFactory.getSocketFactory()));
+		} else {
+			schemeRegistry.register(sch);
+		}
+
+		ThreadSafeClientConnManager cm = new ThreadSafeClientConnManager(schemeRegistry);
+		// These are probably overkill for most sites.
+		cm.setMaxTotal(1152);
+		cm.setDefaultMaxPerRoute(256);
+
+		DefaultHttpClient client = new DefaultHttpClient(cm, params);
+
+		// Set proxy if set via guice.
+		if (!Strings.isNullOrEmpty(basicHttpFetcherProxy)) {
+			String[] splits = StringUtils.split(basicHttpFetcherProxy, ':');
+			ConnRouteParams.setDefaultProxy(
+					client.getParams(), new HttpHost(splits[0], Integer.parseInt(splits[1]), "http"));
+		}
+
+		// try resending the request once
+		client.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(1, true));
+
+		// Add hooks for gzip/deflate
+		client.addRequestInterceptor(new HttpRequestInterceptor() {
+			public void process(
+					final org.apache.http.HttpRequest request,
+					final HttpContext context) throws HttpException, IOException {
+				if (!request.containsHeader("Accept-Encoding")) {
+					request.addHeader("Accept-Encoding", "gzip, deflate");
+				}
+			}
+		});
+		client.addResponseInterceptor(new HttpResponseInterceptor() {
+			public void process(
+					final org.apache.http.HttpResponse response,
+					final HttpContext context) throws HttpException, IOException {
+				HttpEntity entity = response.getEntity();
+				if (entity != null) {
+					Header ceheader = entity.getContentEncoding();
+					if (ceheader != null) {
+						for (HeaderElement codec : ceheader.getElements()) {
+							String codecname = codec.getName();
+							if ("gzip".equalsIgnoreCase(codecname)) {
+								response.setEntity(
+										new GzipDecompressingEntity(response.getEntity()));
+								return;
+							} else if ("deflate".equals(codecname)) {
+								response.setEntity(new DeflateDecompressingEntity(response.getEntity()));
+								return;
+							}
+						}
+					}
+				}
+			}
+		});
+		client.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler() );
+
+		// Disable automatic storage and sending of cookies (see SHINDIG-1382)
+		client.removeRequestInterceptorByClass(RequestAddCookies.class);
+		client.removeResponseInterceptorByClass(ResponseProcessCookies.class);
+
+		// Use Java's built-in proxy logic in case no proxy set via guice.
+		if (Strings.isNullOrEmpty(basicHttpFetcherProxy)) {
+			ProxySelectorRoutePlanner routePlanner = new ProxySelectorRoutePlanner(
+					client.getConnectionManager().getSchemeRegistry(),
+					ProxySelector.getDefault());
+			client.setRoutePlanner(routePlanner);
+		}
+
+		trustAllFetcher = client;
+	}
+
+	@Override
+	public HttpResponse fetch(HttpRequest request) throws GadgetException {
+		String container = request.getContainer();
+		ContainerExtPoint extpt = manager.getExtPoint(container);
+		if(extpt != null) {
+			OpenSocialContainerConfig config = extpt.getContainerConfig();
+			Object allowedObj = config.getProperties().get(
+					OpenSocialContainerConfig.ALLOW_UNTRUSTED_SSL_CONNECTIONS);
+			if(allowedObj instanceof Boolean) {
+				Boolean allowed = (Boolean)allowedObj;
+				if(allowed) {
+					return makeUnsecureFetch(request);
+				}
+			}
+		}
+		if(connectingToSelf(request)) {
+			return makeUnsecureFetch(request);
+		}
+		return super.fetch(request);
+	}
+	
+	private boolean connectingToSelf(HttpRequest request) {
+		final String method = "connectingToSelf";
+		try {
+			String requestHost = request.getUri().toJavaUri().getHost();
+			String authHost = new URL(authority.getOrigin()).getHost();
+			return requestHost.equalsIgnoreCase(authHost);
+		} catch (MalformedURLException e) {
+			LOG.logp(Level.WARNING, CLASS, method, "Error constuction URL from the authority's origin. Value: " 
+					+ authority.getOrigin(), e);
+			return false;
+		}
+	}
+
+	private HttpResponse makeUnsecureFetch(HttpRequest request) throws GadgetException { 
+		HttpUriRequest httpMethod = null;
+		Preconditions.checkNotNull(request);
+		final String methodType = request.getMethod();
+
+		final org.apache.http.HttpResponse response;
+		final long started = System.currentTimeMillis();
+
+		// Break the request Uri to its components:
+		Uri uri = request.getUri();
+		if (Strings.isNullOrEmpty(uri.getAuthority())) {
+			throw new GadgetException(GadgetException.Code.INVALID_USER_DATA,
+					"Missing domain name for request: " + uri,
+					HttpServletResponse.SC_BAD_REQUEST);
+		}
+		if (Strings.isNullOrEmpty(uri.getScheme())) {
+			throw new GadgetException(GadgetException.Code.INVALID_USER_DATA,
+					"Missing schema for request: " + uri,
+					HttpServletResponse.SC_BAD_REQUEST);
+		}
+		String[] hostparts = StringUtils.splitPreserveAllTokens(uri.getAuthority(),':');
+		int port = -1; // default port
+		if (hostparts.length > 2) {
+			throw new GadgetException(GadgetException.Code.INVALID_USER_DATA,
+					"Bad host name in request: " + uri.getAuthority(),
+					HttpServletResponse.SC_BAD_REQUEST);
+		}
+		if (hostparts.length == 2) {
+			try {
+				port = Integer.parseInt(hostparts[1]);
+			} catch (NumberFormatException e) {
+				throw new GadgetException(GadgetException.Code.INVALID_USER_DATA,
+						"Bad port number in request: " + uri.getAuthority(),
+						HttpServletResponse.SC_BAD_REQUEST);
+			}
+		}
+
+		String requestUri = uri.getPath();
+		// Treat path as / if set as null.
+		if (uri.getPath() == null) {
+			requestUri = "/";
+		}
+		if (uri.getQuery() != null) {
+			requestUri += '?' + uri.getQuery();
+		}
+
+		// Get the http host to connect to.
+		HttpHost host = new HttpHost(hostparts[0], port, uri.getScheme());
+
+		try {
+			if ("POST".equals(methodType) || "PUT".equals(methodType)) {
+				HttpEntityEnclosingRequestBase enclosingMethod = ("POST".equals(methodType))
+						? new HttpPost(requestUri)
+				: new HttpPut(requestUri);
+
+						if (request.getPostBodyLength() > 0) {
+							enclosingMethod.setEntity(new InputStreamEntity(request.getPostBody(), request.getPostBodyLength()));
+						}
+						httpMethod = enclosingMethod;
+			} else if ("GET".equals(methodType)) {
+				httpMethod = new HttpGet(requestUri);
+			} else if ("HEAD".equals(methodType)) {
+				httpMethod = new HttpHead(requestUri);
+			} else if ("DELETE".equals(methodType)) {
+				httpMethod = new HttpDelete(requestUri);
+			}
+			for (Map.Entry<String, List<String>> entry : request.getHeaders().entrySet()) {
+				httpMethod.addHeader(entry.getKey(), Joiner.on(',').join(entry.getValue()));
+			}
+
+			// Disable following redirects.
+			if (!request.getFollowRedirects()) {
+				httpMethod.getParams().setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, false);
+			}
+
+			// HttpClient doesn't handle all cases when breaking url (specifically '_' in domain)
+			// So lets pass it the url parsed:
+			response = trustAllFetcher.execute(host, httpMethod);
+
+			if (response == null) {
+				throw new IOException("Unknown problem with request");
+			}
+
+			long now = System.currentTimeMillis();
+			if (now - started > slowResponseWarning) {
+				slowResponseWarning(request, started, now);
+			}
+
+			return makeResponse(response);
+
+		} catch (Exception e) {
+			long now = System.currentTimeMillis();
+
+			// Find timeout exceptions, respond accordingly
+			if (TIMEOUT_EXCEPTIONS.contains(e.getClass())) {
+				if (LOG.isLoggable(Level.INFO)) {
+					LOG.logp(Level.INFO, CLASS, "fetch", MessageKeys.TIMEOUT_EXCEPTION, new Object[] {request.getUri(),CLASS,e.getMessage(),now-started});
+				}
+				return HttpResponse.timeout();
+			}
+			if (LOG.isLoggable(Level.INFO)) {
+				LOG.logp(Level.INFO, CLASS, "fetch", MessageKeys.EXCEPTION_OCCURRED, new Object[] {request.getUri(),now-started});
+				LOG.logp(Level.INFO, CLASS, "fetch", "", e);
+			}
+			// Separate shindig error from external error
+			throw new GadgetException(GadgetException.Code.INTERNAL_SERVER_ERROR, e,
+					HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		} finally {
+			// cleanup any outstanding resources..
+			if (httpMethod != null) try {
+				httpMethod.abort();
+			} catch (UnsupportedOperationException e) {
+				// ignore
+			}
+		}
+	}
+
+	/**
+	 * @param response The response to parse
+	 * @return A HttpResponse object made by consuming the response of the
+	 *         given HttpMethod.
+	 * @throws IOException when problems occur processing the body content
+	 */
+	private HttpResponse makeResponse(org.apache.http.HttpResponse response) throws IOException {
+		HttpResponseBuilder builder = new HttpResponseBuilder();
+
+		if (response.getAllHeaders() != null) {
+			for (Header h : response.getAllHeaders()) {
+				if (h.getName() != null)
+					builder.addHeader(h.getName(), h.getValue());
+			}
+		}
+
+		HttpEntity entity = response.getEntity();
+
+		if (maxObjSize > 0 && entity != null && entity.getContentLength() > maxObjSize) {
+			return HttpResponse.badrequest("Exceeded maximum number of bytes - " + maxObjSize);
+		}
+
+		byte[] responseBytes = (entity == null) ? null : toByteArraySafe(entity);
+
+		return builder
+				.setHttpStatusCode(response.getStatusLine().getStatusCode())
+				.setResponse(responseBytes)
+				.create();
+	}
+
+	/**
+	 * Change the global maximum fetch size (in bytes) for all fetches.
+	 *
+	 * @param maxObjectSizeBytes value for maximum number of bytes, or 0 for no limit
+	 */
+	@Inject(optional = true)
+	@Override
+	public void setMaxObjectSizeBytes(@Named("shindig.http.client.max-object-size-bytes") int maxObjectSizeBytes) {
+		super.setMaxObjectSizeBytes(maxObjectSizeBytes);
+		this.maxObjSize = maxObjectSizeBytes;
+	}
+
+	/**
+	 * Change the global threshold for warning about slow responses
+	 *
+	 * @param slowResponseWarning time in milliseconds after we issue a warning
+	 */
+
+	@Inject(optional = true)
+	@Override
+	public void setSlowResponseWarning(@Named("shindig.http.client.slow-response-warning") long slowResponseWarning) {
+		super.setSlowResponseWarning(slowResponseWarning);
+		this.slowResponseWarning = slowResponseWarning;
+	}
+
+	/**
+	 * Change the global connection timeout for all new fetchs.
+	 *
+	 * @param connectionTimeoutMs new connection timeout in milliseconds
+	 */
+	@Inject(optional = true)
+	@Override
+	public void setConnectionTimeoutMs(@Named("shindig.http.client.connection-timeout-ms") int connectionTimeoutMs) {
+		super.setConnectionTimeoutMs(connectionTimeoutMs);
+		trustAllFetcher.getParams().setIntParameter(HttpConnectionParams.CONNECTION_TIMEOUT, connectionTimeoutMs);
+	}
+
+	/**
+	 * Change the global read timeout for all new fetchs.
+	 *
+	 * @param readTimeoutMs new connection timeout in milliseconds
+	 */
+	@Inject(optional = true)
+	@Override
+	public void setReadTimeoutMs(@Named("shindig.http.client.read-timeout-ms") int readTimeoutMs) {
+		super.setConnectionTimeoutMs(readTimeoutMs);
+		trustAllFetcher.getParams().setIntParameter(HttpConnectionParams.SO_TIMEOUT, readTimeoutMs);
+	}
+}

--- a/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/modules/DominoModule.java
+++ b/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/modules/DominoModule.java
@@ -2,6 +2,7 @@ package com.ibm.sbt.opensocial.domino.modules;
 
 import org.apache.shindig.auth.SecurityTokenCodec;
 import org.apache.shindig.config.ContainerConfig;
+import org.apache.shindig.gadgets.http.HttpFetcher;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
 
@@ -11,10 +12,11 @@ import com.google.inject.Singleton;
 import com.ibm.sbt.opensocial.domino.config.ExtensionPointContainerConfig;
 import com.ibm.sbt.opensocial.domino.container.ContainerExtPointManager;
 import com.ibm.sbt.opensocial.domino.container.ContainerExtPointManagerProvider;
+import com.ibm.sbt.opensocial.domino.internal.DominoHttpFetcher;
 import com.ibm.sbt.opensocial.domino.security.DominoSecurityTokenCodec;
 
 /**
- * Guice module the injects default bindings for the Playground.
+ * Guice module the injects default bindings for Domino.
  *
  */
 public class DominoModule extends AbstractModule {
@@ -24,6 +26,7 @@ public class DominoModule extends AbstractModule {
 		bind(SecurityTokenCodec.class).to(DominoSecurityTokenCodec.class);
 		bind(ContainerExtPointManager.class).toProvider(ContainerExtPointManagerProvider.class);
 		bind(IExtensionRegistry.class).toProvider(ExtensionRegistryProvider.class);
+		bind(HttpFetcher.class).to(DominoHttpFetcher.class);
 	}
 	
 	/**

--- a/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/oauth/BasicDominoOAuth2Accessor.java
+++ b/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/oauth/BasicDominoOAuth2Accessor.java
@@ -84,10 +84,10 @@ DominoOAuth2Accessor {
 	public String getRedirectUri() {
 		String redirect = super.getRedirectUri();
 		//If we are using standard ports no need to put them in the URL
-		if(redirect.contains(HTTP)) {
+		if(redirect.contains(HTTP_PORT)) {
 			redirect = redirect.replace(HTTP_PORT, "");
 		}
-		if(redirect.contains(HTTPS)) {
+		if(redirect.contains(HTTPS_PORT)) {
 			redirect = redirect.replace(HTTPS_PORT, "");
 		}
 		setRedirectUri(redirect);

--- a/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/security/DominoSecurityTokenCodec.java
+++ b/domino/com.ibm.sbt.opensocial.domino/src/com/ibm/sbt/opensocial/domino/security/DominoSecurityTokenCodec.java
@@ -1,8 +1,13 @@
 package com.ibm.sbt.opensocial.domino.security;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shindig.auth.AnonymousSecurityToken;
 import org.apache.shindig.auth.BasicSecurityTokenCodec;
 import org.apache.shindig.auth.BlobCrypterSecurityTokenCodec;
@@ -21,87 +26,118 @@ import com.google.inject.Singleton;
  */
 @Singleton
 public class DominoSecurityTokenCodec implements SecurityTokenCodec {
+	private static final String CLASS = DominoSecurityTokenCodec.class.getName();
 	private static final String SECURITY_TOKEN_TYPE = "gadgets.securityTokenType";
-	  private SecurityTokenCodec secureCodec;
-	  private SecurityTokenCodec insecureCodec;
-	  private Map<String, String> tokenTypes;
-	  private ContainerConfig config;
+	private SecurityTokenCodec secureCodec;
+	private SecurityTokenCodec insecureCodec;
+	private Map<String, String> tokenTypes;
+	private ContainerConfig config;
+	private final Logger log;
 
-	  @Inject
-	  public DominoSecurityTokenCodec(ContainerConfig config) {
-	    this.config = config;
-	    this.tokenTypes = Maps.newHashMap();
-	    populateTokenTypes(config, config.getContainers(), this.tokenTypes);
-	  }
+	@Inject
+	public DominoSecurityTokenCodec(ContainerConfig config, Logger log) {
+		this.config = config;
+		this.tokenTypes = Maps.newHashMap();
+		this.log = log;
+		populateTokenTypes(config, config.getContainers(), this.tokenTypes);
+	}
 
-	  private void populateTokenTypes(ContainerConfig config, Collection<String> containerNames,
-	          Map<String, String> tokenTypes) {
-	    for (String container : containerNames) {
-	      tokenTypes.put(container, config.getString(container, SECURITY_TOKEN_TYPE));
-	    }
-	  }
+	private void populateTokenTypes(ContainerConfig config, Collection<String> containerNames,
+			Map<String, String> tokenTypes) {
+		for (String container : containerNames) {
+			tokenTypes.put(container, config.getString(container, SECURITY_TOKEN_TYPE));
+		}
+	}
 
-	  public SecurityToken createToken(Map<String, String> tokenParameters)
-	          throws SecurityTokenException {
-	    // FIXME: This is so gross that I have to do this. Shindig needs to be fixed so I can
-	    // consistently get the container from tokenParameters.
-	    String token = tokenParameters.get(SecurityTokenCodec.SECURITY_TOKEN_NAME);
-	    if (token == null || token.length() == 0) {
-	      return new AnonymousSecurityToken();
-	    }
+	public SecurityToken createToken(Map<String, String> tokenParameters)
+			throws SecurityTokenException {
+		final String method = "createToken";
+		// FIXME: This is so gross that I have to do this. Shindig needs to be fixed so I can
+		// consistently get the container from tokenParameters.
+		String token = tokenParameters.get(SecurityTokenCodec.SECURITY_TOKEN_NAME);
+		if (token == null || token.length() == 0) {
+			return new AnonymousSecurityToken();
+		}
 
-	    String[] tokenParts = token.split(":");
-	    String container;
-	    if (tokenParts.length == 2) {
-	      // BlobCrypter. Part 0 is the container. Part 1 is the encrypted blob.
-	      container = tokenParts[0];
-	    } else {
-	      // BasicCrypter. 6 is the magic number that is private static final in
-	      // BasicBlobCrypterSecurityToken
-	      container = tokenParts[6];
-	    }
+		String[] tokenParts = token.split(":");
+		String container;
+		if (tokenParts.length == 2) {
+			// BlobCrypter. Part 0 is the container. Part 1 is the encrypted blob.
+			container = tokenParts[0];
+		} else {
+			// BasicCrypter. 6 is the magic number that is private static final in
+			// BasicBlobCrypterSecurityToken
+			container = tokenParts[6];
+		}
+		
+		SecurityTokenCodec codec = getCodec(container);
+		if(codec == null) {
+			//Shindig is really bad about making sure containers are encoded before they
+			//are placed on URLs.  It basically makes the assumption that container ids do
+			//not need to be encoded and just sticks them on the URLs.  This is the case when
+			//it makes the request to the /rpc endpoint so just to be sure lets encode the container
+			//and try to look up the token type
+			try {
+				String encodedContainer = URLEncoder.encode(container, "UTF-8");
+				codec = getCodec(encodedContainer);
+				if(codec!= null) {
+					//Since the container was not properly encoded make sure it is correct in the token parameters
+					putContainerInTokenParams(tokenParameters, encodedContainer);
+				} else {
+					throw new RuntimeException("Could not find security token codec for container " + container);
+				}
+			} catch (UnsupportedEncodingException e) {
+				log.logp(Level.WARNING, CLASS, method, "Error while encoding container.");
+			}
+		}
+			
+		return codec.createToken(tokenParameters);
+	}
+	
+	public void putContainerInTokenParams(Map<String, String> tokenParams, String container) {
+		String token = StringUtils.defaultString(tokenParams.get(SecurityTokenCodec.SECURITY_TOKEN_NAME));
+		String[] parts = token.split(":");
+		if(parts.length == 2) {
+			String newToken = container + ":" + parts[1];
+			tokenParams.put(SecurityTokenCodec.SECURITY_TOKEN_NAME, newToken);
+		}
+	}
 
-	    return getCodec(container).createToken(tokenParameters);
-	  }
+	public String encodeToken(SecurityToken token) throws SecurityTokenException {
+		if (token == null) {
+			return null;
+		}
+		return getCodec(token.getContainer()).encodeToken(token);
+	}
 
-	  public String encodeToken(SecurityToken token) throws SecurityTokenException {
-	    if (token == null) {
-	      return null;
-	    }
-	    return getCodec(token.getContainer()).encodeToken(token);
-	  }
+	@Deprecated
+	public int getTokenTimeToLive() {
+		return getCodec("default").getTokenTimeToLive("defualt");
+	}
 
-	  @Deprecated
-	  public int getTokenTimeToLive() {
-	    return getCodec("default").getTokenTimeToLive("defualt");
-	  }
+	public int getTokenTimeToLive(String container) {
+		return getCodec(container).getTokenTimeToLive(container);
+	}
 
-	  public int getTokenTimeToLive(String container) {
-	    return getCodec(container).getTokenTimeToLive(container);
-	  }
+	private SecurityTokenCodec getCodec(String container) {
+		String tokenType = this.tokenTypes.get(container);
+		return getCodecByType(tokenType);
+	}
 
-	  private SecurityTokenCodec getCodec(String container) {
-	    String tokenType = this.tokenTypes.get(container);
-	    return getCodecByType(tokenType);
-	  }
+	SecurityTokenCodec getCodecByType(String tokenType) {
+		if ("insecure".equals(tokenType)) {
+			if (this.insecureCodec == null) {
+				this.insecureCodec = new BasicSecurityTokenCodec(this.config);
+			}
+			return this.insecureCodec;
+		}
 
-	  SecurityTokenCodec getCodecByType(String tokenType) {
-	    if ("insecure".equals(tokenType)) {
-	      if (this.insecureCodec == null) {
-	        this.insecureCodec = new BasicSecurityTokenCodec(this.config);
-	      }
-	      return this.insecureCodec;
-	    }
-
-	    if ("secure".equals(tokenType)) {
-	      if (this.secureCodec == null) {
-	        this.secureCodec = new BlobCrypterSecurityTokenCodec(this.config);
-	      }
-	      return this.secureCodec;
-	    }
-
-	    throw new RuntimeException("Unknown security token type specified in "
-	            + ContainerConfig.DEFAULT_CONTAINER + " container configuration. "
-	            + SECURITY_TOKEN_TYPE + ": " + tokenType);
-	  }
+		if ("secure".equals(tokenType)) {
+			if (this.secureCodec == null) {
+				this.secureCodec = new BlobCrypterSecurityTokenCodec(this.config);
+			}
+			return this.secureCodec;
+		}
+		return null;
+	}
 }

--- a/samples/domino/com.ibm.xsp.sbtsdk.playground/src/nsf/playground/environments/PlaygroundEnvironment.java
+++ b/samples/domino/com.ibm.xsp.sbtsdk.playground/src/nsf/playground/environments/PlaygroundEnvironment.java
@@ -9,6 +9,8 @@ import java.util.Map;
 
 import javax.faces.context.FacesContext;
 
+import org.apache.commons.lang3.StringUtils;
+
 import nsf.playground.beans.DataAccessBean;
 import nsf.playground.extension.Endpoints;
 
@@ -82,6 +84,7 @@ public class PlaygroundEnvironment extends SBTEnvironment implements ContainerEx
 			  null,
 			  properties);
 		setEndpointsArray(createEndpoints());
+		containerConfig.getProperties().put(OpenSocialContainerConfig.ALLOW_UNTRUSTED_SSL_CONNECTIONS, true);
 	}
 	
 	public Map<String,String> getFieldMap() {
@@ -175,7 +178,10 @@ public class PlaygroundEnvironment extends SBTEnvironment implements ContainerEx
 	@Override
 	public String getId() throws ContainerExtPointException {
 		try {
-			return URLEncoder.encode(this.notesUrl, "UTF-8");
+			//There cannot be any colons in this id or else they end up in the security token
+			//The security token uses colons for separators of different parts so remove all
+			//the colons.  In this case since it is a URL there should only be 1
+			return URLEncoder.encode(StringUtils.defaultString(this.notesUrl).replaceAll(":", ""), "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			throw new ContainerExtPointException(e);
 		}

--- a/samples/domino/nsfsrc/nsf.playground/WebContent/modules/widgets/gadgetarea/PlaygroundGadgetArea.js
+++ b/samples/domino/nsfsrc/nsf.playground/WebContent/modules/widgets/gadgetarea/PlaygroundGadgetArea.js
@@ -125,10 +125,8 @@ define(['dojo/_base/declare', 'explorer/widgets/gadgetarea/GadgetArea', 'dojo/on
         		  debug: debug
         	  });
         	  var self = this;
-        	  gadgetSpecService.postGadgetSpec(form).then(function(data){
-        		  // https require the certificates on the server... 
+        	  gadgetSpecService.postGadgetSpec(form).then(function(data){ 
         		  var url = form.action+"/"+gadgetId+"/gadget.xml";
-        		  url = url.replace("https://","http://");
         		  var jsonCode = self.jsonEditor.getValue();
         		  if(!jsonCode) {
         			  var params = {};


### PR DESCRIPTION
This allows gadget XMLs and proxied requests to be fetched over HTTPS
even if the certificate the server is using is not trusted by the JVM. 
By default this is not enabled, but containers can enable it on a
container by container basis.
