### PR TITLE
Resolve #1675 : Extend SearchService by adding MYSEARCH methods

### DIFF
--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/BaseSearchServiceTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/BaseSearchServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+package com.ibm.sbt.services.client.connections.search;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import com.ibm.sbt.services.BaseUnitTest;
+
+/**
+ * Tests for the java connections Search API a test class provides its own
+ * tests extending the test endpoint abstract class
+ * 
+ * @author Christian Gosch, inovex GmbH
+ * @date Apr 24, 2015
+ */
+
+public class BaseSearchServiceTest extends BaseUnitTest {
+
+	protected Result result;
+	protected SearchService searchService;
+	@Rule public ExpectedException thrown= ExpectedException.none();
+
+	@Before
+	public void createTestData() throws Exception {
+		//FIXME: Needs to be fixed to address issues with mock files
+		if (searchService==null) {
+			searchService = new SearchService();
+		}
+	}
+	
+}

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/SearchServiceTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/SearchServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+package com.ibm.sbt.services.client.connections.search;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ibm.sbt.services.client.base.datahandlers.EntityList;
+import com.ibm.sbt.test.lib.TestEnvironment;
+
+/**
+ * Tests for the java connections Search API a test class provides its own
+ * tests extending the test endpoint abstract class
+ * 
+ * @author Christian Gosch, inovex GmbH
+ * @date Apr 24, 2015
+ */
+
+public class SearchServiceTest extends BaseSearchServiceTest {
+
+    /**
+     * Test is valid if the query runs through. All results including empty list are accepted!
+     * @throws Exception
+     */
+    @Test
+    public final void testGetResults() throws Exception {
+    	//FIXME: Test is Broken
+    	// lookup public content having "test" in its searched data fields
+    	TestEnvironment.setRequiresAuthentication(false);
+    	EntityList<Result> results = searchService.getResults("test");
+    	Assert.assertTrue(results.size() >= 0);
+    }
+
+    /**
+     * Test is valid if the query runs through. All results including empty list are accepted!
+     * @throws Exception
+     */
+    @Test
+    public final void testGetMyResults() throws Exception {
+    	//FIXME: Test is Broken
+    	// lookup "my" content having "test" in its searched data fields
+    	TestEnvironment.setRequiresAuthentication(true);
+    	EntityList<Result> results = searchService.getMyResults("test");
+    	Assert.assertTrue(results.size() >= 0);
+    }
+
+    /**
+     * Test is valid if the query runs through. All results including empty list are accepted!
+     * @throws Exception
+     */
+    @Test
+    public final void testGetResultsByTag() throws Exception {
+    	//FIXME: Test is Broken
+    	// lookup public content having "testtag" in its tags
+    	// this in turn tests multiple methods in SearchService.
+    	TestEnvironment.setRequiresAuthentication(false);
+    	EntityList<Result> results = searchService.getResultsByTag("testtag");
+    	Assert.assertTrue(results.size() >= 0);
+    }
+
+    /**
+     * Test is valid if the query runs through. All results including empty list are accepted!
+     * @throws Exception
+     */
+    @Test
+    public final void testGetMyResultsByTag() throws Exception {
+    	//FIXME: Test is Broken
+    	// lookup "my" content having "testtag" in its tags
+    	// this in turn tests multiple methods in SearchService.
+    	TestEnvironment.setRequiresAuthentication(true);
+    	EntityList<Result> results = searchService.getMyResultsByTag("testtag");
+    	Assert.assertTrue(results.size() >= 0);
+    }
+
+}

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/SearchServiceTestSuite.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/services/client/connections/search/SearchServiceTestSuite.java
@@ -1,0 +1,34 @@
+/*
+ * © Copyright IBM Corp. 2013
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at:
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0 
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the License is distributed on an "AS IS" BASIS, 
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
+ * implied. See the License for the specific language governing 
+ * permissions and limitations under the License.
+ */
+
+package com.ibm.sbt.services.client.connections.search;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+/**
+ * 
+ * @author Christian Gosch, inovex GmbH
+ *
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ 
+	SearchServiceTest.class
+})
+public class SearchServiceTestSuite {
+
+}

--- a/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/search/SearchService.java
+++ b/sdk/com.ibm.sbt.core/src/main/java/com/ibm/sbt/services/client/connections/search/SearchService.java
@@ -56,7 +56,6 @@ import org.w3c.dom.Node;
 import com.ibm.commons.util.StringUtil;
 import com.ibm.commons.xml.xpath.XPathExpression;
 import com.ibm.sbt.services.client.ClientServicesException;
-import com.ibm.sbt.services.client.ClientService.Args;
 import com.ibm.sbt.services.client.base.AtomFeedHandler;
 import com.ibm.sbt.services.client.base.BaseService;
 import com.ibm.sbt.services.client.base.ConnectionsService;
@@ -147,6 +146,26 @@ public class SearchService extends ConnectionsService {
 		return getResultEntityList(searchQry.toString(), new HashMap<String,String>());
 	}
 	
+	/**
+	 * Lists the elements in an Atom entry representing the result returned by a search.
+	 * 
+	 * @param query
+	 *            Text to search for
+	 * @param Map
+	 *            for additional parameters
+	 * @return EntityList<Result>
+	 * @throws ClientServicesException
+	 */
+	public EntityList<Result> getMyResultsList(String query,Map<String, List<String>> parameters) throws ClientServicesException {
+		if(parameters==null){
+			parameters= new HashMap<String,List<String>>();
+		}
+
+		StringBuilder searchQry = new StringBuilder(SearchUrls.MYSEARCH.format(this, SearchUrls.getQuery(query)));
+		addUrlParameters(searchQry, parameters);
+		return getResultEntityList(searchQry.toString(), new HashMap<String,String>());
+	}
+	
 	protected void addUrlParameters(StringBuilder b, Map<String,List<String>> parameters) throws ClientServicesException {
 		
 		if (parameters != null) {
@@ -206,6 +225,24 @@ public class SearchService extends ConnectionsService {
 	 * entry to make it easier to find the content later. The format of the tags document 
 	 * is an Atom publishing protocol (APP) categories document.
 	 * 
+	 * @param String
+	 *            Single tag to be search for, for multiple tags use other overloaded method
+	 * @return EntityList<Result>
+	 * @throws ClientServicesException
+	 */
+	public EntityList<Result> getMyResultsByTag(String tag) throws ClientServicesException {
+		List<String> taglist = new ArrayList<String>();
+		taglist.add(tag);
+		return getMyResultsByTag(taglist,null);
+	}
+	
+	/**
+	 * The category document identifies the tags that have been assigned to particular 
+	 * items, such as blog posts or community entries. Tags are single-word keywords that 
+	 * categorize a posting or entry. A tag classifies the information in the posting or 
+	 * entry to make it easier to find the content later. The format of the tags document 
+	 * is an Atom publishing protocol (APP) categories document.
+	 * 
 	 * @param List
 	 *            of Tags to searched for
 	 * @return EntityList<Result>
@@ -213,6 +250,22 @@ public class SearchService extends ConnectionsService {
 	 */
 	public EntityList<Result> getResultsByTag(List<String> tags) throws ClientServicesException {
 		return getResultsByTag(tags,null);
+	}
+	
+	/**
+	 * The category document identifies the tags that have been assigned to particular 
+	 * items, such as blog posts or community entries. Tags are single-word keywords that 
+	 * categorize a posting or entry. A tag classifies the information in the posting or 
+	 * entry to make it easier to find the content later. The format of the tags document 
+	 * is an Atom publishing protocol (APP) categories document.
+	 * 
+	 * @param List
+	 *            of Tags to searched for
+	 * @return EntityList<Result>
+	 * @throws ClientServicesException
+	 */
+	public EntityList<Result> getMyResultsByTag(List<String> tags) throws ClientServicesException {
+		return getMyResultsByTag(tags,null);
 	}
 	
 	/**
@@ -239,6 +292,32 @@ public class SearchService extends ConnectionsService {
 		constraint.setValues(formattedTags);
 		constraints.add(constraint);
 		return getResultsWithConstraint("", constraints,parameters);
+	}
+	
+	/**
+	 * The category document identifies the tags that have been assigned to particular 
+	 * items, such as blog posts or community entries. Tags are single-word keywords that 
+	 * categorize a posting or entry. A tag classifies the information in the posting or 
+	 * entry to make it easier to find the content later. The format of the tags document 
+	 * is an Atom publishing protocol (APP) categories document.
+	 * 
+	 * @param List
+	 *            of Tags to searched for
+	 * @return EntityList<Result>
+	 * @throws ClientServicesException
+	 */
+	public EntityList<Result> getMyResultsByTag(List<String> tags,
+			Map<String, String> parameters) throws ClientServicesException {
+		// High level wrapper, provides a convenient mechanism for search for
+		// tags, uses constraints internally
+		List<String> formattedTags = new ArrayList<String>();
+		List<Constraint> constraints = new ArrayList<Constraint>();
+		formattedTags = createTagConstraint(tags);
+		Constraint constraint = new Constraint();
+		constraint.setType("category");
+		constraint.setValues(formattedTags);
+		constraints.add(constraint);
+		return getMyResultsWithConstraint("", constraints,parameters);
 	}
 	
 	/**
@@ -349,6 +428,21 @@ public class SearchService extends ConnectionsService {
 	
     /**
      * @param query Text to search for
+     * @param Constraint
+     * 
+     * @return EntityList<Result>
+     * @throws ClientServicesException
+     * 
+	   *http://www-10.IBM.com/ldd/appdevwiki.nsf/xpDocViewer.xsp?lookupName=IBM+Connections+4.0+API+Documentation#action=openDocument&res_title=Constraints&content=pdcontent  
+     */
+	public EntityList<Result> getMyResultsWithConstraint(String query, Constraint constraint) throws ClientServicesException {
+		List<Constraint> constraintList = new ArrayList<Constraint>();
+		constraintList.add(constraint);
+		return getMyResultsWithConstraint(query, constraintList,null);
+	}
+	
+    /**
+     * @param query Text to search for
      * @param List<Constraint>
      * 
      * @return EntityList<Scope>
@@ -358,6 +452,19 @@ public class SearchService extends ConnectionsService {
      */
 	public EntityList<Result> getResultsWithConstraint(String query, List<Constraint> constraints) throws ClientServicesException {
 		return getResultsWithConstraint(query, constraints,null);
+	}
+    
+    /**
+     * @param query Text to search for
+     * @param List<Constraint>
+     * 
+     * @return EntityList<Scope>
+     * @throws ClientServicesException
+     * 
+	   *http://www-10.IBM.com/ldd/appdevwiki.nsf/xpDocViewer.xsp?lookupName=IBM+Connections+4.0+API+Documentation#action=openDocument&res_title=Constraints&content=pdcontent  
+     */
+	public EntityList<Result> getMyResultsWithConstraint(String query, List<Constraint> constraints) throws ClientServicesException {
+		return getMyResultsWithConstraint(query, constraints,null);
 	}
     
     /**
@@ -384,6 +491,32 @@ public class SearchService extends ConnectionsService {
 		}
 		params.put("constraint", formattedConstraints);
 		return getResultsList(query, params);
+	}
+
+    /**
+     * @param query Text to search for
+     * @param List<Constraint>
+     * 
+     * @return EntityList<Result>
+     * @throws ClientServicesException
+     * 
+	   *http://www-10.IBM.com/ldd/appdevwiki.nsf/xpDocViewer.xsp?lookupName=IBM+Connections+4.0+API+Documentation#action=openDocument&res_title=Constraints&content=pdcontent  
+     */
+	public EntityList<Result> getMyResultsWithConstraint(String query, List<Constraint> constraints, Map<String, String> parameters) throws ClientServicesException{
+		
+		Map<String, List<String>> params = new HashMap<String, List<String>>();
+		// We can not use a map of constraints, since there could be multiple constraints but map can have only one key named constraint
+		List<String> formattedConstraints = generateConstraintParameter(constraints);
+		if(parameters == null){
+			parameters = new HashMap<String,String>();
+		}
+		for(Map.Entry<String, String> entry : parameters.entrySet()){
+			List<String> valueList = new ArrayList<String>();
+			valueList.add(entry.getValue());
+			params.put(entry.getKey(), valueList);
+		}
+		params.put("constraint", formattedConstraints);
+		return getMyResultsList(query, params);
 	}
 
 	/**


### PR DESCRIPTION
Currently, some methods and logic in SearchService are available only for searching public content. This does not cover restricted or private content even if the search is executed authenticated.

This change symmetrically adds methods and logic for searching private and restricted content. Obviously it will cover only content related to the currently authenticated user, i. e. own content and content to which the currently authenticated user has access by invitation, membership or other means.