### PR TITLE
Fix for smartcloud not displaying community image

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/communities/templates/CommunityRow.html
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/communities/templates/CommunityRow.html
@@ -1,6 +1,6 @@
 <tr class="${rowClass}" >
 	<td class=lotusFirstCell width=35 dojoAttachPoint="communityIcon">
-		<img role=presentation alt="" src="${communityImage}" width=64 height=64>
+		<img role=presentation alt="" src="${logoUrl}" width=64 height=64>
 	</td>
 	<td class=lotusFirstCell>
 		<h4>


### PR DESCRIPTION
Changing the src of the image so it is not loaded through the proxy as this is not needed for smartcloud or connections, however there is still an issue with the playground not loading the image but this is unrelated to this code. 
