### PR TITLE
Update ActivityStreamService.js

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/ActivityStreamService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/ActivityStreamService.js
@@ -206,7 +206,7 @@ define([ "../declare", "../lang", "../stringUtil", "../config", "../Promise", ".
 //			var url = consts.ActivityStreamUrls.activityStreamBaseUrl+this.endpoint.authType+consts.ActivityStreamUrls.activityStreamRestUrl+_userType+"/"+_groupType+"/"+_applicationType;
             var url = this.constructUrl(consts.ActivityStreamUrls.activityStreamBaseUrl+"{authType}"+consts.ActivityStreamUrls.activityStreamRestUrl+"{userType}/{groupType}/{appType}", 
                     {}, 
-                    { authType : this.endpoint.authType, userType : _userType, groupType : _groupType, appType : _applicationType });
+                    { authType : (this.endpoint.authType == "sso")  ? "":this.endpoint.authType, userType : _userType, groupType : _groupType, appType : _applicationType });
             var options = {
                 method : "GET",
                 handleAs : "json",


### PR DESCRIPTION
there doesn't appear to be a URL with connections/connections/opensocial/sso/rest/activitystreams/urn:lsid:lconn.ibm.com:communities.community:{communityUuid}/@all/@all?

Removing sso from the URL allows retrieving this feed with that auth type. Without this change a 404 is returned