### PR TITLE
BUGFIX: Wrong argument passed into constructor

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/FileGrid.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/FileGrid.js
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2013
+ * © Copyright IBM Corp. 2013
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); 
  * you may not use this file except in compliance with the License. 


### PR DESCRIPTION
@markewallace @DaviRyan The constructor of the FileGrid, should instantiate the FileService using args not endpointName || connections (because otherwise the passed endpoint will never get used).
