### PR TITLE
Added endpoint initialization timing

### DIFF
--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/WEB-INF/managed-beans.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/WEB-INF/managed-beans.xml
@@ -223,7 +223,7 @@
 		<managed-bean-scope>session</managed-bean-scope>
 		<managed-property>
 			<property-name>url</property-name>
-			<value>%{sso.url}</value>
+			<value>%{connections.url}</value>
 		</managed-property>
 		<!-- Trust the connection -->
 		<managed-property>

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/service/basic/ProxyEndpointService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/service/basic/ProxyEndpointService.java
@@ -124,7 +124,9 @@ public class ProxyEndpointService extends ProxyService {
     @Override
     protected boolean prepareForwardingMethod(HttpRequestBase method, HttpServletRequest request, DefaultHttpClient client) throws ServletException {
         boolean ret = super.prepareForwardingMethod(method, request, client);
+    	Object timedObject = ProxyProfiler.getTimedObject();
         initEndpoint(method, request, client, endpoint);
+        ProxyProfiler.profileTimedRequest(timedObject, "Endpoint initialization");
         return ret;
     }
 


### PR DESCRIPTION
Set sso endpoint to use the base connection url
sso.url is no longer present in properties left the endpoint broken
