### PR TITLE
Updated to use maven deps and res plugin

### DIFF
--- a/domino/com.ibm.sbt.opensocial.domino.explorer/pom.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.explorer/pom.xml
@@ -46,64 +46,64 @@
   <build>
   	<defaultGoal>package</defaultGoal>
     <plugins>
-      <plugin>
-        <groupId>com.github.goldin</groupId>
-        <artifactId>copy-maven-plugin</artifactId>
-        <version>${com.github.goldin.version}</version>
+                <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                
+                                    <execution>
+                        <id>prepare</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.opensocial.explorer</groupId>
+                                    <artifactId>opensocial-explorer-webcontent</artifactId>
+                                    <version>${opensocial-explorer-webcontent.version}</version>
+                                    <overWrite>true</overWrite>
+                            <outputDirectory>${project.build.directory}/explorer-resources</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}/explorer-resources</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                   
+                </executions>
+            </plugin>
+            
+             <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>2.7</version>
         <executions>
           <execution>
-            <id>unpack-webcontent</id>
-            <phase>prepare-package</phase>
+            <id>copy-resources</id>
+            <!-- here the phase you need -->
+            <phase>generate-resources</phase>
             <goals>
-              <goal>copy</goal>
+              <goal>copy-resources</goal>
             </goals>
             <configuration>
-              <resources>
+              <outputDirectory>${project.basedir}/WebContent/js</outputDirectory>
+              <resources>          
                 <resource>
-                  <unpack>true</unpack>
-                  <targetPath>${project.build.directory}/webcontent</targetPath>
-                  <dependencies>
-                    <dependency>
-                      <groupId>org.opensocial.explorer</groupId>
-                      <artifactId>opensocial-explorer-webcontent</artifactId>
-                      <version>${opensocial-explorer-webcontent.version}</version>
-                    </dependency>
-                  </dependencies>
-                </resource>
-                <resource>
-                  <targetPath>${project.basedir}/WebContent/js</targetPath>
-                  <directory>${project.build.directory}/webcontent/js/modules</directory>
-                  <preservePath>true</preservePath>
+                  <directory>${project.build.directory}/explorer-resources/js/modules</directory>
+                  <filtering>false</filtering>
+                 
                 </resource>
               </resources>
-            </configuration>
-          </execution>
-          <!-- Runs during the Maven clean phase to remove the copied files -->
-          <execution>
-            <id>clean-explorer</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/WebContent/js</directory>
-                  <includes>
-                    <include>**/*.js</include>
-                    <include>**/*.html</include>
-                    <include>**/*.xml</include>
-                  </includes>
-                  <clean>true</clean>
-                  <cleanEmptyDirectories>true</cleanEmptyDirectories>
-                  <!-- If we can't find the directory that means we are starting from a clean state, don't fail -->
-                  <failIfNotFound>false</failIfNotFound>
-                </resource>
-              </resources>
-            </configuration>
+              <overwrite>true</overwrite>              
+            </configuration>            
           </execution>
         </executions>
       </plugin>
+            
+            
     </plugins>
   </build>
 

--- a/samples/j2ee/acme/acme.sample.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/acme/acme.sample.webapp/.settings/org.eclipse.wst.common.component
@@ -4,7 +4,7 @@
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/resources"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/.apt_generated"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -13,7 +13,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="acme.sample.webapp"/>

--- a/samples/j2ee/acme/acme.social.sample.ear/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/acme/acme.social.sample.ear/.settings/org.eclipse.wst.common.component
@@ -2,19 +2,19 @@
     <wb-module deploy-name="acme.social.sample-2.0.0-SNAPSHOT">
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/ear-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/application" tag="defaultRootSource"/>
-        <dependent-module archiveName="acme.social.sample.dataapp-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.social.sample.dataapp/acme.social.sample.dataapp">
+        <dependent-module archiveName="acme.social.sample.dataapp-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.social.sample.dataapp/acme.social.sample.dataapp">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="acme.social.sample.webapp-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.social.sample.webapp/acme.social.sample.webapp">
+        <dependent-module archiveName="acme.social.sample.webapp-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.social.sample.webapp/acme.social.sample.webapp">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="acme.sample.webapp-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.sample.webapp/acme.sample.webapp">
+        <dependent-module archiveName="acme.sample.webapp-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/acme.sample.webapp/acme.sample.webapp">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.sbt.web-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.web/com.ibm.sbt.web">
+        <dependent-module archiveName="com.ibm.sbt.web-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.web/com.ibm.sbt.web">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="sbt.dojo180-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.dojo180/com.ibm.sbt.dojo180">
+        <dependent-module archiveName="sbt.dojo180-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.dojo180/com.ibm.sbt.dojo180">
             <dependency-type>uses</dependency-type>
         </dependent-module>
     </wb-module>

--- a/samples/j2ee/acme/acme.social.sample.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/acme/acme.social.sample.webapp/.settings/org.eclipse.wst.common.component
@@ -4,7 +4,7 @@
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/resources"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/webapp"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -13,7 +13,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="acme.social.sample.webapp"/>

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.ear/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.ear/.settings/org.eclipse.wst.common.component
@@ -2,19 +2,19 @@
     <wb-module deploy-name="sbt.sample-2.0.0-SNAPSHOT">
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/ear-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/application" tag="defaultRootSource"/>
-        <dependent-module archiveName="sbt.sample.web-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.sample.web/com.ibm.sbt.sample.web">
+        <dependent-module archiveName="sbt.sample.web-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.sample.web/com.ibm.sbt.sample.web">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.sbt.web-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.web/com.ibm.sbt.web">
+        <dependent-module archiveName="com.ibm.sbt.web-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.web/com.ibm.sbt.web">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="sbt.dojo180-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.dojo180/com.ibm.sbt.dojo180">
+        <dependent-module archiveName="sbt.dojo180-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.dojo180/com.ibm.sbt.dojo180">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="sbt.bootstrap211-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.bootstrap211/com.ibm.sbt.bootstrap211">
+        <dependent-module archiveName="sbt.bootstrap211-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.bootstrap211/com.ibm.sbt.bootstrap211">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="sbt.jquery182-1.1.0-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.jquery182/com.ibm.sbt.jquery182">
+        <dependent-module archiveName="sbt.jquery182-1.1.3-SNAPSHOT.war" deploy-path="/" handle="module:/resource/com.ibm.sbt.jquery182/com.ibm.sbt.jquery182">
             <dependency-type>uses</dependency-type>
         </dependent-module>
     </wb-module>

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/.settings/org.eclipse.wst.common.component
@@ -3,10 +3,10 @@
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.sbt.samples.commons-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.samples.commons/com.ibm.sbt.samples.commons">
+        <dependent-module archiveName="com.ibm.sbt.samples.commons-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.samples.commons/com.ibm.sbt.samples.commons">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -15,7 +15,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="java-output-path" value="/com.ibm.sbt.sample.web/target/classes"/>

--- a/samples/j2ee/templates/demosocial.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/demosocial.webapp/.settings/org.eclipse.wst.common.component
@@ -4,7 +4,7 @@
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/resources"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -13,7 +13,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.0.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="demosocial.webapp"/>

--- a/samples/j2ee/templates/grantaccess.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/grantaccess.webapp/.settings/org.eclipse.wst.common.component
@@ -3,7 +3,7 @@
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -12,7 +12,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="grantaccess.webapp"/>

--- a/samples/j2ee/templates/helloworld.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/helloworld.webapp/.settings/org.eclipse.wst.common.component
@@ -2,7 +2,7 @@
     <wb-module deploy-name="helloworld.webapp">
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -11,7 +11,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="helloworld.webapp"/>

--- a/samples/j2ee/templates/smartcloud.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/smartcloud.webapp/.settings/org.eclipse.wst.common.component
@@ -3,7 +3,7 @@
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
         <wb-resource deploy-path="/WEB-INF/classes" source-path="/src/main/java"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -12,7 +12,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="smartcloud.webapp"/>

--- a/samples/j2ee/templates/social.helloworld.webapp/.settings/org.eclipse.wst.common.component
+++ b/samples/j2ee/templates/social.helloworld.webapp/.settings/org.eclipse.wst.common.component
@@ -2,7 +2,7 @@
     <wb-module deploy-name="social.helloworld.webapp">
         <wb-resource deploy-path="/" source-path="/target/m2e-wtp/web-resources"/>
         <wb-resource deploy-path="/" source-path="/src/main/webapp" tag="defaultRootSource"/>
-        <dependent-module archiveName="com.ibm.sbt.core-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
+        <dependent-module archiveName="com.ibm.sbt.core-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.sbt.core/com.ibm.sbt.core">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <dependent-module archiveName="com.ibm.commons-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons/com.ibm.commons">
@@ -11,7 +11,7 @@
         <dependent-module archiveName="com.ibm.commons.xml-9.0.0.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.xml/com.ibm.commons.xml">
             <dependency-type>uses</dependency-type>
         </dependent-module>
-        <dependent-module archiveName="com.ibm.commons.runtime-1.1.0-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
+        <dependent-module archiveName="com.ibm.commons.runtime-1.1.3-SNAPSHOT.jar" deploy-path="/WEB-INF/lib" handle="module:/resource/com.ibm.commons.runtime/com.ibm.commons.runtime">
             <dependency-type>uses</dependency-type>
         </dependent-module>
         <property name="context-root" value="social.helloworld.webapp"/>


### PR DESCRIPTION
copy maven plugin seems unmaintained and 
doesn't currently support modern maven versions,
which are in turn required because older version 
of the wagon plugin insists on SSLv3, failing
downloads on all POODLE patched servers