### PR TITLE
Community service update

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/CommunityService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/CommunityService.js
@@ -2094,7 +2094,8 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
 					
 			var headers = {
 				"Content-Type" : false,
-				"Process-Data" : false //processData = false is reaquired by jquery
+				"Process-Data" : false, //processData = false is reaquired by jquery
+				"X-Endpoint-name" : this.endpoint.name
 			};
 			var options = {
 				method : "POST",


### PR DESCRIPTION
@markewallace - Hi Mark. When changing the FileService to support file uploads through the PHP proxy I forgot to modify the CommunityService to do the same. I added a header field for the endpoint name, just as is done in the FileService.
