### PR TITLE
Allow Endpoint to specify which proxy module to use

### DIFF
--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/html/EmbedFilesView.html
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/src/main/webapp/html/EmbedFilesView.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" style="height: 100%;">
+
+<head>
+<meta charset="utf-8">
+<title>Embed Files View</title>
+<link href="images/sbt.png" rel="shortcut icon">
+</head>
+
+<body>
+	<script type="text/javascript">
+	var iframe = document.createElement("iframe");
+	iframe.setAttribute("src", "http://localhost:8080/sbt.sample.web/javascriptPreview.jsp?snippet=Social_Files_Views_FilesView&jsLibId=dojo180");
+	iframe.style.width = "1200px";
+	iframe.style.height = "800px";
+	document.body.appendChild(iframe); 
+	</script>
+</body>
+</html>

--- a/samples/j2ee/templates/mysocial.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/mysocial.webapp/.settings/org.eclipse.wst.common.component
@@ -4,16 +4,10 @@
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/test/java"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
-            <dependency-type>uses</dependency-type>
-        </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
-            <dependency-type>uses</dependency-type>
-        </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="mysocial.webapp"/>

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AddSubscriberTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AddSubscriberTest.java
@@ -19,6 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.commons.util.io.json.JsonJavaObject;
+import com.ibm.sbt.services.client.base.JsonEntity;
 
 /**
  * @author mwallace
@@ -83,6 +84,10 @@ public class AddSubscriberTest extends BaseBssTest {
         	long subscriberId = response.getAsLong("Long");
         	Assert.assertNotNull("Invalid subscriber id", subscriberId);
         	System.out.println(subscriberId);
+        	
+        	JsonEntity subscriberEntity = getSubscriberManagementService().getSubscriberById(String.valueOf(subscriberId));
+        	System.out.println(subscriberEntity.toJsonString());
+        	
     	} catch (BssException be) {
     		JsonJavaObject jsonObject = be.getResponseJson();
     		System.err.println(jsonObject);

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AddSubscriptionTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AddSubscriptionTest.java
@@ -41,10 +41,12 @@ public class AddSubscriptionTest extends BaseBssTest {
     		// Step 3. Create "IBM SmartCloud Connections" Subscription
     		String engageSubscriptionId = createSubscription(customerId, 3, "D0NWLLL", 5);
     		System.out.println(engageSubscriptionId);
+    		System.out.println(getSubscriptionBYid(engageSubscriptionId).toJsonString());
 
     		// Step 4. Create Extra Storage Subscription
     		String storageSubscriptionId = createSubscription(customerId, 3, "D100PLL", 5);
     		System.out.println(storageSubscriptionId);
+    		System.out.println(getSubscriptionBYid(storageSubscriptionId).toJsonString());
 
     		// Step 5. Activate the subscriber
     		activateSubscriber(subscriberId);

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AssignRoleTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/AssignRoleTest.java
@@ -35,11 +35,16 @@ public class AssignRoleTest extends BaseBssTest {
     		String loginName = subscriber.getAsString("Subscriber/Person/EmailAddress");
     		System.out.println(loginName);
     		
-    		AuthorizationService authorizationService = getAuthorizationService();
+			AuthorizationService authorizationService = getAuthorizationService();
+    		String[] roles = authorizationService.getRoles(loginName);
+			for (String role : roles) {
+				System.out.println(role);
+			}
+
     		authorizationService.assignRole(loginName, "CustomerAdministrator");
     		authorizationService.assignRole(loginName, "CustomerPurchaser");
     		
-    		String[] roles = authorizationService.getRoles(loginName);
+    		roles = authorizationService.getRoles(loginName);
 			for (String role : roles) {
 				System.out.println(role);
 			}

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/BaseBssTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/BaseBssTest.java
@@ -239,6 +239,21 @@ public class BaseBssTest {
     	return null;
     }
     
+    public JsonEntity getSubscriptionBYid(String subscriptionId) {
+    	try {
+    		SubscriptionManagementService subscriptionManagement = getSubscriptionManagementService();
+    		return subscriptionManagement.getSubscriptionById(subscriptionId);
+    		
+    	} catch (BssException be) {
+    		JsonJavaObject jsonObject = be.getResponseJson();
+    		System.err.println(jsonObject);
+    		Assert.fail("Error retrieving subscription because: "+jsonObject);
+    	} catch (Exception e) {
+    		Assert.fail("Error retrieving subscription caused by: "+e.getMessage());    		
+    	}
+    	return null;
+    }
+    
 	public String getLoginName(String subscriberId) {
     	try {
     		JsonEntity subscriber = getSubscriberById(subscriberId);

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/EntitleSubscriberTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/smartcloud/bss/EntitleSubscriberTest.java
@@ -80,6 +80,7 @@ public class EntitleSubscriberTest extends BaseBssTest {
 			System.out.println("Entitlement: " + entitlement.toJsonString());
 			
 			jsonEntity = subscriberManagement.getSubscriberById(subscriberId);
+			System.out.println("Entitled subscriber: " + jsonEntity.toJsonString());
 			Assert.assertNotNull("Unable to retrieve activated subscriber: "+subscriberId, jsonEntity);
 			Assert.assertEquals(subscriberId, subscriberManagement.getSubscriberId(jsonEntity.getJsonObject()));
 				

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/jslibrary/servlet/AbstractLibrary.java
@@ -97,6 +97,7 @@ abstract public class AbstractLibrary {
 	public static final String		PROP_MODULE_PREFIX				= "_module";
 	public static final String		PROP_MODULE_AUTHENTICATOR		= "_moduleAuthenticator";
 	public static final String		PROP_MODULE_TRANSPORT			= "_moduleTransport";
+	public static final String		PROP_MODULE_PROXY				= "_moduleProxy";
 
 	public static final String		REF_SBT_TRANSPORT				= "sbtTransport";
 	public static final String		REF_ERR_TRANSPORT				= "errTransport";
@@ -356,6 +357,8 @@ abstract public class AbstractLibrary {
 				JsonReference proxyRef = createProxyRef(request, endpoint, endpointName);
 				if (proxyRef != null) {
 					jsonEndpoint.putJsonProperty(PROP_PROXY, proxyRef);
+					String moduleName = getProxy(request, endpoint, endpointName).getModuleName();
+					jsonEndpoint.putJsonProperty(PROP_MODULE_PROXY, moduleName);
 				}
 				String proxyPath = endpoint.getProxyPath(endpointName);
 				if (!StringUtil.isEmpty(proxyPath)) {
@@ -637,9 +640,12 @@ abstract public class AbstractLibrary {
 				// is proxy being used for this endpoint
 				if (jsonObject.getJsonProperty(PROP_PROXY) != null) {
 					// add proxy module if not already in the list
-					if (!modules.contains(MODULE_PROXY)) {
-						modules.add(MODULE_PROXY);
-						modules.add(MODULE_WPS_PROXY);
+					String proxyModule = (String) jsonObject.getJsonProperty(PROP_MODULE_PROXY);
+					if (StringUtil.isEmpty(proxyModule)) {
+						proxyModule = MODULE_PROXY;
+					}
+					if (!modules.contains(proxyModule)) {
+						modules.add(proxyModule);
 					}
 				}
 
@@ -843,6 +849,13 @@ abstract public class AbstractLibrary {
 	}
 
 	/*
+	 * Return the JSReference for the Proxy module to use
+	 */
+	protected JSReference getProxy(LibraryRequest request, Endpoint endpoint, String endpointName) {
+		return endpoint.getProxy(endpointName, getDefaultProxy(request));
+	}
+
+	/*
 	 * Return the JSReference for the Transport module to use
 	 */
 	protected String getDefaultTransport(LibraryRequest request) {
@@ -852,6 +865,13 @@ abstract public class AbstractLibrary {
 			return MODULE_MOCK_TRANSPORT;
 		}
 		return MODULE_TRANSPORT;
+	}
+
+	/*
+	 * Return the JSReference for the Proxy module to use
+	 */
+	protected String getDefaultProxy(LibraryRequest request) {
+		return MODULE_PROXY;
 	}
 
 	/*

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/AbstractEndpoint.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/AbstractEndpoint.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 
 
 
+
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.DefaultHttpClient;
 
@@ -292,6 +293,14 @@ public abstract class AbstractEndpoint implements Endpoint, Cloneable {
      */
     @Override
     public JSReference getTransport(String endpointName, String moduleId) {
+    	return new JSReference(moduleId);
+    }
+    
+    /* (non-Javadoc)
+     * @see com.ibm.sbt.services.endpoints.Endpoint#getProxy(java.lang.String, java.lang.String)
+     */
+    @Override
+    public JSReference getProxy(String endpointName, String moduleId) {
     	return new JSReference(moduleId);
     }
 

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/ApplicationEndpoint.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/ApplicationEndpoint.java
@@ -116,6 +116,11 @@ public class ApplicationEndpoint implements Endpoint {
 	public JSReference getTransport(String endpointName, String moduleId) {
     	return null;
     }
+    
+    @Override
+    public JSReference getProxy(String endpointName, String moduleId) {
+    	return null;
+    }
 
     @Override
 	public String getLabel() {

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/Endpoint.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/endpoints/Endpoint.java
@@ -76,9 +76,14 @@ public interface Endpoint {
     public JSReference getAuthenticator(String endpointName, String sbtUrl);
     
     /**
-     * Get the client transport using moduleId
+     * Get the client transport moduleId
      */
     public JSReference getTransport(String endpointName, String moduleId);
+
+    /**
+     * Get the client proxy moduleId
+     */
+    public JSReference getProxy(String endpointName, String moduleId);
 
     /**
      * Get the endpoint label, for the login dialog. 


### PR DESCRIPTION
The client proxy module can be overridden by the endpoint rather than having a hard-coded list of proxy modules being included always
