### PR TITLE
Added X-header field to support file uploads for the PHP proxy

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/CommunityService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/CommunityService.js
@@ -2094,7 +2094,8 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
 					
 			var headers = {
 				"Content-Type" : false,
-				"Process-Data" : false //processData = false is reaquired by jquery
+				"Process-Data" : false, //processData = false is reaquired by jquery,
+				"X-Endpoint-name" : this.endpoint.name
 			};
 			var options = {
 				method : "POST",


### PR DESCRIPTION
@LorenzoBoccaccia  - Added X-header field to support file uploads for the PHP proxy (required to use the Moodle block and/or Wordpress plugin). Ran Maven Test on com.ibm.sbt.web.
