### PR TITLE
In IE DOMParser is returning an XML doc that is not working with sbt/xpath  

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/xml.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/xml.js
@@ -40,13 +40,13 @@ define(['./lang'], function(lang) {
 		parse: function(xml) {
 			var xmlDoc=null;
 			try {
-				if(window.DOMParser){
-					parser=new DOMParser();
-					xmlDoc=parser.parseFromString(xml,"text/xml");
-				} else {
-					xmlDoc=new ActiveXObject("Microsoft.XMLDOM");
+				if(window.ActiveXObject !== undefined){
+					xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
 					xmlDoc.async="false";
 					xmlDoc.loadXML(xml);
+				} else if (window.DOMParser){
+					parser=new DOMParser();
+					xmlDoc=parser.parseFromString(xml,"text/xml");
 				}
 			}catch(ex){
 				console.log(ex.message);


### PR DESCRIPTION
The issue here is that Internet explorer does have window.DOMParser however the XML doc that is returns causes issues when the code reaches  selectNodes() in sbt/xpath. In IE an error will get thrown here. 