### PR TITLE
Add content tags to the create community request body, if the user does

### DIFF
--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/communities/CommunityServiceTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/communities/CommunityServiceTest.java
@@ -54,6 +54,11 @@ public class CommunityServiceTest extends BaseCommunityServiceTest {
         community = community.load();
         Assert.assertNotSame(oldTitle, community.getTitle());
         assertEquals("test Content", community.getContent());
+        
+        community.setContent("new content");
+        communityService.updateCommunity(community);
+        community = community.load();
+        assertEquals("new content", community.getContent());
     }
 
     @Test

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/communities/serializers/CommunitySerializer.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/communities/serializers/CommunitySerializer.java
@@ -89,7 +89,11 @@ public class CommunitySerializer extends AtomEntitySerializer<Community> {
 
 	@Override
 	protected Element content() {
-		return textElement(CONTENT, entity.getContent(), attribute(TYPE, HTML));
+		String content = entity.getContent();
+		if(content == null){
+			content="";
+		}
+		return textElement(CONTENT, content, attribute(TYPE, HTML));
 	}
 
 	protected Element category() {


### PR DESCRIPTION
not set the content the tags are send with not value. this means if the
user can create a community without calling set content, as they can
with the api.
