### PR TITLE
Widget updates

### DIFF
--- a/php/moodle-block/src/user_widgets/communities.php
+++ b/php/moodle-block/src/user_widgets/communities.php
@@ -2,10 +2,11 @@
 
 <?php 
 // Ensure that element IDs are unique
-$timestamp = time();
+$milliseconds = microtime(true) * 1000; 
+$timestamp = round($milliseconds);
 
 global $CFG;
-require_once $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-communities-grid-row.php';
+require $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-communities-grid-row.php';
 ?>
 <div id="<?php echo $this->config->elementID;?>"></div>
 <script type="text/javascript">

--- a/php/moodle-block/src/user_widgets/community-files.php
+++ b/php/moodle-block/src/user_widgets/community-files.php
@@ -2,10 +2,11 @@
 
 <?php 
 // Ensure that element IDs are unique
-$timestamp = time();
+$milliseconds = microtime(true) * 1000; 
+$timestamp = round($milliseconds);
 
 global $CFG;
-require_once $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-community-files.php';
+require $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-community-files.php';
 ?>
 
 <script type="text/javascript">
@@ -17,7 +18,7 @@ function onCommunityChange<?php echo $timestamp; ?>() {
 		var currentCommunity = communityList.options[communityList.selectedIndex].value;
 
 		var domNode = dom.byId("fileRow-<?php echo $timestamp; ?>");
-		console.log(domNode);
+
 		var FileRow = domNode.text || domNode.textContent;
 	    domNode = dom.byId("pagingHeader-<?php echo $timestamp; ?>");
 	    var PagingHeader = domNode.text || domNode.textContent;
@@ -35,7 +36,9 @@ function onCommunityChange<?php echo $timestamp; ?>() {
 	    });
 		dom.byId("ibm-sbt-community-files-list-<?php echo $timestamp; ?>").innerHTML = "";
         dom.byId("ibm-sbt-community-files-list-<?php echo $timestamp; ?>").appendChild(grid<?php echo $timestamp; ?>.domNode);
-        
+
+        grid<?php echo $timestamp; ?>.renderer.tableClass = "table";
+	    grid<?php echo $timestamp; ?>.renderer.template = FileRow;
         grid<?php echo $timestamp; ?>.update();
 	});
 }
@@ -93,9 +96,7 @@ function clearError<?php echo $timestamp; ?>(dom) {
 }
 
 function loadCommunity<?php echo $timestamp; ?>(communityService, dom) {
-	communityService.getMyCommunities({
-		ps : 1
-	}).then(function(communities) {
+	communityService.getMyCommunities({ps: 10000}).then(function(communities) {
 		var communityList = dom.byId("ibm-sbt-communities-<?php echo $timestamp; ?>");
 		for (var i = 0; i < communities.length; i++) {
 			var opt = document.createElement('option');

--- a/php/moodle-block/src/user_widgets/files-view.php
+++ b/php/moodle-block/src/user_widgets/files-view.php
@@ -1,19 +1,16 @@
 <?php 	
 // Ensure that element IDs are unique
-$timestamp = time();
+$milliseconds = microtime(true) * 1000; 
+$timestamp = round($milliseconds);
 
 global $CFG;
-require_once $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-files-view.php';
+require $CFG->dirroot . '/blocks/ibmsbt/user_widgets/templates/ibm-sbt-files-view.php';
 ?>
 
 <select id="ibm-sbt-files-view-list-<?php echo $timestamp; ?>" onchange="onFilesViewTypeChange<?php echo $timestamp; ?>();">
 	<option value="myFiles"><?php echo get_string('my_files', 'block_ibmsbt');?></option>
 	<option value="publicFiles"><?php echo get_string('public_files', 'block_ibmsbt');?></option>
 	<option value="myPinnedFiles"><?php echo get_string('my_pinned_files', 'block_ibmsbt');?></option>
-	<option value="myFolders"><?php echo get_string('my_folders', 'block_ibmsbt');?></option>
-	<option value="publicFolders"><?php echo get_string('public_folders', 'block_ibmsbt');?></option>
-	<option value="myPinnedFolders"><?php echo get_string('my_pinned_folders', 'block_ibmsbt');?></option>
-	<option value="activeFolders"><?php echo get_string('active_folders', 'block_ibmsbt');?></option>
 </select>
 <div id="<?php echo $this->config->elementID; ?>"></div>
 
@@ -39,7 +36,7 @@ function onFilesViewTypeChange<?php echo $timestamp; ?>() {
 			    var PagingFooter = domNode.text || domNode.textContent;
 			    domNode = dom.byId("filesViewRow<?php echo $timestamp; ?>");
 			    var FileRow = domNode.text || domNode.textContent;
-			
+				
 				var filesView = new FilesView({
 					gridArgs: {
 						 type : currentType,
@@ -60,6 +57,12 @@ function onFilesViewTypeChange<?php echo $timestamp; ?>() {
 					actionBarArgs: {actionTemplate:actionTemplate, disabledClass: "btn-disabled"}
 				});
 
+				if (currentType == "publicFiles") {
+					filesView.hideAction("share");
+					filesView.hideAction("Upload File");
+				}
+				filesView.hideAction("Add Tags");
+				console.log(filesView.actionBar.actions);
 			    filesView.grid.renderer.tableClass = "table";
 			    var gridTemplate = dom.byId("filesViewRow<?php echo $timestamp; ?>").textContent;
 			    filesView.grid.renderer.template = gridTemplate;

--- a/php/moodle-block/src/user_widgets/templates/ibm-sbt-community-files.php
+++ b/php/moodle-block/src/user_widgets/templates/ibm-sbt-community-files.php
@@ -34,7 +34,7 @@
 <span style="display: none; font-size: 12px;" id="ibm-sbt-community-files-success-<?php echo $timestamp; ?>"></span><br/><br/>
 <script type="text/template" id="fileRow-<?php echo $timestamp; ?>">
 <tr style="padding-bottom: 0.3em; font-size: 12px;">
-	<td style="width:15em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; padding-left: 10px;">
+	<td style="width:14em;  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; padding-left: 10px;">
 			<span dojoAttachPoint="placeLinkNode">
 				<a href="javascript: void(0)" target="_self" title="${title}" dojoAttachPoint="placeTitleLink" data-dojo-attach-event="onclick: handleClick">${title}</a>
 			</span>
@@ -57,7 +57,7 @@
 </div>
 </script>
 <script type="text/template" id="pagingFooter-<?php echo $timestamp; ?>" style="font-size: 12px;">
-<div dojoattachpoint="pagingFooter" class="lotusPaging">
+<div dojoattachpoint="pagingFooter" class="lotusPaging" style="font-size: 12px;">
 		Show:
 			<a href="javascript: void(0)" title="${nls.show10Items}" aria-pressed="false"
 				role="button" data-dojo-attach-event="onclick: show10ItemsPerPage">10</a> |
@@ -68,7 +68,6 @@
 		
 			<a href="javascript: void(0)" title="${nls.show50Items}" data-dojo-attach-event="onclick: show50ItemsPerPage"
 			aria-pressed="false" role="button">50</a> |
-	
 	
 			<a href="javascript: void(0)" title="${nls.show100Items}" data-dojo-attach-event="onclick: show100ItemsPerPage"
 			aria-pressed="false" role="button">100</a>

--- a/php/moodle-block/src/user_widgets/templates/ibm-sbt-files-view.php
+++ b/php/moodle-block/src/user_widgets/templates/ibm-sbt-files-view.php
@@ -13,7 +13,7 @@
 
 <script type="text/template" id="filesViewRow<?php echo $timestamp; ?>">
 <tr>
-	<td style="width:15em;  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; padding-left: 10px;">
+	<td style="width:15em;  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: inline-block; padding-left: 10px; font-size: 12px;">
 			<span dojoAttachPoint="placeLinkNode">
 				<input type="checkbox" data-dojo-attach-point="rowSelectionInput" data-dojo-attach-event="onclick: handleCheckBox" />
 				<a href="javascript: void(0)" target="_self" title="${tooltip}" dojoAttachPoint="placeTitleLink" data-dojo-attach-event="onclick: handleClick">${title}</a>
@@ -296,7 +296,7 @@
 <div dojoAttachPoint="domNode">
 	<div dojoAttachPoint="mainNode">
 		<div role="alert" style="display: none; padding-top: 3em;" class="alert alert-success ibmsbtDialog" dojoattachpoint="messageNode">
-			<span class="alert alert-success" dojoattachpoint="messageBody"></span>
+			<span dojoattachpoint="messageBody"></span>
 			&nbsp;<a dojoattachevent="onclick: hideMessage" title="${nls.root.messageClose}" dojoattachpoint="messageClose" role="button"  href="javascript:;">Close</a>
 		</div>	
 		<br/><br/>


### PR DESCRIPTION
- Greenhouse "public folder fix" (I had to modify the files widget to use the ProfileService to pull the user profile data in before being able to pass the creator ID to the file grid)
- Community Files fix (the dropdown box for the community files widget only listed the communities specified via the default page size - I now set this to the maximum number to retrieve all communities).
- CSS dialogue box fixes (tidied the header and padding of dialogue boxes to look consistent across all samples)
- Consolidated the files grid and community files grid (they looked slightly different)
- FilesView changes: buttons that might confuse users are automatically hidden (e.g. when selecting "public files", the "Upload File" button is hidden since, by default, uploading a file will place it into "My Files" (unless the user specifies otherwise)
- Removed redundant calls to console.log()
