### PR TITLE
Test unify enh fixes

### DIFF
--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/activities/ActivityMoveFieldTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/activities/ActivityMoveFieldTest.java
@@ -42,7 +42,7 @@ public class ActivityMoveFieldTest extends BaseActivityServiceTest {
 	@Rule public ExpectedException thrown= ExpectedException.none();
 	
 	@Test
-	public void testMoveFieldACL() throws ClientServicesException {
+	public void testMoveNodeACL() throws ClientServicesException {
 		Activity activityA = new Activity();
 		activityA.setTitle(createActivityTitle());
 		activityA = activityService.createActivity(activityA);


### PR DESCRIPTION
- Added assertion to check that the result of the put operation of moveField contains the updated destination node with the moved field
- Added assertion to check that the descendants api also contains the 2 nodes with their respective fields after the move operation
- Added another test to check that passing a non existing destination node id returns a 404 Not found instead of a 400 Bad Request
- Added another test to check that trying to move a field without enough authorization (trying to move a field to a node created by another user) results in a 403 Forbidden
- Added a test for the use case of moving a node to another activity with a member in the ACL
