### PR TITLE
[Fixed] string entity using local codepage for serialization without conversion

### DIFF
--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/ClientService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/ClientService.java
@@ -47,9 +47,9 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.InputStreamEntity;
-import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.util.EntityUtils;
@@ -422,7 +422,11 @@ public abstract class ClientService {
 		@Override
 		protected HttpEntity createEntity() throws ClientServicesException {
 			try {
-				return new StringEntity(content);
+				String encoding= "UTF-8";
+				ByteArrayEntity bae= new ByteArrayEntity(content.getBytes(encoding));
+				bae.setContentType(getContentType());
+				bae.setContentEncoding(encoding);
+				return bae;
 			} catch (Exception ex) {
 				throw new ClientServicesException(ex);
 			}
@@ -455,7 +459,12 @@ public abstract class ClientService {
 		@Override
 		protected HttpEntity createEntity() throws ClientServicesException {
 			try {
-				return new StringEntity(JsonGenerator.toJson(factory, content, true));
+				
+				String encoding= "UTF-8";
+				ByteArrayEntity bae= new ByteArrayEntity(JsonGenerator.toJson(factory, content, true).getBytes(encoding));
+				bae.setContentType(getContentType());
+				bae.setContentEncoding(encoding);
+				return bae;
 			} catch (Exception ex) {
 				throw new ClientServicesException(ex);
 			}
@@ -479,7 +488,14 @@ public abstract class ClientService {
 		@Override
 		protected HttpEntity createEntity() throws ClientServicesException {
 			try {
-				return new StringEntity(DOMUtil.getXMLString(content, true));
+				String encoding= "UTF-8";
+				if (content != null && content.getOwnerDocument()!=null && content.getOwnerDocument().getXmlEncoding()!=null){
+					encoding = content.getOwnerDocument().getXmlEncoding();
+				}
+				ByteArrayEntity bae= new ByteArrayEntity(DOMUtil.getXMLString(content, true).getBytes(encoding));
+				bae.setContentType(getContentType());
+				bae.setContentEncoding(encoding);
+				return bae;
 			} catch (Exception ex) {
 				throw new ClientServicesException(ex);
 			}


### PR DESCRIPTION
made content request codepage independent
StringEntity was using local codepage as default
the string is serialized and kept to the document encoding if specified
content encoding is preserved in the entity
