### PR TITLE
Fix to support PHP proxy and removal of serviceUrl when download files

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/Endpoint.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/Endpoint.js
@@ -470,6 +470,16 @@ var Endpoint = declare(null, {
 		return promise;
 	},
 	
+	/**
+	 * Creates a download URL for the given file URL so that the download
+	 * request will go through the proxy.
+	 * 
+	 * @param string url	The actual URL to the file.
+	 */
+	rewriteUrl : function(url) {
+		return this.proxy.rewriteUrl(this.baseUrl, url, this.proxyPath);
+	},
+	
 	// Internal stuff goes here and should not be documented
 	
     /*

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/FileService.js
@@ -284,8 +284,7 @@ define(
 		 */
 		getDownloadUrl : function() {
 			var url = this.getAsString("downloadUrl");
-			var endpoint = this.service.endpoint;
-			return endpoint.proxy.rewriteUrl(endpoint.baseUrl, url, endpoint.proxyPath);
+			return this.service.endpoint.rewriteUrl(url);
 		},
 		/**
 		 * Returns the type
@@ -1739,11 +1738,7 @@ define(
 		 * @param {String} libraryId The library ID of the file
 		 */
 		downloadFile : function(fileId, libraryId) {
-//			var url = config.Properties.serviceUrl + "/files/" + this.endpoint.proxyPath + "/" + "connections" + "/" + "DownloadFile" + "/" + fileId
-//					+ "/" + libraryId;
-			var url = this.getAsString("downloadUrl");
-			var endpoint = this.service.endpoint;
-			window.open(endpoint.proxy.rewriteUrl(endpoint.baseUrl, url, endpoint.proxyPath));
+			window.open(this.getDownloadUrl());
 		},
 
 		actOnCommentAwaitingApproval : function(commentId, action, actionReason) {


### PR DESCRIPTION
@markewallace - Hi Mark. Here the temporary fix that we discussed earlier (i.e. added endpoint name to the header).
