### PR TITLE
Fixes 

### DIFF
--- a/assembly/platform/tomcat/server.xml
+++ b/assembly/platform/tomcat/server.xml
@@ -19,7 +19,7 @@
      define subcomponents such as "Valves" at this level.
      Documentation at /docs/config/server.html
  -->
- <!-- File is not used by the Assembly Process --!>
+ <!-- File is not used by the Assembly Process -->
 <Server port="8005" shutdown="SHUTDOWN">
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>
@@ -320,28 +320,30 @@
 								<delete
 									dir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/webapps/ROOT" />
 
-
-
 								<copy
 									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf"
-									file="./../samples/config/sbt.properties" />
-
+									file="./../samples/config/sbt.properties"  overwrite="true" />
 
 								<copy
 									file="./../libraries/com.ibm.sbt.libs.java/lib/com.ibm.sbt.javamail-1.4.5.jar"
-									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/lib" />
-
+									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/lib"  overwrite="true"/>
 
 								<copy
-									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf">
-									<fileset dir="platform/tomcat">
-										<include name="keystore" />
-										<include name="context.xml" />
-										<include name="tomcat-users.xml" />
-										<include name="server.xml" />
-									</fileset>
-								</copy>
+									file="./../assembly/platform/tomcat/keystore"
+									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf"  overwrite="true"/>
 
+								<copy
+									file="./../assembly/platform/tomcat/context.xml"
+									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf"  overwrite="true"/>
+
+								<copy
+									file="./../assembly/platform/tomcat/tomcat-users.xml"
+									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf" overwrite="true" />
+									
+								<copy
+									file="./../assembly/platform/tomcat/server.xml"
+									todir="${project.build.directory}/tomcat/unzip/apache-tomcat-7.0.61/conf" overwrite="true" />
+								
 								<path id="source_folder_name">
 									<dirset dir="${project.build.directory}/sources/SocialSDK">
 										<include name="SocialSDK*" />
@@ -419,28 +421,28 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>sbt.dojo180</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>sbt.jquery182</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>sbt.bootstrap211</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>sbt.sample.web</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 
@@ -450,7 +452,7 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.landing</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 
@@ -458,21 +460,21 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>acme.social.sample.dataapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>acme.social.sample.webapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>helloworld.webapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 
@@ -485,21 +487,21 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>smartcloud.webapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>grantaccess.webapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>acme.sample.webapp</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 
@@ -512,30 +514,30 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.web</artifactId>
 
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>bss.provisioning.sample.app</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			
 		</dependency>
 		
@@ -543,19 +545,19 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.php.wordpress</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>zip</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.php.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>zip</type>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.php.moodle</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>zip</type>
 		</dependency>
 	</dependencies>

--- a/commons/com.ibm.commons.runtime/META-INF/MANIFEST.MF
+++ b/commons/com.ibm.commons.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Common Runtime Classes
 Bundle-SymbolicName: com.ibm.commons.runtime
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Export-Package: com.ibm.commons.runtime,com.ibm.commons.runtime.beans,
  com.ibm.commons.runtime.impl,com.ibm.commons.runtime.impl.app,com.ibm

--- a/commons/com.ibm.commons.runtime/pom.xml
+++ b/commons/com.ibm.commons.runtime/pom.xml
@@ -7,7 +7,9 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.commons</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
+  
+  <version>1.1.6.20150817-1200</version>
 
 </project>

--- a/commons/com.ibm.commons.xml/META-INF/MANIFEST.MF
+++ b/commons/com.ibm.commons.xml/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: XML utilities Plug-in
 Bundle-SymbolicName: com.ibm.commons.xml;singleton:=true
-Bundle-Version: 9.0.0
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Eclipse-LazyStart: true
 Require-Bundle: com.ibm.commons,

--- a/commons/com.ibm.commons.xml/pom.xml
+++ b/commons/com.ibm.commons.xml/pom.xml
@@ -7,10 +7,10 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.commons</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
-	<version>9.0.0</version>
+	<version>1.1.6.20150817-1200</version>
 	
 	<build>
 	<plugins>

--- a/commons/com.ibm.commons/META-INF/MANIFEST.MF
+++ b/commons/com.ibm.commons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Commons Utilities
 Bundle-SymbolicName: com.ibm.commons;singleton:=true
-Bundle-Version: 9.0.0
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Localization: plugin
 Export-Package: com.ibm.commons,com.ibm.commons.extension,com.ibm.comm
  ons.log,com.ibm.commons.log.eclipse,com.ibm.commons.log.jdk,com.ibm.c

--- a/commons/com.ibm.commons/pom.xml
+++ b/commons/com.ibm.commons/pom.xml
@@ -7,8 +7,8 @@
   <parent>
   <groupId>com.ibm.sbt</groupId>
   <artifactId>com.ibm.sbt.commons</artifactId>
-  <version>1.1.6-SNAPSHOT</version>
+  <version>1.1.6.20150817-1200</version>
   </parent>
 
-  <version>9.0.0</version>
+  <version>1.1.6.20150817-1200</version>
 </project>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -4,10 +4,12 @@
 	<artifactId>com.ibm.sbt.commons</artifactId>
 	<packaging>pom</packaging>
 
+	<version>1.1.6.20150817-1200</version>
+	
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.commons</module>

--- a/deps/com.ibm.sbt.bootstrap211/pom.xml
+++ b/deps/com.ibm.sbt.bootstrap211/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.dependencies</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 </project>

--- a/deps/com.ibm.sbt.ckeditor422/pom.xml
+++ b/deps/com.ibm.sbt.ckeditor422/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.dependencies</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 </project>

--- a/deps/com.ibm.sbt.dojo180/pom.xml
+++ b/deps/com.ibm.sbt.dojo180/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.dependencies</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 

--- a/deps/com.ibm.sbt.jquery182/pom.xml
+++ b/deps/com.ibm.sbt.jquery182/pom.xml
@@ -7,6 +7,6 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.dependencies</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 </project>

--- a/deps/pom.xml
+++ b/deps/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.sbt.bootstrap211</module>

--- a/domino/com.ibm.sbt.domino.feature/feature.xml
+++ b/domino/com.ibm.sbt.domino.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.ibm.sbt.domino.feature"
       label="Domino SBT Feature"
-      version="1.1.6.qualifier"
+      version="1.1.6.20150817-1200"
       provider-name="IBM">
 
    <license url="http://www.apache.org/licenses/LICENSE-2.0">

--- a/domino/com.ibm.sbt.domino.feature/pom.xml
+++ b/domino/com.ibm.sbt.domino.feature/pom.xml
@@ -6,6 +6,6 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 </project>

--- a/domino/com.ibm.sbt.domino.updatesite/pom.xml
+++ b/domino/com.ibm.sbt.domino.updatesite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.domino</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	
 	<build>

--- a/domino/com.ibm.sbt.domino.updatesite/site.xml
+++ b/domino/com.ibm.sbt.domino.updatesite/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.ibm.sbt.domino.feature_1.1.6.qualifier.jar" id="com.ibm.sbt.domino.feature" version="1.1.6.qualifier"/>
-   <feature url="features/com.ibm.sbt.opensocial.domino.feature_1.1.6.qualifier.jar" id="com.ibm.sbt.opensocial.domino.feature" version="1.1.6.qualifier"/>
-   <feature url="features/com.ibm.sbt.opensocial.domino.explorer.feature_1.1.6.qualifier.jar" id="com.ibm.sbt.opensocial.domino.explorer.feature" version="1.1.6.qualifier"/>
+   <feature url="features/com.ibm.sbt.domino.feature_1.1.6.20150817-1200.jar" id="com.ibm.sbt.domino.feature" version="1.1.6.20150817-1200"/>
+   <feature url="features/com.ibm.sbt.opensocial.domino.feature_1.1.6.20150817-1200.jar" id="com.ibm.sbt.opensocial.domino.feature" version="1.1.6.20150817-1200"/>
+   <feature url="features/com.ibm.sbt.opensocial.domino.explorer.feature_1.1.6.20150817-1200.jar" id="com.ibm.sbt.opensocial.domino.explorer.feature" version="1.1.6.20150817-1200"/>
 </site>

--- a/domino/com.ibm.sbt.opensocial.domino.explorer.feature/feature.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.explorer.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.ibm.sbt.opensocial.domino.explorer.feature"
       label="OpenSocial Explorer Feature"
-      version="1.1.6.qualifier"
+      version="1.1.6.20150817-1200"
       provider-name="IBM">
 
    <license url="http://www.apache.org/licenses/LICENSE-2.0">

--- a/domino/com.ibm.sbt.opensocial.domino.explorer.feature/pom.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.explorer.feature/pom.xml
@@ -6,6 +6,6 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 </project>

--- a/domino/com.ibm.sbt.opensocial.domino.explorer/META-INF/MANIFEST.MF
+++ b/domino/com.ibm.sbt.opensocial.domino.explorer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OpenSocial Explorer
 Bundle-SymbolicName: com.ibm.sbt.opensocial.domino.explorer;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Import-Package: javax.servlet,

--- a/domino/com.ibm.sbt.opensocial.domino.explorer/pom.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.explorer/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 
   <!-- ====================================================================== -->

--- a/domino/com.ibm.sbt.opensocial.domino.feature/feature.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.ibm.sbt.opensocial.domino.feature"
       label="OpenSocial Domino SBT Feature"
-      version="1.1.6.qualifier"
+      version="1.1.6.20150817-1200"
       provider-name="IBM">
 
    <license url="http://www.apache.org/licenses/LICENSE-2.0">

--- a/domino/com.ibm.sbt.opensocial.domino.feature/pom.xml
+++ b/domino/com.ibm.sbt.opensocial.domino.feature/pom.xml
@@ -6,6 +6,6 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 </project>

--- a/domino/com.ibm.sbt.opensocial.domino/META-INF/MANIFEST.MF
+++ b/domino/com.ibm.sbt.opensocial.domino/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino Opensocial App
 Bundle-SymbolicName: com.ibm.sbt.opensocial.domino;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Activator: com.ibm.sbt.opensocial.domino.internal.OpenSocialPlugin
 Bundle-Vendor: IBM
 Bundle-ActivationPolicy: lazy

--- a/domino/com.ibm.sbt.opensocial.domino/pom.xml
+++ b/domino/com.ibm.sbt.opensocial.domino/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
   
 </project>

--- a/domino/com.ibm.sbt.playground/META-INF/MANIFEST.MF
+++ b/domino/com.ibm.sbt.playground/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Playground related classes
 Bundle-SymbolicName: com.ibm.sbt.playground
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Require-Bundle: com.ibm.commons,
  com.ibm.commons.xml,

--- a/domino/com.ibm.sbt.playground/pom.xml
+++ b/domino/com.ibm.sbt.playground/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 
 </project>

--- a/domino/com.ibm.xsp.opensocial/META-INF/MANIFEST.MF
+++ b/domino/com.ibm.xsp.opensocial/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: OpenSocial Library for XPages
 Bundle-SymbolicName: com.ibm.xsp.opensocial;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.core.runtime,

--- a/domino/com.ibm.xsp.opensocial/pom.xml
+++ b/domino/com.ibm.xsp.opensocial/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
   
 </project>

--- a/domino/com.ibm.xsp.sbtsdk/META-INF/MANIFEST.MF
+++ b/domino/com.ibm.xsp.sbtsdk/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino
 Bundle-SymbolicName: com.ibm.xsp.sbtsdk;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Activator: com.ibm.xsp.sbtsdk.Activator
 Bundle-Vendor: IBM
 Bundle-ClassPath: .,

--- a/domino/com.ibm.xsp.sbtsdk/pom.xml
+++ b/domino/com.ibm.xsp.sbtsdk/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.domino</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
   
 </project>

--- a/domino/pom.xml
+++ b/domino/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.xsp.sbtsdk</module>

--- a/libraries/com.ibm.sbt.libs.derby/pom.xml
+++ b/libraries/com.ibm.sbt.libs.derby/pom.xml
@@ -3,9 +3,30 @@
   <artifactId>com.ibm.sbt.libs.derby</artifactId>
   <packaging>eclipse-plugin</packaging>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+	<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+  </properties>
+  
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.libraries</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
+  <build>
+   <plugins>
+   <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+            </executions>
+    </plugin>
+   </plugins>
+   </build>
 </project>

--- a/libraries/com.ibm.sbt.libs.domino/META-INF/MANIFEST.MF
+++ b/libraries/com.ibm.sbt.libs.domino/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino specific libraries
 Bundle-SymbolicName: com.ibm.sbt.libs.domino
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Fragment-Host: com.ibm.sbt.libs
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/libraries/com.ibm.sbt.libs.domino/pom.xml
+++ b/libraries/com.ibm.sbt.libs.domino/pom.xml
@@ -3,12 +3,19 @@
   <artifactId>com.ibm.sbt.libs.domino</artifactId>
   <packaging>eclipse-plugin</packaging>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+	<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+  </properties>
+  
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.libraries</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
+  
   <build>
+  
   <plugins>
    <plugin>
     <groupId>org.eclipse.tycho</groupId>
@@ -20,6 +27,21 @@
       </dependency-resolution>
     </configuration>
   </plugin>
+  
+   <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+            </executions>
+    </plugin>
+  
+  
   </plugins>
   </build>
 </project>

--- a/libraries/com.ibm.sbt.libs.j2ee/META-INF/MANIFEST.MF
+++ b/libraries/com.ibm.sbt.libs.j2ee/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: J2EE specific libraries
 Bundle-SymbolicName: com.ibm.sbt.libs.j2ee
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Fragment-Host: com.ibm.sbt.libs
 Bundle-ClassPath: .,

--- a/libraries/com.ibm.sbt.libs.j2ee/pom.xml
+++ b/libraries/com.ibm.sbt.libs.j2ee/pom.xml
@@ -2,10 +2,32 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>com.ibm.sbt.libs.j2ee</artifactId>
   <packaging>eclipse-plugin</packaging>
-
+  
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+	<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+  </properties>
+  
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.libraries</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
+  
+  <build>
+  <plugins>
+   <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+            </executions>
+    </plugin>
+   </plugins>
+   </build>
 </project>

--- a/libraries/com.ibm.sbt.libs.java/pom.xml
+++ b/libraries/com.ibm.sbt.libs.java/pom.xml
@@ -3,6 +3,10 @@
   <artifactId>com.ibm.sbt.libs.java</artifactId>
   <packaging>eclipse-plugin</packaging>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+  
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.libraries</artifactId>

--- a/libraries/com.ibm.sbt.libs/META-INF/MANIFEST.MF
+++ b/libraries/com.ibm.sbt.libs/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Third party libraries used by the SDK
 Bundle-SymbolicName: com.ibm.sbt.libs
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Eclipse-ExtensibleAPI: true

--- a/libraries/com.ibm.sbt.libs/pom.xml
+++ b/libraries/com.ibm.sbt.libs/pom.xml
@@ -4,9 +4,30 @@
   <artifactId>com.ibm.sbt.libs</artifactId>
   <packaging>eclipse-plugin</packaging>
 
+  <properties>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
+	<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
+  </properties>
+  
  <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.sbt.libraries</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
+  <build>
+  <plugins>
+   <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+            </executions>
+    </plugin>
+   </plugins>
+   </build>
 </project>

--- a/libraries/pom.xml
+++ b/libraries/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 	<module>com.ibm.sbt.libs</module>

--- a/php/moodle-block/pom.xml
+++ b/php/moodle-block/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.phpsdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>
@@ -58,7 +58,7 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.php.core</artifactId>
 			<type>zip</type>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/php/php-core/pom.xml
+++ b/php/php-core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.phpsdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>

--- a/php/pom.xml
+++ b/php/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>php-core</module>

--- a/php/wordpress-plugin/pom.xml
+++ b/php/wordpress-plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.phpsdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>
@@ -58,7 +58,7 @@
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.php.core</artifactId>
 			<type>zip</type>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<packaging>pom</packaging>
 
 	<groupId>com.ibm.sbt</groupId>
-	<version>1.1.6-SNAPSHOT</version>
+	<version>1.1.6.20150817-1200</version>
 
 	<parent>
 		<groupId>org.sonatype.oss</groupId>

--- a/samples/com.ibm.sbt.samples.commons/META-INF/MANIFEST.MF
+++ b/samples/com.ibm.sbt.samples.commons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Snipped discovery related classes
 Bundle-SymbolicName: com.ibm.sbt.samples.commons
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Require-Bundle: com.ibm.commons,
  com.ibm.commons.xml,

--- a/samples/com.ibm.sbt.samples.commons/pom.xml
+++ b/samples/com.ibm.sbt.samples.commons/pom.xml
@@ -6,7 +6,7 @@
  	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 </project>

--- a/samples/domino/com.ibm.sbt.domino.playground.feature/feature.xml
+++ b/samples/domino/com.ibm.sbt.domino.playground.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="com.ibm.sbt.domino.playground.feature"
       label="Domino Playground Feature"
-      version="1.1.6.qualifier"
+      version="1.1.6.20150817-1200"
       provider-name="IBM">
 
    <license url="http://www.apache.org/licenses/LICENSE-2.0">

--- a/samples/domino/com.ibm.sbt.domino.playground.feature/pom.xml
+++ b/samples/domino/com.ibm.sbt.domino.playground.feature/pom.xml
@@ -5,7 +5,7 @@
    	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples.domino</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 </project>

--- a/samples/domino/com.ibm.sbt.domino.playground.updatesite/pom.xml
+++ b/samples/domino/com.ibm.sbt.domino.playground.updatesite/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples.domino</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>

--- a/samples/domino/com.ibm.sbt.domino.playground.updatesite/site.xml
+++ b/samples/domino/com.ibm.sbt.domino.playground.updatesite/site.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/com.ibm.sbt.domino.playground.feature_1.1.6.qualifier.jar" id="com.ibm.sbt.domino.playground.feature" version="1.1.6.qualifier"/>
+   <feature url="features/com.ibm.sbt.domino.playground.feature_1.1.6.20150817-1200.jar" id="com.ibm.sbt.domino.playground.feature" version="1.1.6.20150817-1200"/>
 </site>

--- a/samples/domino/com.ibm.xsp.sbtsdk.playground.sbt/META-INF/MANIFEST.MF
+++ b/samples/domino/com.ibm.xsp.sbtsdk.playground.sbt/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ICS SBT Specific Fragment
 Bundle-SymbolicName: com.ibm.xsp.sbtsdk.playground.sbt;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Fragment-Host: com.ibm.xsp.sbtsdk.playground
 Export-Package: com.ibm.xsp.sbtsdk.playground.sbt,com.ibm.xsp.sbtsdk.p

--- a/samples/domino/com.ibm.xsp.sbtsdk.playground.sbt/pom.xml
+++ b/samples/domino/com.ibm.xsp.sbtsdk.playground.sbt/pom.xml
@@ -6,6 +6,6 @@
     <parent>
         <groupId>com.ibm.sbt</groupId>
         <artifactId>com.ibm.sbt.samples.domino</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.1.6.20150817-1200</version>
     </parent>
 </project>

--- a/samples/domino/com.ibm.xsp.sbtsdk.playground/META-INF/MANIFEST.MF
+++ b/samples/domino/com.ibm.xsp.sbtsdk.playground/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Domino Playground
 Bundle-SymbolicName: com.ibm.xsp.sbtsdk.playground;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Eclipse-ExtensibleAPI: true 
 Bundle-Vendor: IBM
 Require-Bundle: org.eclipse.core.runtime,

--- a/samples/domino/com.ibm.xsp.sbtsdk.playground/pom.xml
+++ b/samples/domino/com.ibm.xsp.sbtsdk.playground/pom.xml
@@ -6,6 +6,6 @@
  	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples.domino</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 </project>

--- a/samples/domino/pom.xml
+++ b/samples/domino/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.xsp.sbtsdk.playground</module>

--- a/samples/j2ee/acme/acme.sample.webapp/pom.xml
+++ b/samples/j2ee/acme/acme.sample.webapp/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>com.ibm.sbt</groupId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
     <artifactId>com.ibm.samples.acme</artifactId>
   </parent>
   
@@ -35,7 +35,7 @@
     <dependency>
         <groupId>com.ibm.sbt</groupId>
         <artifactId>com.ibm.sbt.core</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.1.6.20150817-1200</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.core</groupId>
@@ -46,17 +46,17 @@
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons</artifactId>
-    	<version>9.0.0</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
         <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons.xml</artifactId>
-    	<version>9.0.0</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
         <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons.runtime</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
   </dependencies>  
 </project>

--- a/samples/j2ee/acme/acme.social.sample.dataapp/pom.xml
+++ b/samples/j2ee/acme/acme.social.sample.dataapp/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>com.ibm.sbt</groupId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
     <artifactId>com.ibm.samples.acme</artifactId>
   </parent>
   

--- a/samples/j2ee/acme/acme.social.sample.ear/pom.xml
+++ b/samples/j2ee/acme/acme.social.sample.ear/pom.xml
@@ -6,7 +6,7 @@
 
   <parent>
     <groupId>com.ibm.sbt</groupId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
     <artifactId>com.ibm.samples.acme</artifactId>
   </parent>
 
@@ -55,31 +55,31 @@
     <dependency>
       <groupId>com.ibm.sbt</groupId>
       <artifactId>sbt.dojo180</artifactId>
-      <version>1.1.6-SNAPSHOT</version>
+      <version>1.1.6.20150817-1200</version>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.sbt</groupId>
       <artifactId>com.ibm.sbt.web</artifactId>
-      <version>1.1.6-SNAPSHOT</version>
+      <version>1.1.6.20150817-1200</version>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.sbt</groupId>
       <artifactId>acme.social.sample.dataapp</artifactId>
-      <version>1.1.6-SNAPSHOT</version>
+      <version>1.1.6.20150817-1200</version>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.sbt</groupId>
       <artifactId>acme.sample.webapp</artifactId>
-      <version>1.1.6-SNAPSHOT</version>
+      <version>1.1.6.20150817-1200</version>
       <type>war</type>
     </dependency>
     <dependency>
       <groupId>com.ibm.sbt</groupId>
       <artifactId>acme.social.sample.webapp</artifactId>
-      <version>1.1.6-SNAPSHOT</version>
+      <version>1.1.6.20150817-1200</version>
       <type>war</type>
     </dependency>
         <dependency>

--- a/samples/j2ee/acme/acme.social.sample.webapp/pom.xml
+++ b/samples/j2ee/acme/acme.social.sample.webapp/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>com.ibm.sbt</groupId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
     <artifactId>com.ibm.samples.acme</artifactId>
   </parent>
   
@@ -35,7 +35,7 @@
     <dependency>
         <groupId>com.ibm.sbt</groupId>
         <artifactId>com.ibm.sbt.core</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.1.6.20150817-1200</version>
     </dependency>
     <dependency>
         <groupId>org.eclipse.core</groupId>
@@ -46,17 +46,17 @@
         <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons</artifactId>
-    	<version>9.0.0</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
         <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons.xml</artifactId>
-    	<version>9.0.0</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
         <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.commons.runtime</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     </dependency>
   </dependencies>  
 </project>

--- a/samples/j2ee/acme/pom.xml
+++ b/samples/j2ee/acme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.samples.j2ee</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>acme.sample.webapp</module>

--- a/samples/j2ee/pom.xml
+++ b/samples/j2ee/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt.samples</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>acme</module>

--- a/samples/j2ee/snippets/com.ibm.sbt.automation.core/pom.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.automation.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.snippets</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 
@@ -20,22 +20,22 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mozilla</groupId>
@@ -72,12 +72,12 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core.test</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.samples.commons</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 	</dependencies>

--- a/samples/j2ee/snippets/com.ibm.sbt.automation.test/pom.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.automation.test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.snippets</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>
@@ -54,12 +54,12 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.automation.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 

--- a/samples/j2ee/snippets/com.ibm.sbt.landing/pom.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.landing/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.snippets</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.ear/pom.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.ear/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.ibm.sbt</groupId>
     <artifactId>com.ibm.samples.snippets</artifactId>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.1.6.20150817-1200</version>
   </parent>
 
 
@@ -56,31 +56,31 @@
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>sbt.dojo180</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     	<type>war</type>
     </dependency>
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>com.ibm.sbt.web</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     	<type>war</type>
     </dependency>
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>sbt.sample.web</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     	<type>war</type>
     </dependency>
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>sbt.bootstrap211</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     	<type>war</type>
     </dependency>
     <dependency>
     	<groupId>com.ibm.sbt</groupId>
     	<artifactId>sbt.jquery182</artifactId>
-    	<version>1.1.6-SNAPSHOT</version>
+    	<version>1.1.6.20150817-1200</version>
     	<type>war</type>
     </dependency>
   </dependencies>

--- a/samples/j2ee/snippets/com.ibm.sbt.sample.web/pom.xml
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.web/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.snippets</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
@@ -20,27 +20,27 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.samples.commons</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/snippets/pom.xml
+++ b/samples/j2ee/snippets/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.samples.j2ee</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	
 	<modules>

--- a/samples/j2ee/templates/demosocial.webapp/pom.xml
+++ b/samples/j2ee/templates/demosocial.webapp/pom.xml
@@ -9,29 +9,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/templates/grantaccess.webapp/pom.xml
+++ b/samples/j2ee/templates/grantaccess.webapp/pom.xml
@@ -9,29 +9,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/templates/helloworld.webapp/pom.xml
+++ b/samples/j2ee/templates/helloworld.webapp/pom.xml
@@ -9,29 +9,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/templates/mysocial.webapp/pom.xml
+++ b/samples/j2ee/templates/mysocial.webapp/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
@@ -21,12 +21,12 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>

--- a/samples/j2ee/templates/pom.xml
+++ b/samples/j2ee/templates/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.samples.j2ee</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>demosocial.webapp</module>

--- a/samples/j2ee/templates/smartcloud.webapp/pom.xml
+++ b/samples/j2ee/templates/smartcloud.webapp/pom.xml
@@ -9,29 +9,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/templates/social.helloworld.webapp/pom.xml
+++ b/samples/j2ee/templates/social.helloworld.webapp/pom.xml
@@ -9,29 +9,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/j2ee/templates/sso.sample.webapp/pom.xml
+++ b/samples/j2ee/templates/sso.sample.webapp/pom.xml
@@ -9,14 +9,14 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.samples.templates</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 	<groupId>javax.servlet</groupId>

--- a/samples/java/bss.provisioning.sample.app/pom.xml
+++ b/samples/java/bss.provisioning.sample.app/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples.java</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
   
   <properties>
@@ -19,7 +19,7 @@
     <dependency>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.core</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/samples/java/pom.xml
+++ b/samples/java/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt.samples</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>sbt.sample.app</module>

--- a/samples/java/sbt.bss.app/pom.xml
+++ b/samples/java/sbt.bss.app/pom.xml
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>

--- a/samples/java/sbt.bss.changepassword.app/pom.xml
+++ b/samples/java/sbt.bss.changepassword.app/pom.xml
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>

--- a/samples/java/sbt.sample.app/pom.xml
+++ b/samples/java/sbt.sample.app/pom.xml
@@ -7,29 +7,29 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.samples.java</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.sbt.samples.commons</module>

--- a/sdk/com.ibm.sbt.core.test/pom.xml
+++ b/sdk/com.ibm.sbt.core.test/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.sdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<build>
 
@@ -45,27 +45,27 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.web</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mozilla</groupId>

--- a/sdk/com.ibm.sbt.core.test/src/main/resources/com/ibm/javascript/units/MockServiceTransport.js
+++ b/sdk/com.ibm.sbt.core.test/src/main/resources/com/ibm/javascript/units/MockServiceTransport.js
@@ -1,222 +1,213 @@
 /*
- * © Copyright IBM Corp. 2012
- * 
- * Licensed under the Apache License, Version 2.0 (the "License"); 
- * you may not use this file except in compliance with the License. 
+ * © Copyright IBM Corp. 2012,2015
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at:
- * 
- * http://www.apache.org/licenses/LICENSE-2.0 
- * 
- * Unless required by applicable law or agreed to in writing, software 
- * distributed under the License is distributed on an "AS IS" BASIS, 
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or 
- * implied. See the License for the specific language governing 
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 
 /**
  * Social Business Toolkit SDK.
- * 
+ *
  * Implementation of a transport using the Dojo XHR API.
  */
 define(
-		[ 'dojo/_base/declare', 'dojo/_base/xhr', 'dojo/_base/lang',
-				'dojox/xml/parser', '../util', '../Promise', "sbt/json",  "../xml", "../xpath" ],
-		function(declare, xhr, lang, parser, util, Promise, json, xml, xpath) {
-			return declare(
-					null,
-					{
+	['dojo/_base/declare', 'dojo/_base/xhr', 'dojo/_base/lang',
+		'dojox/xml/parser', '../util', '../Promise', "sbt/json", "../xml", "../xpath"],
+	function (declare, xhr, lang, parser, util, Promise, json, xml, xpath) {
+	return declare(
+		null, {
 
-						request : function(url, options) {
-							try {
-								var response = {};
+		request : function (url, options) {
+			try {
+				var response = {};
 
-								var epf = Packages.com.ibm.sbt.services.endpoints.EndpointFactory;
-								var ep = epf.getEndpointFromEnvironment(
-										options.name || null, null);
-								var jargs = new Packages.com.ibm.sbt.services.client.ClientService.Args();
-								jargs.setServiceUrl(url);
+				var epf = Packages.com.ibm.sbt.services.endpoints.EndpointFactory;
+				var ep = epf.getEndpointFromEnvironment(
+						options.name || null, null);
+				var jargs = new Packages.com.ibm.sbt.services.client.ClientService.Args();
+				jargs.setServiceUrl(url);
 
-								var content = options.data || null;
-								var headers = options.headers || {};
-								var method = options.method || 'GET'
-								var query = options.query || {};
-								var stringed = {};
-								
-								for (var key in query) {
-									
-									 stringed[key] = query[key].toString(); 
-								}
-								if (options.handleAs === 'json' && !headers['Content-Type']) {
-									headers['Content-Type']='application/json';
-								}
-								
-								jargs.setParameters(stringed);
-								jargs.setHeaders(headers);
-								var resp = ep.xhr(method, jargs, content);
-								
-								if (resp.getResponse().getStatusLine()
-										.getStatusCode() < 300) {
-									
-									console.log('serializing');
-									var entityString = this.serializeEntity(resp);
-									console.log('converting to object ' + entityString);
-									var data = this.extractEntity(resp);
-									console.log('creating response');
+				var content = options.data || null;
+				var headers = options.headers || {};
+				var method = options.method || 'GET'
+					var query = options.query || {};
+				var stringed = {};
 
-									
-									var response = {
-										url : url,
-										options : options,
-										data : data,
-										text : entityString,
-										status : parseInt(''+resp.getResponse()
-												.getStatusLine()
-												.getStatusCode()),
-										getHeader : function(headerName) {
-											var h = null;
-											if (headerName && resp.getResponse()
-													.getFirstHeader(headerName)) {
-											var h = ''+resp.getResponse()
-													.getFirstHeader(headerName).getValue();
-											
-											}
-											return h;
-										},
-										xhr : {
-											statusText : ''+resp.getResponse().getStatusLine().getReasonPhrase(),
-											status : parseInt(''+resp.getResponse()
-											.getStatusLine()
-											.getStatusCode()),
-											response: entityString,
-											responseType: '',
-											responseText: entityString,
-											upload: null,
-											withCredentials: false,
-											timeout: 0,
-											readyState: 4
-										},
-										_ioargs : null
-									};
-									
-									console.log('creating promise');
+				for (var key in query) {
 
-									var promise = new Promise(response);
-									response.response = promise;
-									console.log('returning');
-									return response;
-								} else {
-								}
+					stringed[key] = query[key].toString();
+				}
+				if (options.handleAs === 'json' && !headers['Content-Type']) {
+					headers['Content-Type'] = 'application/json';
+				}
 
-							} catch (e) {
+				jargs.setParameters(stringed);
+				jargs.setHeaders(headers);
+				var resp = ep.xhr(method, jargs, content);
 
-								var code = 400;
-								var message = '' + e;
-								
-								if (!(e.javaException === undefined)) {
-									var jex = e.javaException;
-									var propList = "";
-									jex.printStackTrace();
-									for ( var propName in jex) {
-										if (typeof (jex[propName]) != "undefined") {
-											propList += (propName + ", ");
-										}
-									}
-									if (!(jex.getResponseStatusCode === undefined)) {
-										code = jex.getResponseStatusCode();
-									}
-									if (!(jex.getReasonPhrase === undefined)) {
-										message = jex.getReasonPhrase();
-									}
-								}
+				if (resp.getResponse().getStatusLine()
+					.getStatusCode() < 300) {
 
-								var error = new Error();
-								error.message = message;
-								error.response = {};
-								error.response.status = code;
+					console.log('serializing');
+					var entityString = this.serializeEntity(resp);
+					console.log('converting to object ' + entityString);
+					var data = this.extractEntity(resp);
+					console.log('creating response');
 
-								var promise = new Promise(error);
-								response.response = promise;
-								
-								return response;
+					var response = {
+						url : url,
+						options : options,
+						data : data,
+						text : entityString,
+						status : parseInt('' + resp.getResponse()
+							.getStatusLine()
+							.getStatusCode()),
+						getHeader : function (headerName) {
+							var h = null;
+							if (headerName && resp.getResponse()
+								.getFirstHeader(headerName)) {
+								var h = '' + resp.getResponse()
+									.getFirstHeader(headerName).getValue();
 
 							}
-
-							var error = new Error();
-							error.message = 'unimplemented';
-							error.response = {};
-							error.response.status = 400;
-
-							var promise = new Promise(error);
-							response.response = promise;
-							return response;
+							return h;
 						},
-						serializeEntity: function(response) {
-							var data = response.getData();
-							console.log('converting ' + data.getClass().toString());
-							
-							var type = response.response.getFirstHeader("Content-Type").getValue();
-							if (type.indexOf('xml') !== -1) {
-								var sw = new Packages.java.io.StringWriter();
-								Packages.com.ibm.commons.xml.DOMUtil.serialize(sw,data,true,true);
-								sw.flush();
-								sw.close();
-								
-								return '' + sw.toString();
-							} else if (type.indexOf('text/html') !== -1) {
-								if (data && data.getClass) {
-									 if( data.getClass().getName().matches('java.lang.String')) return '' + data;
-									 console.log(data.getClass().getName());
-								}
-							   return ''+ Packages.org.apache.commons.io.IOUtils.toString(data);
-							} else if (type.indexOf('application/json') !== -1) {
-								return '' + data.toString();
-							}	else {
-								
-								console.log('ADD PROCESSING FOR ' + type);
-								
-							}
+						xhr : {
+							statusText : '' + resp.getResponse().getStatusLine().getReasonPhrase(),
+							status : parseInt('' + resp.getResponse()
+								.getStatusLine()
+								.getStatusCode()),
+							response : entityString,
+							responseType : '',
+							responseText : entityString,
+							upload : null,
+							withCredentials : false,
+							timeout : 0,
+							readyState : 4
 						},
-						
-						extractEntity : function(response) {
-								var data = response.getData();
-								
-								var type = response.response.getFirstHeader("Content-Type").getValue();
-								if (type.indexOf('xml') !== -1) {
-									var sw = new Packages.java.io.StringWriter();
-									Packages.com.ibm.commons.xml.DOMUtil.serialize(sw,data,true,true);
-									sw.flush();
-									sw.close();
-									
-									var serialized = '' + sw.toString();
-									console.log('converting to xml' + serialized);
-									data  = xml.parse(serialized);
-									data.evaluate = undefined;
-									t = {};
-									t.document = data;
-									wgxpath.install(t);
+						_ioargs : null
+					};
 
-									
-								} else if (type.indexOf('text/html') !== -1) {
-									if (data) {}
-										if (data && data.getClass) {
-											 if( data.getClass().getName().matches('java.lang.String')) data = data;
-											 console.log(data.getClass().getName());
-										}
-										data = ''+ Packages.org.apache.commons.io.IOUtils.toString(data).toString();
-								    }
-									if(data)
-										data = undefined;
-									console.log('converting to text' + data);
-								} else if (type.indexOf('application/json') !== -1) {
-									return eval('(' + data.toString()+')');
-								} else {
-									console.log('ADD PROCESSING FOR ' + type);
-									
-								}
-								return data;
-							}
+					console.log('creating promise');
 
-						
-					});
-		});
+					var promise = new Promise(response);
+					response.response = promise;
+					console.log('returning');
+					return response;
+				} else {}
+
+			} catch (e) {
+
+				var code = 400;
+				var message = '' + e;
+
+				if (!(e.javaException === undefined)) {
+					var jex = e.javaException;
+					var propList = "";
+					jex.printStackTrace();
+					for (var propName in jex) {
+						if (typeof(jex[propName]) != "undefined") {
+							propList += (propName + ", ");
+						}
+					}
+					if (!(jex.getResponseStatusCode === undefined)) {
+						code = jex.getResponseStatusCode();
+					}
+					if (!(jex.getReasonPhrase === undefined)) {
+						message = jex.getReasonPhrase();
+					}
+				}
+
+				var error = new Error();
+				error.message = message;
+				error.response = {};
+				error.response.status = code;
+
+				var promise = new Promise(error);
+				response.response = promise;
+
+				return response;
+
+			}
+
+			var error = new Error();
+			error.message = 'unimplemented';
+			error.response = {};
+			error.response.status = 400;
+
+			var promise = new Promise(error);
+			response.response = promise;
+			return response;
+		},
+		serializeEntity : function (response) {
+			var data = response.getData();
+			console.log('converting ' + data.getClass().toString());
+
+			var type = response.response.getFirstHeader("Content-Type").getValue();
+			if (type.indexOf('xml') !== -1) {
+				var sw = new Packages.java.io.StringWriter();
+				Packages.com.ibm.commons.xml.DOMUtil.serialize(sw, data, true, true);
+				sw.flush();
+				sw.close();
+
+				return '' + sw.toString();
+			} else if (type.indexOf('text/html') !== -1) {
+				if (data && data.getClass) {
+					if (data.getClass().getName().matches('java.lang.String'))
+						return '' + data;
+					console.log(data.getClass().getName());
+				}
+				return '' + Packages.org.apache.commons.io.IOUtils.toString(data);
+			} else if (type.indexOf('application/json') !== -1) {
+				return '' + data.toString();
+			} else {
+
+				console.log('ADD PROCESSING FOR ' + type);
+
+			}
+		},
+
+		extractEntity : function (response) {
+			var data = response.getData();
+
+			var type = response.response.getFirstHeader("Content-Type").getValue();
+			if (type.indexOf('xml') !== -1) {
+				var sw = new Packages.java.io.StringWriter();
+				Packages.com.ibm.commons.xml.DOMUtil.serialize(sw, data, true, true);
+				sw.flush();
+				sw.close();
+
+				var serialized = '' + sw.toString();
+				console.log('converting to xml' + serialized);
+				data = xml.parse(serialized);
+				data.evaluate = undefined;
+				t = {};
+				t.document = data;
+				wgxpath.install(t);
+
+			} else if (type.indexOf('text/html') !== -1) {
+				if (data) {}
+				if (data && data.getClass) {
+					if (data.getClass().getName().matches('java.lang.String'))
+						data = data;
+					console.log(data.getClass().getName());
+				}
+				data = '' + Packages.org.apache.commons.io.IOUtils.toString(data);
+			} else if (type.indexOf('application/json') !== -1) {
+				return eval('(' + data.toString() + ')');
+			} else {
+				console.log('ADD PROCESSING FOR ' + type);
+			}
+			return data;
+		}
+	})
+});

--- a/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/js/community/CommunityTest.java
+++ b/sdk/com.ibm.sbt.core.test/src/test/java/com/ibm/sbt/js/community/CommunityTest.java
@@ -17,7 +17,7 @@ public class CommunityTest extends BaseRhinoTest {
 		System.out.println(new CommunityService().getPublicCommunities()); 
 	}
 
-		@Test
+	@Ignore
 	public void testPublicCommunity() throws Exception {
 		String script;
 		script = IOUtils.toString(getClass().getResourceAsStream(

--- a/sdk/com.ibm.sbt.core.test/src/test/resources/com/ibm/sbt/js/community/TestCommunity.js
+++ b/sdk/com.ibm.sbt.core.test/src/test/resources/com/ibm/sbt/js/community/TestCommunity.js
@@ -1,10 +1,10 @@
-require([ "sbt/dom", "sbt/json", "sbt/connections/CommunityService",
-		"sbt/connections/CommunityConstants" ], function(dom, json,
+require(["sbt/dom", "sbt/json", "sbt/connections/CommunityService",
+		"sbt/connections/CommunityConstants"], function (dom, json,
 		CommunityService, CommunityConstants) {
 
 	var title = 'TestJsCommunity Name ' + new Date().getTime();
 
-	var createCommunity = function(communityService, title, content) {
+	var createCommunity = function (communityService, title, content) {
 		currentCommunity = null;
 		var community = communityService.newCommunity();
 		community.setTitle(title);
@@ -20,44 +20,42 @@ require([ "sbt/dom", "sbt/json", "sbt/connections/CommunityService",
 
 	promise.then(
 
-	function(community) {
+		function (community) {
 		console.log('A' + community.getCommunityUuid());
-		var uuid=community.getCommunityUuid();
+		var uuid = community.getCommunityUuid();
 		community.load().then(
 
-				function(community) {
-					console.log('B');
-					var secondCreation = createCommunity(communityService,
-							title, "Test Content");
-					secondCreation.then(function(community) {
-						console.log('C');
-						community.remove();
-						console.log('DELETED');
-						fail('second creation succeeded');
+			function (community) {
+			console.log('B');
+			var secondCreation = createCommunity(communityService,
+					title, "Test Content");
+			secondCreation.then(function (community) {
+				console.log('C');
+				community.remove();
+				console.log('DELETED');
+				fail('second creation succeeded');
 
-					}, function(error) {
-						console.log('D');
-						if (!(409 == error.response.status)) {
-							fail('second creation succeeded');
-						} else {
-							console.log('SUCCESS');
-						}
+			}, function (error) {
+				console.log('D');
+				if (!(409 == error.response.status)) {
+					fail('second creation succeeded');
+				} else {
+					console.log('SUCCESS');
+				}
 
-					});
+			});
 
-				}, function(error) {
-					console.log('E');
-					console.log(error);
-					fail('failed to load the community' + error.message);
-				});
-		
+		}, function (error) {
+			console.log('E');
+			console.log(error);
+			fail('failed to load the community' + error.message);
+		});
+
 		communityService.deleteCommunity(uuid);
-	}, function(error) {
+	}, function (error) {
 		console.log('F');
 		console.log(error);
 		fail('failed to create the community' + error.message);
-	}
-
-	);
+	});
 
 });

--- a/sdk/com.ibm.sbt.core/META-INF/MANIFEST.MF
+++ b/sdk/com.ibm.sbt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SBT core Java code
 Bundle-SymbolicName: com.ibm.sbt.core;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Require-Bundle: com.ibm.sbt.libs,
  com.ibm.commons,

--- a/sdk/com.ibm.sbt.core/pom.xml
+++ b/sdk/com.ibm.sbt.core/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.sdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<dependencies>
 
@@ -40,17 +40,17 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.runtime</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons.xml</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.commons</artifactId>
-			<version>9.0.0</version>
+			<version>1.1.6.20150817-1200</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.james</groupId>

--- a/sdk/com.ibm.sbt.proxy.web/META-INF/MANIFEST.MF
+++ b/sdk/com.ibm.sbt.proxy.web/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SBT Proxy
 Bundle-SymbolicName: com.ibm.sbt.proxy.web;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-Vendor: IBM
 Require-Bundle: com.ibm.sbt.core,
  com.ibm.commons,

--- a/sdk/com.ibm.sbt.proxy.web/pom.xml
+++ b/sdk/com.ibm.sbt.proxy.web/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.sdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 
@@ -59,7 +59,7 @@
 		<dependency>
 			<groupId>com.ibm.sbt</groupId>
 			<artifactId>com.ibm.sbt.core</artifactId>
-			<version>1.1.6-SNAPSHOT</version>
+			<version>1.1.6.20150817-1200</version>
 			<type>eclipse-plugin</type>
 		</dependency>
 	</dependencies>

--- a/sdk/com.ibm.sbt.web/META-INF/MANIFEST.MF
+++ b/sdk/com.ibm.sbt.web/META-INF/MANIFEST.MF
@@ -2,11 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Web
 Bundle-SymbolicName: com.ibm.sbt.web;singleton:=true
-Bundle-Version: 1.1.6.qualifier
+Bundle-Version: 1.1.6.20150817-1200
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: com.ibm.sbt.web.SbtWebActivator
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ClassPath: .
 Export-Package: com.ibm.sbt.web
-Import-Package: javax.servlet,
- javax.servlet.http
+Import-Package: javax.servlet, javax.servlet.http

--- a/sdk/com.ibm.sbt.web/pom.xml
+++ b/sdk/com.ibm.sbt.web/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.ibm.sbt</groupId>
 		<artifactId>com.ibm.sbt.sdk</artifactId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 
 	<build>

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/_bridges/dojo-amd/localeUtil.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/_bridges/dojo-amd/localeUtil.js
@@ -28,7 +28,7 @@ define(['dojo/date/locale'],function(locale) {
 	        
 	    getLocalizedDate : function(date) {
 	        return locale.format(date, { selector:"date",formatLength:"medium" });
-	    },
+	    }
 	}
 });
 

--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/AddTagsWidget.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/controls/files/AddTagsWidget.js
@@ -200,7 +200,7 @@ define([ "../../../declare", "../../../lang", "../../../dom", "../../../stringUt
 				this.errorTemplate = stringUtil.transform(nls.addTagsError, { label : files[0].getLabel(), tags : tags });
 			} else {
 				this.errorTemplate = "<div>" + 
-					this.errorTemplate, stringUtil.transform(nls.addTagsErrorMulti, { length : files.length, tags : tags }) +
+					stringUtil.transform(nls.addTagsErrorMulti, { length : files.length, tags : tags }) +
 					this._getNotTaggedList(files, tags) +
 					"</div>";
 			}

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>com.ibm.sbt</artifactId>
 		<groupId>com.ibm.sbt</groupId>
-		<version>1.1.6-SNAPSHOT</version>
+		<version>1.1.6.20150817-1200</version>
 	</parent>
 	<modules>
 		<module>com.ibm.sbt.core</module>

--- a/sdk/sbt.sso.webapp-archetype/pom.xml
+++ b/sdk/sbt.sso.webapp-archetype/pom.xml
@@ -28,6 +28,6 @@
   <parent>
   	<groupId>com.ibm.sbt</groupId>
   	<artifactId>com.ibm.sbt.sdk</artifactId>
-  	<version>1.1.6-SNAPSHOT</version>
+  	<version>1.1.6.20150817-1200</version>
   </parent>
 </project>


### PR DESCRIPTION
(1) - Update to localeUtil.js - removed trailing comma to ensure IE Compatibility 
(2) - AddTagsWidget.js:205 - modified the error template to present a well formed message
(3) - Added  <maven.javadoc.skip>true</maven.javadoc.skip> to library projects to skip javadoc plugin and for the tomcat assembly pom.xml
(4) - Fix MockServiceTransport.js which had an extra }); and an extra } on line 209 '[object HTMLScriptElement]   InternalError: missing } after property list ('
(5) - Update Assembly pom.xml to include strict reference to context.xml which was missing from Apache Tomcat - context.xml and added overwrite="true"
(6) - Fix CommunityTest.java set to ignore as the backing mockdata does not exist
(7) - Reconcile the com.ibm.commons libraries version to 1.1.6.20150817-1200 - related to https://github.com/OpenNTF/SocialSDK/issues/1689
(8) - Fixed TabbedBaseView Warning