### PR TITLE
fixes missing Application Build ID in WebSphere by adding a MANIFEST-…

### DIFF
--- a/samples/j2ee/snippets/com.ibm.sbt.sample.ear/META-INF/MANIFEST.MF
+++ b/samples/j2ee/snippets/com.ibm.sbt.sample.ear/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Implementation-Version: 1.1.7-SNAPSHOT


### PR DESCRIPTION
fixes missing Application Build ID in WebSphere by adding a MANIFEST-MF value