### PR TITLE
Create community folders

### DIFF
--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -59,6 +59,7 @@ import com.ibm.sbt.services.client.connections.files.serializer.CommentSerialize
 import com.ibm.sbt.services.client.connections.files.serializer.EntityIdSerializer;
 import com.ibm.sbt.services.client.connections.files.serializer.FileSerializer;
 import com.ibm.sbt.services.client.connections.files.serializer.FlagSerializer;
+import com.ibm.sbt.services.client.connections.files.serializer.FolderSerializer;
 import com.ibm.sbt.services.client.connections.files.serializer.ModerationSerializer;
 import com.ibm.sbt.services.client.connections.files.util.Messages;
 import com.ibm.sbt.services.endpoints.Endpoint;

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -1135,8 +1135,8 @@ public class FileService extends ConnectionsService {
      * @throws ClientServicesException
      * @throws TransformerException
      */
-    public File createCommunityFolder(String name) throws ClientServicesException, TransformerException {
-        return createCommunityFolder(name, null);
+    public File createCommunityFolder(String communityId, String name) throws ClientServicesException, TransformerException {
+        return createCommunityFolder(communityId, name, null);
     }
 
     /**
@@ -1148,12 +1148,12 @@ public class FileService extends ConnectionsService {
      * @throws ClientServicesException
      * @throws TransformerException
      */
-    public File createCommunityFolder(String name, String summary) throws ClientServicesException {
+    public File createCommunityFolder(String communityId, String name, String summary) throws ClientServicesException {
         File f  = new File(this,null);
         f.setTitle(name);
         f.setLabel(name);
         f.setSummary(summary);
-        return createCommunityFolder(f);
+        return createCommunityFolder(communityId, f);
         
     }
 

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -1125,6 +1125,59 @@ public class FileService extends ConnectionsService {
         folder.setDataHandler(r.getDataHandler());
         return folder;
     }
+	
+	/**
+     * Create a file folder in a community programmatically.
+     * 
+     * @param name name of the folder to be created
+     * @return File
+     * @throws ClientServicesException
+     * @throws TransformerException
+     */
+    public File createCommunityFolder(String name) throws ClientServicesException, TransformerException {
+        return createCommunityFolder(name, null);
+    }
+
+    /**
+     * Create a file folder in a community programmatically.
+     * 
+     * @param name name of the folder to be created
+     * @param summary description of the folder
+     * @return File
+     * @throws ClientServicesException
+     * @throws TransformerException
+     */
+    public File createCommunityFolder(String name, String summary) throws ClientServicesException {
+        File f  = new File(this,null);
+        f.setTitle(name);
+        f.setLabel(name);
+        f.setSummary(summary);
+        return createCommunityFolder(f);
+        
+    }
+	
+	/**
+     * Create a file folder in a community programmatically.
+     * 
+	 * @param communityId
+     * @param folder the folder objct to be created
+     * @return File
+     * @throws ClientServicesException
+     * @throws TransformerException
+     */
+	public File createCommunityFolder(String communityId, File folder) throws ClientServicesException {
+		String accessType = AccessType.AUTHENTICATED.getText();
+
+	    String requestUri = IFileUrls.COMMUNITY_COLLECTIONS_FEED.format(this, FileUrlParts.accessType.get(accessType), FileUrlParts.communityId.get(communityId));
+	    String payload = new FolderSerializer(folder).generateFolderUpdatePayload();
+	    
+	    Response response = createData(requestUri, null, new ClientService.ContentString(payload, CommonConstants.APPLICATION_ATOM_XML));
+	    checkResponseCode(response, HTTPCode.CREATED);
+	    File r = getFileFeedHandler().createEntity(response);
+	    folder.clearFieldsMap();
+	    folder.setDataHandler(r.getDataHandler());
+	    return folder;
+	}
 
     /**
      * Retrieve an Atom document representation of a file folder.

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -1168,7 +1168,7 @@ public class FileService extends ConnectionsService {
 	public File createCommunityFolder(String communityId, File folder) throws ClientServicesException {
 		String accessType = AccessType.AUTHENTICATED.getText();
 
-	    String requestUri = IFileUrls.COMMUNITY_COLLECTIONS_FEED.format(this, FileUrlParts.accessType.get(accessType), FileUrlParts.communityId.get(communityId));
+	    String requestUri = FileUrls.COMMUNITY_COLLECTIONS_FEED.format(this, FileUrlParts.accessType.get(accessType), FileUrlParts.communityId.get(communityId));
 	    String payload = new FolderSerializer(folder).generateFolderUpdatePayload();
 	    
 	    Response response = createData(requestUri, null, new ClientService.ContentString(payload, CommonConstants.APPLICATION_ATOM_XML));

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileService.java
@@ -1126,7 +1126,7 @@ public class FileService extends ConnectionsService {
         return folder;
     }
 	
-	/**
+    /**
      * Create a file folder in a community programmatically.
      * 
      * @param name name of the folder to be created
@@ -1155,11 +1155,11 @@ public class FileService extends ConnectionsService {
         return createCommunityFolder(f);
         
     }
-	
-	/**
+
+    /**
      * Create a file folder in a community programmatically.
      * 
-	 * @param communityId
+     * @param communityId
      * @param folder the folder objct to be created
      * @return File
      * @throws ClientServicesException

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileUrls.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileUrls.java
@@ -27,6 +27,7 @@ import com.ibm.sbt.services.client.base.VersionedUrl;
 /**
  * @author Carlos Manias
  */
+ 
 public enum FileUrls implements URLContainer {
     SERVICE_DOCUMENT(new VersionedUrl(v4_0, 					"{files}/{authType}/{accessType}/introspection")),
     GET_NONCE(new VersionedUrl(v4_0, 							"{files}/{authType}/{accessType}/nonce")),

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileUrls.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/FileUrls.java
@@ -56,6 +56,7 @@ public enum FileUrls implements URLContainer {
     COMMUNITY_FILE_METADATA(new VersionedUrl(v4_0, 				"{files}/{authType}/{accessType}/library/{communityLibraryId}/document/{fileId}/entry")),
     COLLECTION_FEED(new VersionedUrl(v4_0, 						"{files}/{authType}/{accessType}/collection/{folderId}/feed")),
     COLLECTION_ENTRY(new VersionedUrl(v4_0,						"{files}/{authType}/{accessType}/collection/{folderId}/entry")),
+    COMMUNITY_COLLECTIONS_FEED(new VersionedUrl(v4_0, 		"{files}/{authType}/{accessType}/communitycollection/{communityId}/feed")),
     GET_FOLDERS_WITH_RECENT_FILES(new VersionedUrl(v4_0, 		"{files}/{authType}/{accessType}/collections/addedto/feed")),
     MYUSERLIBRARY_RECYCLEBIN_FEED(new VersionedUrl(v4_0, 		"{files}/{authType}/{accessType}/myuserlibrary/view/recyclebin/feed")),
     MYUSERLIBRARY_RECYCLEBIN_ENTRY(new VersionedUrl(v4_0, 		"{files}/{authType}/{accessType}/myuserlibrary/view/recyclebin/{fileId}/entry")),

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
@@ -1,0 +1,103 @@
+/*
+ * Â© Copyright IBM Corp. 2014
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+import static com.ibm.sbt.services.client.base.ConnectionsConstants.CATEGORY;
+import static com.ibm.sbt.services.client.base.ConnectionsConstants.LABEL;
+import static com.ibm.sbt.services.client.base.ConnectionsConstants.SCHEME;
+import static com.ibm.sbt.services.client.base.ConnectionsConstants.TERM;
+import static com.ibm.sbt.services.client.base.ConnectionsConstants.UUID;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.CATEGORY_TAG;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.CREATED;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.MODIFIED;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.MODIFIER;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.NOTIFICATION;
+import static com.ibm.sbt.services.client.connections.files.FileConstants.VISIBILITY;
+
+import org.w3c.dom.Node;
+
+import com.ibm.commons.util.StringUtil;
+import com.ibm.sbt.services.client.base.ConnectionsConstants.Namespace;
+import com.ibm.sbt.services.client.base.serializers.AtomEntitySerializer;
+import com.ibm.sbt.services.client.base.serializers.PersonSerializer;
+import com.ibm.sbt.services.client.connections.files.File;
+
+public class FolderSerializer extends AtomEntitySerializer<File> {
+
+	private final static String FOLDERTERM 		= "collection";
+	private final static String FOLDERLABEL 	= "collection";
+
+    public FolderSerializer(File entity) {
+        super(entity);
+    }
+
+    
+    public Node getFolderEntry() {
+        Node n =genericAtomEntry();
+        if (entity.getFileId()!=null) {
+            appendChildren(n, textElement(Namespace.TD.getUrl(), UUID, entity.getFileId()));
+        }
+        if (entity.getLabel() != null) {
+            appendChildren(n, textElement(Namespace.TD.getUrl(), LABEL, entity.getLabel()));
+        }
+        
+        /* 
+         * Originele FileSerializer voegt aan de category een namespace toe: Namespace.TD.getUrl()
+         * Voor het toevoegen van een folder moet deze worden weggelaten.
+         * 
+         * Layout van een folderentry:
+         * 
+         * 		<?xml version="1.0" encoding="UTF-8"?>
+    	 * 		<entry xmlns="http://www.w3.org/2005/Atom">
+    	 * 			<category term="collection" label="collection" scheme="tag:ibm.com,2006:td/type" />
+    	 *	   		<label xmlns="urn:ibm.com/td" makeUnique="true">FOLDERNAAM</label>
+    	 *	   		<title>FOLDERNAAM</title>
+    	 *	   		<summary type="text" />
+    	 * 		</entry>
+         */
+        appendChildren(n, element(CATEGORY, attribute(SCHEME, Namespace.TAG.getUrl()), attribute(TERM, FOLDERTERM), attribute(LABEL, FOLDERLABEL)));
+        
+        if (entity.getTags()!=null) {
+	        for (String tag : entity.getTags()) {
+	            appendChildren(n, textElement(CATEGORY, tag, attribute(TERM, CATEGORY_TAG)));
+	        }
+        }
+        if (StringUtil.isNotEmpty( entity.getVisibility())) { 
+        	appendChildren(n, textElement(Namespace.TD.getUrl(), VISIBILITY, entity.getVisibility()));
+        }
+        
+        if (StringUtil.isNotEmpty( entity.getNotification())) {
+            appendChildren(n, textElement(Namespace.TD.getUrl(), NOTIFICATION, entity.getNotification()));
+        }
+            
+        if (entity.getModified()!=null) {  
+            appendChildren(n, textElement(Namespace.TD.getUrl(), MODIFIED, DateSerializer.toString(entity.getModified())));
+        }
+        if (entity.getCreated()!=null) {  
+            appendChildren(n, textElement(Namespace.TD.getUrl(), CREATED, DateSerializer.toString(entity.getCreated())));   
+        }
+        
+        if (entity.getModifier()!=null) { 
+            appendChildren(n,new PersonSerializer(entity.getModifier()).xmlNode(MODIFIER, Namespace.TD.getUrl() ));
+        }
+            
+        return n;
+    }
+
+    public String generateFolderUpdatePayload() {
+       getFolderEntry();
+        return serializeToString();
+    }
+}

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
@@ -38,8 +38,8 @@ import com.ibm.sbt.services.client.connections.files.File;
 
 public class FolderSerializer extends AtomEntitySerializer<File> {
 
-	private final static String FOLDERTERM 		= "collection";
-	private final static String FOLDERLABEL 	= "collection";
+    private final static String FOLDERTERM 	= "collection";
+    private final static String FOLDERLABEL 	= "collection";
 
     public FolderSerializer(File entity) {
         super(entity);
@@ -55,20 +55,6 @@ public class FolderSerializer extends AtomEntitySerializer<File> {
             appendChildren(n, textElement(Namespace.TD.getUrl(), LABEL, entity.getLabel()));
         }
         
-        /* 
-         * Originele FileSerializer voegt aan de category een namespace toe: Namespace.TD.getUrl()
-         * Voor het toevoegen van een folder moet deze worden weggelaten.
-         * 
-         * Layout van een folderentry:
-         * 
-         * 		<?xml version="1.0" encoding="UTF-8"?>
-    	 * 		<entry xmlns="http://www.w3.org/2005/Atom">
-    	 * 			<category term="collection" label="collection" scheme="tag:ibm.com,2006:td/type" />
-    	 *	   		<label xmlns="urn:ibm.com/td" makeUnique="true">FOLDERNAAM</label>
-    	 *	   		<title>FOLDERNAAM</title>
-    	 *	   		<summary type="text" />
-    	 * 		</entry>
-         */
         appendChildren(n, element(CATEGORY, attribute(SCHEME, Namespace.TAG.getUrl()), attribute(TERM, FOLDERTERM), attribute(LABEL, FOLDERLABEL)));
         
         if (entity.getTags()!=null) {

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/files/serializer/FolderSerializer.java
@@ -13,6 +13,8 @@
  * implied. See the License for the specific language governing 
  * permissions and limitations under the License.
  */
+ 
+package com.ibm.sbt.services.client.connections.files.serializer;
 
 import static com.ibm.sbt.services.client.base.ConnectionsConstants.CATEGORY;
 import static com.ibm.sbt.services.client.base.ConnectionsConstants.LABEL;


### PR DESCRIPTION
By modifying `public File createFolder(File folder) throws ClientServicesException` in `com.ibm.sbt.services.client.connections.files.FileService` a folder can be created in a community.

See also http://stackoverflow.com/questions/26912475/ibm-sbt-create-a-folder-in-a-community/27444275#27444275