### PR TITLE
Get reply count from getreply url

### DIFF
--- a/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/ForumService.js
+++ b/sdk/com.ibm.sbt.web/src/main/webapp/js/sdk/sbt/connections/ForumService.js
@@ -621,6 +621,29 @@ define([ "../declare", "../config", "../lang", "../stringUtil", "../Promise", ".
         	return this.service.getForumTopicReplies(this.getTopicUuid(), args);
         },
         
+                
+        /**
+         * Get the number of replies for this topic
+         * 
+         * @method getReplyCount
+         */
+        
+        getReplyCount: function(){
+        	var links = this.data.getElementsByTagName("link");
+        	var replyCount = 0;
+        	for(var j = 0; j < links.length;j++){
+        		var link =links[j];
+        		if(link.getAttribute("rel") == "replies"){
+        			var count = link.getAttribute("thr:count");
+        			if(count!=null){
+        				replyCount = parseInt(count);
+        				break;
+        			}
+        		}
+        	}
+        	return replyCount;
+        },
+        
         /**
          * To like this topic in a stand-alone forum, create forum recommendation to the forum topic resources.
          * 


### PR DESCRIPTION
Added getreplycount method to retrieve the thr:count attribute so that we don't have to do an extra xhr:Get to retrieve the number of total replies on a specified topic. 

Should be tested!!!